### PR TITLE
Fix BasePushEntityStateTests

### DIFF
--- a/Toggl.Foundation.Tests/Helpers/ApiExceptions.cs
+++ b/Toggl.Foundation.Tests/Helpers/ApiExceptions.cs
@@ -35,6 +35,15 @@ namespace Toggl.Foundation.Tests.Helpers
                 new object[] { new TooManyRequestsException(request, response) }
             };
 
+        public static object[] ExceptionsWhichCauseRethrow()
+            => new[]
+            {
+                new object[] { new ClientDeprecatedException(Substitute.For<IRequest>(), Substitute.For<IResponse>()), },
+                new object[] { new ApiDeprecatedException(Substitute.For<IRequest>(), Substitute.For<IResponse>()), },
+                new object[] { new UnauthorizedException(Substitute.For<IRequest>(), Substitute.For<IResponse>()), },
+                new object[] { new OfflineException() }
+            };
+
         public static object[] ServerExceptions
             => new[]
             {

--- a/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BaseCreateEntityStateTests.cs
+++ b/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BaseCreateEntityStateTests.cs
@@ -52,6 +52,11 @@ namespace Toggl.Foundation.Tests.Sync.States
         public void UpdateIsCalledWithCorrectParameters()
             => helper.UpdateIsCalledWithCorrectParameters();
 
+        [Theory, LogIfTooSlow]
+        [MemberData(nameof(ApiExceptions.ExceptionsWhichCauseRethrow), MemberType = typeof(ApiExceptions))]
+        public void ThrowsWhenCertainExceptionsAreCaught(Exception exception)
+            => helper.ThrowsWhenCertainExceptionsAreCaught(exception);
+
         public interface IStartMethodTestHelper
         {
             void ReturnsFailTransitionWhenEntityIsNull();
@@ -61,6 +66,7 @@ namespace Toggl.Foundation.Tests.Sync.States
             void ReturnsFailTransitionWhenDatabaseOperationFails();
             void ReturnsSuccessfulTransitionWhenEverythingWorks();
             void UpdateIsCalledWithCorrectParameters();
+            void ThrowsWhenCertainExceptionsAreCaught(Exception exception);
         }
 
         internal abstract class TheStartMethod<TModel, TApiModel> : BasePushEntityStateTests<TModel, TApiModel>, IStartMethodTestHelper

--- a/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BaseDeleteEntityStateTests.cs
+++ b/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BaseDeleteEntityStateTests.cs
@@ -56,6 +56,11 @@ namespace Toggl.Foundation.Tests.Sync.States
         public void DoesNotDeleteTheEntityLocallyIfTheApiOperationFails()
             => helper.DoesNotDeleteTheEntityLocallyIfTheApiOperationFails();
 
+        [Theory, LogIfTooSlow]
+        [MemberData(nameof(ApiExceptions.ExceptionsWhichCauseRethrow), MemberType = typeof(ApiExceptions))]
+        public void ThrowsWhenCertainExceptionsAreCaught(Exception exception)
+            => helper.ThrowsWhenCertainExceptionsAreCaught(exception);
+
         public interface IStartMethodTestHelper
         {
             void ReturnsFailTransitionWhenEntityIsNull();
@@ -66,6 +71,7 @@ namespace Toggl.Foundation.Tests.Sync.States
             void ReturnsSuccessfulTransitionWhenEverythingWorks();
             void CallsDatabaseDeleteOperationWithCorrectParameter();
             void DoesNotDeleteTheEntityLocallyIfTheApiOperationFails();
+            void ThrowsWhenCertainExceptionsAreCaught(Exception exception);
         }
 
         internal abstract class TheStartMethod<TModel, TApiModel> : BasePushEntityStateTests<TModel, TApiModel>, IStartMethodTestHelper

--- a/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BaseUpdateEntityStateTests.cs
+++ b/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BaseUpdateEntityStateTests.cs
@@ -58,6 +58,11 @@ namespace Toggl.Foundation.Tests.Sync.States
         public void ReturnsTheUpdatingSuccessfulTransitionWhenEntityDoesNotChangeLocallyAndAllFunctionsAreCalledWithCorrectParameters()
             => helper.ReturnsTheUpdatingSuccessfulTransitionWhenEntityDoesNotChangeLocallyAndAllFunctionsAreCalledWithCorrectParameters();
 
+        [Theory, LogIfTooSlow]
+        [MemberData(nameof(ApiExceptions.ExceptionsWhichCauseRethrow), MemberType = typeof(ApiExceptions))]
+        public void ThrowsWhenCertainExceptionsAreCaught(Exception exception)
+            => helper.ThrowsWhenCertainExceptionsAreCaught(exception);
+
         public interface TheStartMethodHelper
         {
             void ReturnsTheFailTransitionWhenEntityIsNull();
@@ -68,6 +73,7 @@ namespace Toggl.Foundation.Tests.Sync.States
             void UpdateApiCallIsCalledWithTheInputEntity();
             void ReturnsTheEntityChangedTransitionWhenEntityChangesLocally();
             void ReturnsTheUpdatingSuccessfulTransitionWhenEntityDoesNotChangeLocallyAndAllFunctionsAreCalledWithCorrectParameters();
+            void ThrowsWhenCertainExceptionsAreCaught(Exception exception);
         }
 
         internal abstract class TheStartMethod<TModel, TApiModel> : BasePushEntityStateTests<TModel, TApiModel>, TheStartMethodHelper


### PR DESCRIPTION
Some tests were incorrectly used and weren't discovered and run by XUnit. This fixes it.

Squash whenever