### PR TITLE
Avoid app crashing and showing blank time entries log

### DIFF
--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -61,7 +61,7 @@ namespace Toggl.Daneel.ViewSources
             => GetGroupAt(section).Count();
 
         protected IEnumerable<T> GetGroupAt(nint section)
-            => GroupedItems.ElementAt((int)section);
+            => GroupedItems.ElementAtOrDefault((int)section) ?? new MvxObservableCollection<T>();
 
         protected sealed override object GetItemAt(NSIndexPath indexPath)
             => GroupedItems.ElementAtOrDefault(indexPath.Section)?.ElementAtOrDefault((int)indexPath.Item);


### PR DESCRIPTION
Closes #895 and also closes #768 

First, here is how to reproduce the issue in `develop`:

Replace the method

```csharp
protected IEnumerable<T> GetGroupAt(nint section)
    => GroupedItems.ElementAt((int)section);
```

with

```csharp
protected IEnumerable<T> GetGroupAt(nint section)
{
    var group = GroupedItems.ElementAtOrDefault((int)section);
    if (group == null)
    {
        var a = 123;
        // group = new MvxObservableCollection<T>();
    }
    return group;
}
```
Set a breakpoint at line containing `var a = 123;` and start the app in simulator. In the webapp create several time entries on different dates (so they will be in different groups) which weren't used by any older time entries. Now initiate a pull sync. You should hit the breakpoint and if you continue, the time entry log will be blank (the view crashes). In the original implementation the `.ElementAt` would throw an exception so the whole app would crash. If you now uncomment the line `// group = ...` and repeat the whole process, the log should remain intact even when you hit the breakpoint.

The code in this PR is just a condensed version of the snippet in this description.

As of ✅ - there are no tests for view sources and so I didn't add any new ones. Maybe we should add an issue for this to add these tests later.