### PR TITLE
Fix picker issue when editing end time

### DIFF
--- a/Toggl.Daneel/Binding/DatePickerDateTimeOffsetTargetBinding.cs
+++ b/Toggl.Daneel/Binding/DatePickerDateTimeOffsetTargetBinding.cs
@@ -20,12 +20,6 @@ namespace Toggl.Daneel.Binding
 
         protected override void SetValue(DateTimeOffset value)
         {
-            /* We are setting the date to NSDate.Now here because of a glitch that causes the picker
-             * to show the correct time, but an invalid date (Jan 1 or Dec 31).
-             * This glitch seems to be related to the Xamarin wrapper, since I wasn't able to reproduce
-             * the same problem in a Swift app.
-             */
-            Target.SetDate(NSDate.Now, false);
             Target.SetDate(value.ToNSDate(), true);
         }
 

--- a/Toggl.Daneel/Binding/DatePickerDateTimeOffsetTargetBinding.cs
+++ b/Toggl.Daneel/Binding/DatePickerDateTimeOffsetTargetBinding.cs
@@ -16,10 +16,19 @@ namespace Toggl.Daneel.Binding
         public DatePickerDateTimeOffsetTargetBinding(UIDatePicker target) : base(target)
         {
             Target.ValueChanged += onValueChanged;
-        } 
-        
+        }
+
         protected override void SetValue(DateTimeOffset value)
-            => Target.Date = value.ToNSDate();
+        {
+            /* Related to issue https://github.com/toggl/mobileapp/issues/1887
+             * We are setting the date to NSDate.Now here because of a glitch that causes the picker
+             * to show the correct time, but an invalid date (Jan 1 or Dec 31).
+             * This glitch seems to be related to the Xamarin wrapper, since I wasn't able to reproduce
+             * the same problem in a Swift app.
+             */
+            Target.SetDate(NSDate.Now, false);
+            Target.SetDate(value.ToNSDate(), true);
+        }
 
         protected override void Dispose(bool isDisposing)
         {

--- a/Toggl.Daneel/Binding/DatePickerDateTimeOffsetTargetBinding.cs
+++ b/Toggl.Daneel/Binding/DatePickerDateTimeOffsetTargetBinding.cs
@@ -20,8 +20,7 @@ namespace Toggl.Daneel.Binding
 
         protected override void SetValue(DateTimeOffset value)
         {
-            /* Related to issue https://github.com/toggl/mobileapp/issues/1887
-             * We are setting the date to NSDate.Now here because of a glitch that causes the picker
+            /* We are setting the date to NSDate.Now here because of a glitch that causes the picker
              * to show the correct time, but an invalid date (Jan 1 or Dec 31).
              * This glitch seems to be related to the Xamarin wrapper, since I wasn't able to reproduce
              * the same problem in a Swift app.

--- a/Toggl.Foundation.MvvmCross/ViewModels/EditDurationViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/EditDurationViewModel.cs
@@ -150,6 +150,9 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             StopTime = parameter.Duration.HasValue
                 ? StartTime + parameter.Duration.Value
                 : timeService.CurrentDateTime;
+
+            MinimumDateTime = StartTime.DateTime;
+            MaximumDateTime = StopTime.DateTime;
         }
 
         public override async Task Initialize()


### PR DESCRIPTION
Closes #1887 

This fixes the glitch for sure, but I'm not 100% sure we're on the correct path here, since the problem happens only when tapping the end time and I would expect the same issue with start time too.