### PR TITLE
Fix the :bug: - once and for all

### DIFF
--- a/Toggl.Daneel/ViewControllers/MainViewController.cs
+++ b/Toggl.Daneel/ViewControllers/MainViewController.cs
@@ -84,6 +84,7 @@ namespace Toggl.Daneel.ViewControllers
 
             //Table view
             bindingSet.Bind(source)
+                      .For(v => v.AnimatableCollection)
                       .To(vm => vm.TimeEntriesLogViewModel.TimeEntries);
 
             bindingSet.Bind(source)

--- a/Toggl.Daneel/ViewControllers/MainViewController.cs
+++ b/Toggl.Daneel/ViewControllers/MainViewController.cs
@@ -84,7 +84,7 @@ namespace Toggl.Daneel.ViewControllers
 
             //Table view
             bindingSet.Bind(source)
-                      .For(v => v.AnimatableCollection)
+                      .For(v => v.ObservableCollection)
                       .To(vm => vm.TimeEntriesLogViewModel.TimeEntries);
 
             bindingSet.Bind(source)

--- a/Toggl.Daneel/ViewControllers/SelectProjectViewController.cs
+++ b/Toggl.Daneel/ViewControllers/SelectProjectViewController.cs
@@ -38,7 +38,10 @@ namespace Toggl.Daneel.ViewControllers
                       .To(vm => vm.IsEmpty);
 
             //Table view
-            bindingSet.Bind(source).To(vm => vm.Suggestions);
+            bindingSet.Bind(source)
+                      .For(v => v.ObservableCollection)
+                      .To(vm => vm.Suggestions);
+
             bindingSet.Bind(source)
                       .For(v => v.CreateCommand)
                       .To(vm => vm.CreateProjectCommand);

--- a/Toggl.Daneel/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.Daneel/ViewControllers/StartTimeEntryViewController.cs
@@ -49,7 +49,7 @@ namespace Toggl.Daneel.ViewControllers
 
             //TableView
             bindingSet.Bind(source)
-                      .For(v => v.AnimatableCollection)
+                      .For(v => v.ObservableCollection)
                       .To(vm => vm.Suggestions);
 
             bindingSet.Bind(source)

--- a/Toggl.Daneel/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.Daneel/ViewControllers/StartTimeEntryViewController.cs
@@ -48,7 +48,9 @@ namespace Toggl.Daneel.ViewControllers
             var bindingSet = this.CreateBindingSet<StartTimeEntryViewController, StartTimeEntryViewModel>();
 
             //TableView
-            bindingSet.Bind(source).To(vm => vm.Suggestions);
+            bindingSet.Bind(source)
+                      .For(v => v.AnimatableCollection)
+                      .To(vm => vm.Suggestions);
 
             bindingSet.Bind(source)
                       .For(v => v.UseGrouping)

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -145,31 +145,32 @@ namespace Toggl.Daneel.ViewSources
 
         protected void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
         {
-            InvokeOnMainThread(() =>
-            {
-                if (!UseAnimations)
-                {
-                    cloneCollection();
-                    ReloadTableData();
-                    return;
-                }
-
-                animateSectionChangesIfPossible(args);
-            });
+            tryAnimateOnMainThread(() => animateSectionChangesIfPossible(args));
         }
 
         protected void OnChildCollectionChanged(object sender, ChildCollectionChangedEventArgs args)
+        {
+            tryAnimateOnMainThread(() => animateRowChangesIfPossible(args));
+        }
+
+        private void tryAnimateOnMainThread(Action animate)
         {
             InvokeOnMainThread(() =>
             {
                 if (!UseAnimations)
                 {
-                    cloneCollection();
-                    ReloadTableData();
+                    reloadTable();
                     return;
                 }
 
-                animateRowChangesIfPossible(args);
+                try
+                {
+                    animate();
+                }
+                catch
+                {
+                    reloadTable();
+                }
             });
         }
 

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -24,7 +24,7 @@ namespace Toggl.Daneel.ViewSources
 
         private NestableObservableCollection<TCollection, TItem> observableCollection;
 
-        private List<TCollection> displayedGroupedItems = new List<TCollection>();
+        private readonly List<TCollection> displayedGroupedItems = new List<TCollection>();
 
         protected IReadOnlyCollection<TCollection> GroupedItems { get; }
 

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -182,38 +182,33 @@ namespace Toggl.Daneel.ViewSources
                 switch (args.Action)
                 {
                     case NotifyCollectionChangedAction.Add:
-                        var indexToAdd = NSIndexSet.FromIndex(args.NewStartingIndex);
-
-                        var addedSection = new TCollection();
-                        addedSection.AddRange(observableCollection[args.NewStartingIndex]);
-
+                        var addedSection = CloneCollection(observableCollection[args.NewStartingIndex]);
                         displayedGroupedItems.Insert(args.NewStartingIndex, addedSection);
+
+                        var indexToAdd = NSIndexSet.FromIndex(args.NewStartingIndex);
                         TableView.InsertSections(indexToAdd, UITableViewRowAnimation.Automatic);
                         break;
 
                     case NotifyCollectionChangedAction.Remove:
-                        var indexToRemove = NSIndexSet.FromIndex(args.OldStartingIndex);
                         displayedGroupedItems.RemoveAt(args.OldStartingIndex);
+
+                        var indexToRemove = NSIndexSet.FromIndex(args.OldStartingIndex);
                         TableView.DeleteSections(indexToRemove, UITableViewRowAnimation.Automatic);
                         break;
 
                     case NotifyCollectionChangedAction.Move when args.NewItems.Count == 1 && args.OldItems.Count == 1:
+                        var movedSection = CloneCollection(observableCollection[args.NewStartingIndex]);
                         displayedGroupedItems.RemoveAt(args.OldStartingIndex);
-
-                        var movedSection = new TCollection();
-                        movedSection.AddRange(observableCollection[args.NewStartingIndex]);
-
                         displayedGroupedItems.Insert(args.NewStartingIndex, movedSection);
+
                         TableView.MoveSection(args.OldStartingIndex, args.NewStartingIndex);
                         break;
 
                     case NotifyCollectionChangedAction.Replace when args.NewItems.Count == args.OldItems.Count:
-                        var indexSet = NSIndexSet.FromIndex(args.NewStartingIndex);
-
-                        var replacedSection = new TCollection();
-                        replacedSection.AddRange(observableCollection[args.NewStartingIndex]);
-
+                        var replacedSection = CloneCollection(observableCollection[args.NewStartingIndex]);
                         displayedGroupedItems[args.NewStartingIndex] = replacedSection;
+
+                        var indexSet = NSIndexSet.FromIndex(args.NewStartingIndex);
                         TableView.ReloadSections(indexSet, ReplaceAnimation);
                         break;
 

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -281,11 +281,9 @@ namespace Toggl.Daneel.ViewSources
         private void cloneCollection()
         {
             internalCollection = new List<TCollection>();
-            foreach (var animatableSection in observableCollection)
+            foreach (var section in observableCollection)
             {
-                var section = new TCollection();
-                section.AddRange(animatableSection);
-                internalCollection.Add(section);
+                internalCollection.Add(CloneCollection(section));
             }
         }
 
@@ -297,5 +295,7 @@ namespace Toggl.Daneel.ViewSources
 
             ObservableCollection.OnChildCollectionChanged -= OnChildCollectionChanged;
         }
+
+        protected abstract TCollection CloneCollection(TCollection collection);
     }
 }

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -31,7 +31,7 @@ namespace Toggl.Daneel.ViewSources
         public override IEnumerable ItemsSource
         {
             get => internalCollection;
-            set { }
+            set { throw new InvalidOperationException($"You must bind to the {nameof(ObservableCollection)} and not the {nameof(ItemsSource)}"); }
         }
 
         public NestableObservableCollection<TCollection, TItem> ObservableCollection

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -30,7 +30,7 @@ namespace Toggl.Daneel.ViewSources
 
         public override IEnumerable ItemsSource
         {
-            get => displayedGroupedItems;
+            get => GroupedItems;
             set { throw new InvalidOperationException($"You must bind to the {nameof(ObservableCollection)} and not the {nameof(ItemsSource)}"); }
         }
 
@@ -47,7 +47,7 @@ namespace Toggl.Daneel.ViewSources
 
                 observableCollection = value;
                 cloneCollection();
-                base.ItemsSource = displayedGroupedItems;
+                base.ItemsSource = GroupedItems;
 
                 if (observableCollection != null)
                 {

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -24,9 +24,9 @@ namespace Toggl.Daneel.ViewSources
 
         private NestableObservableCollection<TCollection, TItem> observableCollection;
 
-        private IList<TCollection> internalCollection;
+        private readonly IList<TCollection> internalCollection;
 
-        public IList<TCollection> GroupedItems => internalCollection;
+        protected IList<TCollection> GroupedItems => internalCollection;
 
         public override IEnumerable ItemsSource
         {
@@ -280,7 +280,7 @@ namespace Toggl.Daneel.ViewSources
 
         private void cloneCollection()
         {
-            internalCollection = new List<TCollection>();
+            internalCollection.Clear();
             foreach (var section in observableCollection)
             {
                 internalCollection.Add(CloneCollection(section));

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -290,6 +290,7 @@ namespace Toggl.Daneel.ViewSources
 
             if (!disposing || ObservableCollection == null) return;
 
+            ObservableCollection.CollectionChanged -= OnCollectionChanged;
             ObservableCollection.OnChildCollectionChanged -= OnChildCollectionChanged;
         }
 

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -22,7 +22,7 @@ namespace Toggl.Daneel.ViewSources
         private readonly object animationLock = new object();
         private readonly List<IDisposable> disposables = new List<IDisposable>();
 
-        private NestableObservableCollection<TCollection, TItem> animatableCollection;
+        private NestableObservableCollection<TCollection, TItem> observableCollection;
 
         private IList<TCollection> internalCollection;
 
@@ -34,25 +34,25 @@ namespace Toggl.Daneel.ViewSources
             set { }
         }
 
-        public NestableObservableCollection<TCollection, TItem> AnimatableCollection
+        public NestableObservableCollection<TCollection, TItem> ObservableCollection
         {
-            get => animatableCollection;
+            get => observableCollection;
             set
             {
-                if (animatableCollection != null)
+                if (observableCollection != null)
                 {
-                    animatableCollection.CollectionChanged -= OnCollectionChanged;
-                    animatableCollection.OnChildCollectionChanged -= OnChildCollectionChanged;
+                    observableCollection.CollectionChanged -= OnCollectionChanged;
+                    observableCollection.OnChildCollectionChanged -= OnChildCollectionChanged;
                 }
 
-                animatableCollection = value;
+                observableCollection = value;
                 cloneCollection();
                 base.ItemsSource = internalCollection;
 
-                if (animatableCollection != null)
+                if (observableCollection != null)
                 {
-                    animatableCollection.CollectionChanged += OnCollectionChanged;
-                    animatableCollection.OnChildCollectionChanged += OnChildCollectionChanged;
+                    observableCollection.CollectionChanged += OnCollectionChanged;
+                    observableCollection.OnChildCollectionChanged += OnChildCollectionChanged;
                 }
             }
         }
@@ -185,7 +185,7 @@ namespace Toggl.Daneel.ViewSources
                         var indexToAdd = NSIndexSet.FromIndex(args.NewStartingIndex);
 
                         var addedSection = new TCollection();
-                        addedSection.AddRange(animatableCollection[args.NewStartingIndex]);
+                        addedSection.AddRange(observableCollection[args.NewStartingIndex]);
 
                         internalCollection.Insert(args.NewStartingIndex, addedSection);
                         TableView.InsertSections(indexToAdd, UITableViewRowAnimation.Automatic);
@@ -201,7 +201,7 @@ namespace Toggl.Daneel.ViewSources
                         internalCollection.RemoveAt(args.OldStartingIndex);
 
                         var movedSection = new TCollection();
-                        movedSection.AddRange(animatableCollection[args.NewStartingIndex]);
+                        movedSection.AddRange(observableCollection[args.NewStartingIndex]);
 
                         internalCollection.Insert(args.NewStartingIndex, movedSection);
                         TableView.MoveSection(args.OldStartingIndex, args.NewStartingIndex);
@@ -211,7 +211,7 @@ namespace Toggl.Daneel.ViewSources
                         var indexSet = NSIndexSet.FromIndex(args.NewStartingIndex);
 
                         var replacedSection = new TCollection();
-                        replacedSection.AddRange(animatableCollection[args.NewStartingIndex]);
+                        replacedSection.AddRange(observableCollection[args.NewStartingIndex]);
 
                         internalCollection[args.NewStartingIndex] = replacedSection;
                         TableView.ReloadSections(indexSet, ReplaceAnimation);
@@ -241,7 +241,7 @@ namespace Toggl.Daneel.ViewSources
                             .ToArray();
 
                         foreach (var indexPath in indexPathsToAdd)
-                            internalCollection[indexPath.Section].Insert(indexPath.Row, animatableCollection[indexPath.Section][indexPath.Row]);
+                            internalCollection[indexPath.Section].Insert(indexPath.Row, observableCollection[indexPath.Section][indexPath.Row]);
 
                         TableView.InsertRows(indexPathsToAdd, AddAnimation);
                         break;
@@ -263,7 +263,7 @@ namespace Toggl.Daneel.ViewSources
                             .ToArray();
 
                         foreach (var indexPath in indexPathsToUpdate)
-                            internalCollection[indexPath.Section][indexPath.Row] = animatableCollection[indexPath.Section][indexPath.Row];
+                            internalCollection[indexPath.Section][indexPath.Row] = observableCollection[indexPath.Section][indexPath.Row];
 
                         TableView.ReloadRows(indexPathsToUpdate, ReplaceAnimation);
                         break;
@@ -281,7 +281,7 @@ namespace Toggl.Daneel.ViewSources
         private void cloneCollection()
         {
             internalCollection = new List<TCollection>();
-            foreach (var animatableSection in animatableCollection)
+            foreach (var animatableSection in observableCollection)
             {
                 var section = new TCollection();
                 section.AddRange(animatableSection);
@@ -293,9 +293,9 @@ namespace Toggl.Daneel.ViewSources
         {
             base.Dispose(disposing);
 
-            if (!disposing || AnimatableCollection == null) return;
+            if (!disposing || ObservableCollection == null) return;
 
-            AnimatableCollection.OnChildCollectionChanged -= OnChildCollectionChanged;
+            ObservableCollection.OnChildCollectionChanged -= OnChildCollectionChanged;
         }
     }
 }

--- a/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/GroupedCollectionTableViewSource.cs
@@ -213,8 +213,7 @@ namespace Toggl.Daneel.ViewSources
                         break;
 
                     default:
-                        cloneCollection();
-                        TableView.ReloadData();
+                        reloadTable();
                         break;
                 }
 
@@ -264,13 +263,18 @@ namespace Toggl.Daneel.ViewSources
                         break;
 
                     default:
-                        cloneCollection();
-                        TableView.ReloadData();
+                        reloadTable();
                         break;
                 }
 
                 TableView.EndUpdates();
             }
+        }
+
+        private void reloadTable()
+        {
+            cloneCollection();
+            ReloadTableData();
         }
 
         private void cloneCollection()

--- a/Toggl.Daneel/ViewSources/MainTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/MainTableViewSource.cs
@@ -21,16 +21,16 @@ namespace Toggl.Daneel.ViewSources
             set => timeEntriesLogViewSource.ContinueTimeEntryCommand = value;
         }
 
-        public NestableObservableCollection<TimeEntryViewModelCollection, TimeEntryViewModel> AnimatableCollection
+        public NestableObservableCollection<TimeEntryViewModelCollection, TimeEntryViewModel> ObservableCollection
         {
-            get => timeEntriesLogViewSource.AnimatableCollection;
-            set => timeEntriesLogViewSource.AnimatableCollection = value;
+            get => timeEntriesLogViewSource.ObservableCollection;
+            set => timeEntriesLogViewSource.ObservableCollection = value;
         }
 
         public override IEnumerable ItemsSource
         {
             get => timeEntriesLogViewSource.ItemsSource;
-            set { throw new InvalidOperationException($"You must bind to the {nameof(AnimatableCollection)} and not the {nameof(ItemsSource)}"); }
+            set { throw new InvalidOperationException($"You must bind to the {nameof(ObservableCollection)} and not the {nameof(ItemsSource)}"); }
         }
 
         public SyncProgress SyncProgress

--- a/Toggl.Daneel/ViewSources/MainTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/MainTableViewSource.cs
@@ -5,6 +5,7 @@ using MvvmCross.Binding.iOS.Views;
 using MvvmCross.Core.ViewModels;
 using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Foundation.Sync;
+using Toggl.Foundation.MvvmCross.Collections;
 using UIKit;
 
 namespace Toggl.Daneel.ViewSources
@@ -20,10 +21,16 @@ namespace Toggl.Daneel.ViewSources
             set => timeEntriesLogViewSource.ContinueTimeEntryCommand = value;
         }
 
+        public NestableObservableCollection<TimeEntryViewModelCollection, TimeEntryViewModel> AnimatableCollection
+        {
+            get => timeEntriesLogViewSource.AnimatableCollection;
+            set => timeEntriesLogViewSource.AnimatableCollection = value;
+        }
+
         public override IEnumerable ItemsSource
         {
             get => timeEntriesLogViewSource.ItemsSource;
-            set => timeEntriesLogViewSource.ItemsSource = value;
+            set { throw new InvalidOperationException($"You must bind to the {nameof(AnimatableCollection)} and not the {nameof(ItemsSource)}"); }
         }
 
         public SyncProgress SyncProgress

--- a/Toggl.Daneel/ViewSources/SelectProjectTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/SelectProjectTableViewSource.cs
@@ -4,6 +4,7 @@ using MvvmCross.Core.ViewModels;
 using MvvmCross.Plugins.Color.iOS;
 using Toggl.Daneel.Views;
 using Toggl.Foundation.Autocomplete.Suggestions;
+using Toggl.Foundation.MvvmCross.Collections;
 using Toggl.Foundation.MvvmCross.Helper;
 using UIKit;
 
@@ -76,5 +77,8 @@ namespace Toggl.Daneel.ViewSources
         }
 
         protected override object GetCreateSuggestionItem() => $"Create project \"{Text}\"";
+
+        protected override WorkspaceGroupedCollection<AutocompleteSuggestion> CloneCollection(WorkspaceGroupedCollection<AutocompleteSuggestion> collection)
+            => new WorkspaceGroupedCollection<AutocompleteSuggestion>(collection.WorkspaceName, collection.WorkspaceId, collection);
     }
 }

--- a/Toggl.Daneel/ViewSources/StartTimeEntryTableViewSource.cs
+++ b/Toggl.Daneel/ViewSources/StartTimeEntryTableViewSource.cs
@@ -8,6 +8,7 @@ using Toggl.Daneel.Views;
 using Toggl.Daneel.Views.StartTimeEntry;
 using Toggl.Foundation;
 using Toggl.Foundation.Autocomplete.Suggestions;
+using Toggl.Foundation.MvvmCross.Collections;
 using Toggl.Foundation.MvvmCross.Helper;
 using UIKit;
 
@@ -219,5 +220,8 @@ namespace Toggl.Daneel.ViewSources
 
             throw new InvalidOperationException("This method should not be called, when there is no info message to be shown");
         }
+
+        protected override WorkspaceGroupedCollection<AutocompleteSuggestion> CloneCollection(WorkspaceGroupedCollection<AutocompleteSuggestion> collection)
+            => new WorkspaceGroupedCollection<AutocompleteSuggestion>(collection.WorkspaceName, collection.WorkspaceId, collection);
     }
 }

--- a/Toggl.Daneel/ViewSources/TimeEntriesLogViewSource.cs
+++ b/Toggl.Daneel/ViewSources/TimeEntriesLogViewSource.cs
@@ -142,5 +142,8 @@ namespace Toggl.Daneel.ViewSources
 
             throw new ArgumentException($"Unexpected item type. Must be of type {nameof(TimeEntryViewModel)}");
         }
+
+        protected override TimeEntryViewModelCollection CloneCollection(TimeEntryViewModelCollection collection)
+            => new TimeEntryViewModelCollection(collection.Date.LocalDateTime.Date, collection, collection.DurationFormat);
     }
 }

--- a/Toggl.Foundation.MvvmCross/Collections/NestableObservableCollection.cs
+++ b/Toggl.Foundation.MvvmCross/Collections/NestableObservableCollection.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
 using MvvmCross.Core.ViewModels;
-using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Multivac.Extensions;
 
 namespace Toggl.Foundation.MvvmCross.Collections
@@ -12,6 +11,11 @@ namespace Toggl.Foundation.MvvmCross.Collections
         private readonly Func<TItem, Func<TItem, bool>> innerCollectionOrderFunction;
 
         public event EventHandler<ChildCollectionChangedEventArgs> OnChildCollectionChanged;
+
+        public NestableObservableCollection()
+            : this(a => b => true)
+        {
+        }
 
         public NestableObservableCollection(Func<TItem, Func<TItem, bool>> innerCollectionOrderFunction)
         {

--- a/Toggl.Foundation.MvvmCross/ViewModels/SelectProjectViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/SelectProjectViewModel.cs
@@ -64,8 +64,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public IMvxAsyncCommand<AutocompleteSuggestion> SelectProjectCommand { get; }
 
-        public MvxObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>> Suggestions { get; }
-            = new MvxObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>>();
+        public NestableObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>, AutocompleteSuggestion> Suggestions { get; }
+            = new NestableObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>, AutocompleteSuggestion>();
 
         public SelectProjectViewModel(
             ITogglDataSource dataSource, IMvxNavigationService navigationService, IDialogService dialogService)

--- a/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
@@ -135,8 +135,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public TimeSpan? Duration { get; private set; }
 
-        public MvxObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>> Suggestions { get; }
-            = new MvxObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>>();
+        public NestableObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>, AutocompleteSuggestion> Suggestions { get; }
+            = new NestableObservableCollection<WorkspaceGroupedCollection<AutocompleteSuggestion>, AutocompleteSuggestion>();
 
         public IMvxAsyncCommand BackCommand { get; }
 


### PR DESCRIPTION
Closes #1523, closes #1784

The main idea behind this PR is that the `GroupedCollectionTableViewSource` handles its own internal state (`ItemsSource`) and makes sure that the displayed sections and rows in the `UITableView` always match the state of the `ItemsSource`. This means that it is not possible to bind anything directly to the `ItemsSource` (as we normally do), but we must rather bind the collection from the VM to the `ObservableCollection` property.

Whenever the `ObservableCollection` changes, the `CollectionChanged` or `OnChildCollectionChanged` events are invoked. We know exactly how the collection was changed (add/delete/replace/...) and we can update both the internal collection and the `UITableView` state - it is important to do this in between `TableView.BeginUpdate()` and `TableView.EndUpdate()` so that we don't get anymore because of the number of rows in the `ItemsSource` and the `UITableView` is different (internal inconsistency).

This PR doesn't try to merge updates into batches, because that would make a lot more changes and it isn't necessary for this fix. We should still do that in the future - it will give use smoother animations. It can certainly wait for 1.5 or 1.6 though. Let's verify this fix and :shipit: ASAP!

Squash whenever