### PR TITLE
Implement Get Since endpoints

### DIFF
--- a/Toggl.Multivac/Extensions/DateTimeOffsetExtensions.cs
+++ b/Toggl.Multivac/Extensions/DateTimeOffsetExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Toggl.Multivac.Extensions
+{
+    public static class DateTimeOffsetExtensions
+    {
+        public static long ToUnixTimeSeconds(this DateTimeOffset dateTime)
+        {
+            // constant and implementation taken from .NET reference source:
+            // https://referencesource.microsoft.com/#mscorlib/system/datetimeoffset.cs
+            const long unixEpochSeconds = 62_135_596_800L;
+
+            var seconds = dateTime.UtcDateTime.Ticks / TimeSpan.TicksPerSecond;
+            return seconds - unixEpochSeconds;
+        }
+    }
+}

--- a/Toggl.Multivac/Toggl.Multivac.csproj
+++ b/Toggl.Multivac/Toggl.Multivac.csproj
@@ -29,6 +29,7 @@
     <CodeAnalysisRuleSet>..\Toggl.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Extensions\DateTimeOffsetExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Ensure.cs" />
     <Compile Include="Either.cs" />

--- a/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
+++ b/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
@@ -90,7 +90,7 @@ namespace Toggl.Ultrawave.Tests.Integration.BaseTests
         {
             var (api, _) = await SetupTestUser();
 
-            Action callingEndpointWithBadThreshold = async () =>
+            Func<Task> callingEndpointWithBadThreshold = async () =>
                 await CallEndpointWith(api, DateTimeOffset.Now.AddDays(-95));
 
             callingEndpointWithBadThreshold.ShouldThrow<BadRequestException>();

--- a/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
+++ b/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Toggl.Ultrawave.Exceptions;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+using UserModel = Toggl.Ultrawave.Models.User;
+
+namespace Toggl.Ultrawave.Tests.Integration.BaseTests
+{
+    public abstract class AuthenticatedGetSinceEndpointBaseTests<T>
+        : AuthenticatedEndpointBaseTests<List<T>>
+    {
+        protected override IObservable<List<T>> CallEndpointWith(ITogglApi togglApi)
+            => CallEndpointWith(togglApi, DateTimeOffset.Now);
+
+        protected abstract IObservable<List<T>> CallEndpointWith(ITogglApi togglApi, DateTimeOffset threshold);
+
+        protected abstract DateTimeOffset AtDateOf(T model);
+
+        protected abstract T MakeUniqueModel(ITogglApi api, UserModel user);
+
+        protected abstract IObservable<T> PostModelToApi(ITogglApi api, T model);
+
+        protected abstract Expression<Func<T, bool>> ModelWithSameAttributesAs(T model);
+
+        private async Task<(T, T)> setUpModels(ITogglApi api, UserModel user)
+        {
+            var firstModel = MakeUniqueModel(api, user);
+            var firstModelPosted = await PostModelToApi(api, firstModel);
+
+            // make sure we get different `At` dates
+            await Task.Delay(2);
+
+            var secondModel = MakeUniqueModel(api, user);
+            var secondModelPosted = await PostModelToApi(api, secondModel);
+
+            return (firstModelPosted, secondModelPosted);
+        }
+
+        [Fact, LogTestInfo]
+        public async Task ReturnsAllModelsIfThresholdIsOldestAtDate()
+        {
+            var (api, user) = await SetupTestUser();
+            var (firstModel, secondModel) = await setUpModels(api, user);
+
+            var models = await CallEndpointWith(api, AtDateOf(firstModel));
+
+            models.Should().HaveCount(2);
+            models.Should().Contain(ModelWithSameAttributesAs(firstModel));
+            models.Should().Contain(ModelWithSameAttributesAs(secondModel));
+        }
+
+        [Fact, LogTestInfo]
+        public async void ReturnsOnlyModelsWithAtDateNewerOrSameThanThreshold()
+        {
+            var (api, user) = await SetupTestUser();
+            var (_, secondModel) = await setUpModels(api, user);
+
+            var models = await CallEndpointWith(api, AtDateOf(secondModel));
+
+            models.Should().HaveCount(1);
+            models.Should().Contain(ModelWithSameAttributesAs(secondModel));
+        }
+
+        [Fact, LogTestInfo]
+        public async void ReturnsNoModelsIfThresholdIsAfterNewestAtDate()
+        {
+            var (api, user) = await SetupTestUser();
+            var (_, secondModel) = await setUpModels(api, user);
+
+            var models = await CallEndpointWith(api, AtDateOf(secondModel).AddSeconds(1));
+
+            models.Should().HaveCount(0);
+        }
+
+        [Fact, LogTestInfo]
+        public async void SucceedsForThresholdAlmostThreeMonthsAgo()
+        {
+            var (api, _) = await SetupTestUser();
+
+            await CallEndpointWith(api, DateTimeOffset.Now.AddMonths(-3).AddDays(1));
+        }
+
+        [Fact, LogTestInfo]
+        public async void FailsForThresholdMoreThanThreeMonthsAgo()
+        {
+            var (api, _) = await SetupTestUser();
+
+            Action callingEndpointWithBadThreshold = async () =>
+                await CallEndpointWith(api, DateTimeOffset.Now.AddMonths(-3).AddDays(-1));
+
+            callingEndpointWithBadThreshold.ShouldThrow<BadRequestException>();
+        }
+    }
+}

--- a/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
+++ b/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
@@ -33,7 +33,7 @@ namespace Toggl.Ultrawave.Tests.Integration.BaseTests
             var firstModelPosted = await PostModelToApi(api, firstModel);
 
             // make sure we get different `At` dates
-            await Task.Delay(2);
+            await Task.Delay(TimeSpan.FromSeconds(2));
 
             var secondModel = MakeUniqueModel(api, user);
             var secondModelPosted = await PostModelToApi(api, secondModel);

--- a/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
+++ b/Toggl.Ultrawave.Tests.Integration/BaseTests/AuthenticatedGetSinceEndpointBaseTests.cs
@@ -82,7 +82,7 @@ namespace Toggl.Ultrawave.Tests.Integration.BaseTests
         {
             var (api, _) = await SetupTestUser();
 
-            await CallEndpointWith(api, DateTimeOffset.Now.AddMonths(-3).AddDays(1));
+            await CallEndpointWith(api, DateTimeOffset.Now.AddDays(-85));
         }
 
         [Fact, LogTestInfo]
@@ -91,7 +91,7 @@ namespace Toggl.Ultrawave.Tests.Integration.BaseTests
             var (api, _) = await SetupTestUser();
 
             Action callingEndpointWithBadThreshold = async () =>
-                await CallEndpointWith(api, DateTimeOffset.Now.AddMonths(-3).AddDays(-1));
+                await CallEndpointWith(api, DateTimeOffset.Now.AddDays(-95));
 
             callingEndpointWithBadThreshold.ShouldThrow<BadRequestException>();
         }

--- a/Toggl.Ultrawave.Tests.Integration/Toggl.Ultrawave.Tests.Integration.csproj
+++ b/Toggl.Ultrawave.Tests.Integration/Toggl.Ultrawave.Tests.Integration.csproj
@@ -146,6 +146,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BaseTests\AuthenticatedGetSinceEndpointBaseTests.cs" />
     <Compile Include="ClientsApiTests.cs" />
     <Compile Include="BaseTests\EndpointTestBase.cs" />
     <Compile Include="BaseTests\AuthenticatedPostEndpointBaseTests.cs" />

--- a/Toggl.Ultrawave/ApiClients/ClientsApi.cs
+++ b/Toggl.Ultrawave/ApiClients/ClientsApi.cs
@@ -22,6 +22,11 @@ namespace Toggl.Ultrawave.ApiClients
             return observable;
         }
 
+        public IObservable<List<Client>> GetAllSince(DateTimeOffset threshold)
+        {
+            return CreateObservable<List<Client>>(endPoints.GetSince(threshold), AuthHeader);
+        }
+
         public IObservable<Client> Create(Client client)
         {
             var endPoint = endPoints.Post(client.WorkspaceId);

--- a/Toggl.Ultrawave/ApiClients/Interfaces/IClientsApi.cs
+++ b/Toggl.Ultrawave/ApiClients/Interfaces/IClientsApi.cs
@@ -7,6 +7,7 @@ namespace Toggl.Ultrawave.ApiClients
     public interface IClientsApi
     {
         IObservable<List<Client>> GetAll();
+        IObservable<List<Client>> GetAllSince(DateTimeOffset threshold);
         IObservable<Client> Create(Client client);
     }
 }

--- a/Toggl.Ultrawave/Network/Endpoints/ClientEndpoints.cs
+++ b/Toggl.Ultrawave/Network/Endpoints/ClientEndpoints.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Toggl.Multivac.Extensions;
 
 namespace Toggl.Ultrawave.Network
 {
@@ -12,6 +13,9 @@ namespace Toggl.Ultrawave.Network
         }
 
         public Endpoint Get => Endpoint.Get(baseUrl, "me/clients");
+
+        public Endpoint GetSince(DateTimeOffset threshold)
+            => Endpoint.Get(baseUrl, $"me/clients?since={threshold.ToUnixTimeSeconds()}");
 
         public Endpoint Post(long workspaceId)
             => Endpoint.Post(baseUrl, $"workspaces/{ workspaceId }/clients");


### PR DESCRIPTION
Closes #360

These will be needed for faster fetching and syncing of data.

So far only the client endpoints are implemented, but feel free to review, since the others will be analogous.

Note that there is one thing I'm not testing: Whether the API actually uses the last-changed date as expected (and I know it does) or the date the entity was created. I cannot test this easily for anything but time entries since only those have update-API implemented, but I'll add a test very similar to the existing ones for time entries when I add the endpoint.

Also note that add the `long ToUnixTimeSeconds(this DateTimeOffset dateTime)` extension method, since we cannot use .net 4.6 yet. It has the same signature and does the same thing (minus boundary checks, because it's not terribly necessary for us) as the one from the framework, so switching this out in the future will be painless.