### PR TITLE
Update MvvmCross

### DIFF
--- a/Toggl.Daneel/Presentation/TogglPresenter.cs
+++ b/Toggl.Daneel/Presentation/TogglPresenter.cs
@@ -36,8 +36,8 @@ namespace Toggl.Daneel.Presentation
         {
             base.RegisterAttributeTypes();
 
-            _attributeTypesToShowMethodDictionary.Add(typeof(NestedPresentationAttribute), ShowNestedViewController);
-            _attributeTypesToShowMethodDictionary.Add(typeof(ModalCardPresentationAttribute), ShowModalCardViewController);
+            AttributeTypesToShowMethodDictionary.Add(typeof(NestedPresentationAttribute), ShowNestedViewController);
+            AttributeTypesToShowMethodDictionary.Add(typeof(ModalCardPresentationAttribute), ShowModalCardViewController);
         }
 
         protected virtual void ShowNestedViewController(UIViewController viewController, MvxBasePresentationAttribute attribute, MvxViewModelRequest request)

--- a/Toggl.Daneel/Startup/Setup.cs
+++ b/Toggl.Daneel/Startup/Setup.cs
@@ -6,6 +6,7 @@ using MvvmCross.iOS.Platform;
 using MvvmCross.iOS.Views.Presenters;
 using MvvmCross.Platform;
 using MvvmCross.Platform.Platform;
+using MvvmCross.Platform.Plugins;
 using Toggl.Daneel.Presentation;
 using Toggl.Daneel.Services;
 using Toggl.Foundation;
@@ -39,15 +40,23 @@ namespace Toggl.Daneel
         {
         }
 
-        protected override IMvxNavigationService InitializeNavigationService()
+        protected override void InitializeLastChance()
         {
-            navigationService = base.InitializeNavigationService();
-            return navigationService;
+            base.InitializeLastChance();
+
+            Mvx.RegisterSingleton<IPasswordManagerService>(new OnePasswordService());
         }
 
-        protected override IMvxApplication CreateApp()
+        protected override IMvxTrace CreateDebugTrace() => new DebugTrace();
+
+        protected override IMvxApplication CreateApp() => new App();
+
+        protected override IMvxNavigationService InitializeNavigationService(IMvxViewModelLocatorCollection collection)
+            => navigationService = base.InitializeNavigationService(collection);
+            
+        protected override void InitializeApp(IMvxPluginManager pluginManager, IMvxApplication app)
         {
-            base.InitializeFirstChance();
+            base.InitializeApp(pluginManager, app);
 
             var database = new Database();
             var timeService = new TimeService(Scheduler.Default);
@@ -64,16 +73,8 @@ namespace Toggl.Daneel
                 )
             );
 
-            return new App(loginManager, navigationService);
-        }
-
-        protected override IMvxTrace CreateDebugTrace() => new DebugTrace();
-
-        protected override void InitializeLastChance()
-        {
-            base.InitializeLastChance();
-
-            Mvx.RegisterSingleton<IPasswordManagerService>(new OnePasswordService());
+            var togglApp = app as App;
+            togglApp.Initialize(loginManager, navigationService);
         }
     }
 }

--- a/Toggl.Daneel/Toggl.Daneel.csproj
+++ b/Toggl.Daneel/Toggl.Daneel.csproj
@@ -114,39 +114,6 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="MvvmCross.Platform">
-      <HintPath>..\packages\MvvmCross.Platform.5.0.5\lib\Xamarin.iOS10\MvvmCross.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Platform.iOS">
-      <HintPath>..\packages\MvvmCross.Platform.5.0.5\lib\Xamarin.iOS10\MvvmCross.Platform.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Core">
-      <HintPath>..\packages\MvvmCross.Core.5.0.5\lib\Xamarin.iOS10\MvvmCross.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.iOS">
-      <HintPath>..\packages\MvvmCross.Core.5.0.5\lib\Xamarin.iOS10\MvvmCross.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Binding">
-      <HintPath>..\packages\MvvmCross.Binding.5.0.5\lib\Xamarin.iOS10\MvvmCross.Binding.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Binding.iOS">
-      <HintPath>..\packages\MvvmCross.Binding.5.0.5\lib\Xamarin.iOS10\MvvmCross.Binding.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Localization">
-      <HintPath>..\packages\MvvmCross.Binding.5.0.5\lib\Xamarin.iOS10\MvvmCross.Localization.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Plugins.Color">
-      <HintPath>..\packages\MvvmCross.Plugin.Color.5.0.5\lib\Xamarin.iOS10\MvvmCross.Plugins.Color.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Plugins.Color.iOS">
-      <HintPath>..\packages\MvvmCross.Plugin.Color.5.0.5\lib\Xamarin.iOS10\MvvmCross.Plugins.Color.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Plugins.Visibility">
-      <HintPath>..\packages\MvvmCross.Plugin.Visibility.5.0.5\lib\Xamarin.iOS10\MvvmCross.Plugins.Visibility.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Plugins.Visibility.iOS">
-      <HintPath>..\packages\MvvmCross.Plugin.Visibility.5.0.5\lib\Xamarin.iOS10\MvvmCross.Plugins.Visibility.iOS.dll</HintPath>
-    </Reference>
     <Reference Include="OnePasswordExtension">
       <HintPath>..\packages\Xamarin.1PasswordExtension.1.8.4\lib\Xamarin.iOS10\OnePasswordExtension.dll</HintPath>
     </Reference>
@@ -161,6 +128,39 @@
     </Reference>
     <Reference Include="Realm.Sync">
       <HintPath>..\packages\Realm.1.5.0\lib\netstandard1.4\Realm.Sync.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform">
+      <HintPath>..\packages\MvvmCross.Platform.5.1.1\lib\Xamarin.iOS10\MvvmCross.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform.iOS">
+      <HintPath>..\packages\MvvmCross.Platform.5.1.1\lib\Xamarin.iOS10\MvvmCross.Platform.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Core">
+      <HintPath>..\packages\MvvmCross.Core.5.1.1\lib\Xamarin.iOS10\MvvmCross.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.iOS">
+      <HintPath>..\packages\MvvmCross.Core.5.1.1\lib\Xamarin.iOS10\MvvmCross.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Binding">
+      <HintPath>..\packages\MvvmCross.Binding.5.1.1\lib\Xamarin.iOS10\MvvmCross.Binding.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Binding.iOS">
+      <HintPath>..\packages\MvvmCross.Binding.5.1.1\lib\Xamarin.iOS10\MvvmCross.Binding.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Localization">
+      <HintPath>..\packages\MvvmCross.Binding.5.1.1\lib\Xamarin.iOS10\MvvmCross.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Plugins.Color">
+      <HintPath>..\packages\MvvmCross.Plugin.Color.5.1.1\lib\Xamarin.iOS10\MvvmCross.Plugins.Color.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Plugins.Color.iOS">
+      <HintPath>..\packages\MvvmCross.Plugin.Color.5.1.1\lib\Xamarin.iOS10\MvvmCross.Plugins.Color.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Plugins.Visibility">
+      <HintPath>..\packages\MvvmCross.Plugin.Visibility.5.1.1\lib\Xamarin.iOS10\MvvmCross.Plugins.Visibility.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Plugins.Visibility.iOS">
+      <HintPath>..\packages\MvvmCross.Plugin.Visibility.5.1.1\lib\Xamarin.iOS10\MvvmCross.Plugins.Visibility.iOS.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -340,8 +340,6 @@
     <Compile Include="Binding\TextFieldFocusTargetBinding.cs" />
     <Compile Include="Presentation\TogglPresenter.cs" />
     <Compile Include="ViewControllers\Navigation\TogglNavigationController.cs" />
-    <Compile Include="Bootstrap\ColorPluginBootstrap.cs" />
-    <Compile Include="Bootstrap\VisibilityPluginBootstrap.cs" />
     <Compile Include="Views\TimeEntriesLogHeaderViewCell.cs" />
     <Compile Include="Views\TimeEntriesLogHeaderViewCell.designer.cs">
       <DependentUpon>TimeEntriesLogHeaderViewCell.cs</DependentUpon>
@@ -389,6 +387,8 @@
     </Compile>
     <Compile Include="Extensions\FontExtensions.cs" />
     <Compile Include="LinkerPleaseInclude.cs" />
+    <Compile Include="Bootstrap\ColorPluginBootstrap.cs" />
+    <Compile Include="Bootstrap\VisibilityPluginBootstrap.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Toggl.Foundation.MvvmCross\Toggl.Foundation.MvvmCross.csproj">

--- a/Toggl.Daneel/packages.config
+++ b/Toggl.Daneel/packages.config
@@ -5,18 +5,19 @@
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="xamarinios10" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="MvvmCross" version="5.0.5" targetFramework="xamarinios10" />
-  <package id="MvvmCross.Binding" version="5.0.5" targetFramework="xamarinios10" />
-  <package id="MvvmCross.Core" version="5.0.5" targetFramework="xamarinios10" />
-  <package id="MvvmCross.Platform" version="5.0.5" targetFramework="xamarinios10" />
-  <package id="MvvmCross.Plugin.Color" version="5.0.5" targetFramework="xamarinios10" />
-  <package id="MvvmCross.Plugin.Visibility" version="5.0.5" targetFramework="xamarinios10" />
+  <package id="MvvmCross" version="5.1.1" targetFramework="xamarinios10" />
+  <package id="MvvmCross.Binding" version="5.1.1" targetFramework="xamarinios10" />
+  <package id="MvvmCross.Core" version="5.1.1" targetFramework="xamarinios10" />
+  <package id="MvvmCross.Platform" version="5.1.1" targetFramework="xamarinios10" />
+  <package id="MvvmCross.Plugin.Color" version="5.1.1" targetFramework="xamarinios10" />
+  <package id="MvvmCross.Plugin.Visibility" version="5.1.1" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="xamarinios10" />
   <package id="Realm" version="1.5.0" targetFramework="xamarinios10" />
   <package id="Realm.Database" version="1.5.0" targetFramework="xamarinios10" />
   <package id="Realm.DataBinding" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Remotion.Linq" version="2.1.1" targetFramework="xamarinios10" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />
@@ -72,5 +73,4 @@
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="xamarinios10" />
   <package id="Xamarin.1PasswordExtension" version="1.8.4" targetFramework="xamarinios10" />
   <package id="Xamarin.TestCloud.Agent" version="0.20.6" targetFramework="xamarinios10" />
-  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
 </packages>

--- a/Toggl.Foundation.MvvmCross/App.cs
+++ b/Toggl.Foundation.MvvmCross/App.cs
@@ -10,21 +10,19 @@ namespace Toggl.Foundation.MvvmCross
 {
     public class App : MvxApplication
     {
-        private readonly AppStart appStart;
+        public override void Initialize()
+        {
+            
+        }
 
-        public App(ILoginManager loginManager, IMvxNavigationService navigationService)
+        public void Initialize(ILoginManager loginManager, IMvxNavigationService navigationService)
         {
             Ensure.Argument.IsNotNull(loginManager, nameof(loginManager));
             Ensure.Argument.IsNotNull(navigationService, nameof(navigationService));
 
-            appStart = new AppStart(loginManager, navigationService);
-        }
-
-        public override void Initialize()
-        {
             Mvx.RegisterSingleton<IPasswordManagerService>(new StubPasswordManagerService());
 
-            RegisterAppStart(appStart);
+            RegisterAppStart(new AppStart(loginManager, navigationService));
         }
     }
 

--- a/Toggl.Foundation.MvvmCross/Toggl.Foundation.MvvmCross.csproj
+++ b/Toggl.Foundation.MvvmCross/Toggl.Foundation.MvvmCross.csproj
@@ -61,29 +61,29 @@
     <Reference Include="System.Reactive.Linq">
       <HintPath>..\packages\System.Reactive.Linq.3.0.0\lib\netstandard1.1\System.Reactive.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="MvvmCross.Platform">
-      <HintPath>..\packages\MvvmCross.Platform.5.0.5\lib\portable-net45+win+wpa81+wp80\MvvmCross.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Core">
-      <HintPath>..\packages\MvvmCross.Core.5.0.5\lib\portable-net45+win+wpa81+wp80\MvvmCross.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Binding">
-      <HintPath>..\packages\MvvmCross.Binding.5.0.5\lib\portable-net45+win+wpa81+wp80\MvvmCross.Binding.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Localization">
-      <HintPath>..\packages\MvvmCross.Binding.5.0.5\lib\portable-net45+win+wpa81+wp80\MvvmCross.Localization.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Plugins.Color">
-      <HintPath>..\packages\MvvmCross.Plugin.Color.5.0.5\lib\portable-net45+win+wpa81+wp80\MvvmCross.Plugins.Color.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Plugins.Visibility">
-      <HintPath>..\packages\MvvmCross.Plugin.Visibility.5.0.5\lib\portable-net45+win+wpa81+wp80\MvvmCross.Plugins.Visibility.dll</HintPath>
-    </Reference>
     <Reference Include="PropertyChanged">
       <HintPath>..\packages\PropertyChanged.Fody.2.1.3\lib\netstandard1.0\PropertyChanged.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform">
+      <HintPath>..\packages\MvvmCross.Platform.5.1.1\lib\portable-net45+win+wpa81+wp80\MvvmCross.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Core">
+      <HintPath>..\packages\MvvmCross.Core.5.1.1\lib\portable-net45+win+wpa81+wp80\MvvmCross.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Binding">
+      <HintPath>..\packages\MvvmCross.Binding.5.1.1\lib\portable-net45+win+wpa81+wp80\MvvmCross.Binding.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Localization">
+      <HintPath>..\packages\MvvmCross.Binding.5.1.1\lib\portable-net45+win+wpa81+wp80\MvvmCross.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Plugins.Color">
+      <HintPath>..\packages\MvvmCross.Plugin.Color.5.1.1\lib\portable-net45+win+wpa81+wp80\MvvmCross.Plugins.Color.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Plugins.Visibility">
+      <HintPath>..\packages\MvvmCross.Plugin.Visibility.5.1.1\lib\portable-net45+win+wpa81+wp80\MvvmCross.Plugins.Visibility.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
@@ -27,9 +27,9 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             StartTimeEntryCommand = new MvxAsyncCommand(startTimeEntry);
         }
 
-        public override void Appeared()
+        public override void ViewAppeared()
         {
-            base.Appeared();
+            base.ViewAppeared();
             navigationService.Navigate<SuggestionsViewModel>();
             navigationService.Navigate<TimeEntriesLogViewModel>();
         }

--- a/Toggl.Foundation.MvvmCross/packages.config
+++ b/Toggl.Foundation.MvvmCross/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Fody" version="2.0.8" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
-  <package id="MvvmCross" version="5.0.5" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="MvvmCross.Binding" version="5.0.5" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="MvvmCross.Core" version="5.0.5" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="MvvmCross.Platform" version="5.0.5" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="MvvmCross.Plugin.Color" version="5.0.5" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="MvvmCross.Plugin.Visibility" version="5.0.5" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="MvvmCross" version="5.1.1" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="MvvmCross.Binding" version="5.1.1" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="MvvmCross.Core" version="5.1.1" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="MvvmCross.Platform" version="5.1.1" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="MvvmCross.Plugin.Color" version="5.1.1" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="MvvmCross.Plugin.Visibility" version="5.1.1" targetFramework="portable45-net45+win8+wpa81" />
   <package id="PropertyChanged.Fody" version="2.1.3" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="portable45-net45+win8+wpa81" developmentDependency="true" />
   <package id="System.Collections" version="4.3.0" targetFramework="portable45-net45+win8+wpa81" />

--- a/Toggl.Foundation.Tests/MvvmCross/ViewModels/MainViewModelTests.cs
+++ b/Toggl.Foundation.Tests/MvvmCross/ViewModels/MainViewModelTests.cs
@@ -34,12 +34,12 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             }
         }
 
-        public class TheAppearedMethod : MainViewModelTest
+        public class TheViewAppearedMethod : MainViewModelTest
         {
             [Fact]
             public void RequestsTheSuggestionsViewModel()
             {
-                ViewModel.Appeared();
+                ViewModel.ViewAppeared();
 
                 NavigationService.Received().Navigate<SuggestionsViewModel>();
             }
@@ -47,7 +47,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact]
             public void RequestsTheLogTimeEntriesViewModel()
             {
-                ViewModel.Appeared();
+                ViewModel.ViewAppeared();
 
                 NavigationService.Received().Navigate<TimeEntriesLogViewModel>();
             }

--- a/Toggl.Foundation.Tests/Toggl.Foundation.Tests.csproj
+++ b/Toggl.Foundation.Tests/Toggl.Foundation.Tests.csproj
@@ -155,26 +155,26 @@
     <Reference Include="FsCheck.Xunit">
       <HintPath>..\packages\FsCheck.Xunit.2.9.0\lib\net452\FsCheck.Xunit.dll</HintPath>
     </Reference>
-    <Reference Include="MvvmCross.Platform">
-      <HintPath>..\packages\MvvmCross.Platform.5.0.5\lib\net45\MvvmCross.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Platform.Wpf">
-      <HintPath>..\packages\MvvmCross.Platform.5.0.5\lib\net45\MvvmCross.Platform.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Core">
-      <HintPath>..\packages\MvvmCross.Core.5.0.5\lib\net45\MvvmCross.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Wpf">
-      <HintPath>..\packages\MvvmCross.Core.5.0.5\lib\net45\MvvmCross.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="MvvmCross.Test.Core">
-      <HintPath>..\packages\MvvmCross.Tests.5.0.5\lib\portable45-net45+win8+wp8+wpa81\MvvmCross.Test.Core.dll</HintPath>
-    </Reference>
     <Reference Include="FluentAssertions.Core">
       <HintPath>..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.4.19.3\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform">
+      <HintPath>..\packages\MvvmCross.Platform.5.1.1\lib\net45\MvvmCross.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform.Wpf">
+      <HintPath>..\packages\MvvmCross.Platform.5.1.1\lib\net45\MvvmCross.Platform.Wpf.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Core">
+      <HintPath>..\packages\MvvmCross.Core.5.1.1\lib\net45\MvvmCross.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Wpf">
+      <HintPath>..\packages\MvvmCross.Core.5.1.1\lib\net45\MvvmCross.Wpf.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Test.Core">
+      <HintPath>..\packages\MvvmCross.Tests.5.1.1\lib\portable45-net45+win8+wp8+wpa81\MvvmCross.Test.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Toggl.Foundation.Tests/packages.config
+++ b/Toggl.Foundation.Tests/packages.config
@@ -7,9 +7,9 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net462" />
   <package id="Microsoft.Reactive.Testing" version="3.0.0" targetFramework="net462" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net462" />
-  <package id="MvvmCross.Core" version="5.0.5" targetFramework="net462" />
-  <package id="MvvmCross.Platform" version="5.0.5" targetFramework="net462" />
-  <package id="MvvmCross.Tests" version="5.0.5" targetFramework="net462" />
+  <package id="MvvmCross.Core" version="5.1.1" targetFramework="net462" />
+  <package id="MvvmCross.Platform" version="5.1.1" targetFramework="net462" />
+  <package id="MvvmCross.Tests" version="5.1.1" targetFramework="net462" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net462" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net462" />
   <package id="NUnit" version="3.7.1" targetFramework="net462" />


### PR DESCRIPTION
Note on the third commit: 

From version 5.1 onwards, the NavigationService now depends on App. Since our App depends on NavigationService, nothing would compile.

I changed it so that the needed dependencies get injected when initializing rather than when constructing and it’s all fine and ServiceLocator free :shipit: 

Squash whenever