### PR TITLE
:construction: Refactor StartTimeEntryViewModel initialization

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
@@ -260,7 +260,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
         public async override Task Initialize()
         {
             await base.Initialize();
-            
+
             TextFieldInfo =
                 await dataSource.User.Current.Select(user => TextFieldInfo.Empty(user.DefaultWorkspaceId));
 

--- a/Toggl.Foundation.Tests/MvvmCross/ViewModels/StartTimeEntryViewModelTests.cs
+++ b/Toggl.Foundation.Tests/MvvmCross/ViewModels/StartTimeEntryViewModelTests.cs
@@ -328,6 +328,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 [Fact, LogIfTooSlow]
                 public async Task ReturnsTrueNoMatterThatAProjectIsAlreadySelected()
                 {
+                    ViewModel.Prepare();
                     await ViewModel.Initialize();
                     ViewModel.TextFieldInfo = TextFieldInfo.Empty(1)
                         .WithProjectInfo(WorkspaceId, ProjectId, ProjectName, ProjectColor);
@@ -340,6 +341,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 [Fact, LogIfTooSlow]
                 public async Task ReturnsTrueNoMatterThatAProjectIsAlreadySelectedAndInTagSuccestionMode()
                 {
+                    ViewModel.Prepare();
                     await ViewModel.Initialize();
                     ViewModel.TextFieldInfo = TextFieldInfo.Empty(1)
                         .WithProjectInfo(WorkspaceId, ProjectId, ProjectName, ProjectColor);
@@ -365,6 +367,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                     DataSource.Projects.GetById(Arg.Any<long>()).Returns(Observable.Return(project));
                     ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor($"@{currentQuery}", 15);
 
+                    ViewModel.Prepare();
                     ViewModel.Prepare(DefaultParameter);
                 }
 
@@ -410,6 +413,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
 
                 public WhenSuggestingTags()
                 {
+                    ViewModel.Prepare();
                     ViewModel.Prepare(DefaultParameter);
                     ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor($"#{currentQuery}", 1);
                 }
@@ -592,6 +596,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact, LogIfTooSlow]
             public void SetsTheIsSuggestingProjectsPropertyToTrueIfNotInProjectSuggestionMode()
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
 
                 ViewModel.ToggleProjectSuggestionsCommand.Execute();
@@ -643,6 +648,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             public void RemovesTheAtSymbolFromTheDescriptionTextIfAlreadyInProjectSuggestionMode(
                 string description, string expected)
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor(description, description.Length);
 
@@ -684,6 +690,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact, LogIfTooSlow]
             public void SetsTheIsSuggestingTagsPropertyToTrueIfNotInTagSuggestionMode()
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
 
                 ViewModel.ToggleTagSuggestionsCommand.Execute();
@@ -735,6 +742,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             public void RemovesTheHashtagSymbolFromTheDescriptionTextIfAlreadyInTagSuggestionMode(
                 string description, string expected)
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1)
                     .WithProjectInfo(WorkspaceId, ProjectId, ProjectName, ProjectColor)
@@ -901,6 +909,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact]
             public async Task OpensTheSelectDateTimeViewModelWithCorrectLimitsForARunnningTimeEntry()
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(prepareParameters);
 
                 await ViewModel.SetStartDateCommand.ExecuteAsync();
@@ -1263,6 +1272,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                     var user = Substitute.For<IDatabaseUser>();
                     user.DefaultWorkspaceId.Returns(100);
                     DataSource.User.Current.Returns(Observable.Return(user));
+                    ViewModel.Prepare();
                     await ViewModel.Initialize();
 
                     ViewModel.SelectSuggestionCommand.Execute(Suggestion);
@@ -1281,6 +1291,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                     var user = Substitute.For<IDatabaseUser>();
                     user.DefaultWorkspaceId.Returns(WorkspaceId);
                     DataSource.User.Current.Returns(Observable.Return(user));
+                    ViewModel.Prepare();
                     await ViewModel.Initialize();
 
                     ViewModel.SelectSuggestionCommand.Execute(Suggestion);
@@ -1299,6 +1310,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                     var user = Substitute.For<IDatabaseUser>();
                     user.DefaultWorkspaceId.Returns(100);
                     DataSource.User.Current.Returns(Observable.Return(user));
+                    ViewModel.Prepare();
                     await ViewModel.Initialize();
                     Enumerable.Range(100, 10)
                         .Select(i =>
@@ -1440,6 +1452,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                         new TimeEntrySuggestion(timeEntryB) 
                     });
                 AutocompleteProvider.Query(Arg.Any<QueryInfo>()).Returns(suggestions);
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
                 ViewModel.TextFieldInfo =
                     TextFieldInfo.Empty(1).WithProjectInfo(WorkspaceId, ProjectId, ProjectName, ProjectColor);
@@ -1476,6 +1489,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             public void ChangesSuggestionsWhenTheCursorMovesBackBehindTheOldCursorPosition(string text)
             {
                 var extendedText = text + "x";
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor(extendedText, text.Length);
                 ViewModel.TextFieldInfo = ViewModel.TextFieldInfo.WithTextAndCursor(extendedText, 0);
@@ -1491,6 +1505,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [InlineData("abc #def")]
             public void ChangesSuggestionsWhenTheCursorMovesBeforeTheQuerySymbolAndUserStartsTyping(string text)
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor(text, text.Length);
                 ViewModel.TextFieldInfo = ViewModel.TextFieldInfo.WithTextAndCursor(text, 0);
@@ -1504,6 +1519,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact, LogIfTooSlow]
             public void DoesNotSetTheIsDirtyFlagIfTheTextFieldIsEmpty()
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
 
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1);
@@ -1514,6 +1530,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact, LogIfTooSlow]
             public void SetsTheIsDirtyFlag()
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
 
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor("a", 1);
@@ -1524,6 +1541,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [Fact, LogIfTooSlow]
             public void ClearsTheIsDirtyFlagIfTheTextFieldIsErased()
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
 
                 ViewModel.TextFieldInfo = TextFieldInfo.Empty(1).WithTextAndCursor("a", 1);
@@ -1610,6 +1628,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
             [InlineData("x")]
             public async Task ReturnsTrueWhenSuggestingTagsAndUserHasNoTags(string query)
             {
+                ViewModel.Prepare();
                 ViewModel.Prepare(DefaultParameter);
                 await ViewModel.Initialize();
                 ViewModel.TextFieldInfo = TextFieldInfo


### PR DESCRIPTION
This is not directly addressing any issue, but it takes care of a potentially ugly bug.

The thing is that `Prepare(StartTimeEntryParameters parameter)` was being called twice in `StartTimeEntryViewModel`, which caused the observable sequence to execute twice. This is due to the use of `Init`, which is needed for 3D Touch to work.

My solution is to use the method `Prepare` (without params) along with `Init`. `Init` is called only for 3D Touch, and `Prepare()` is called always. According to the [docs](https://www.mvvmcross.com/documentation/fundamentals/navigation) `Prepare()` is where parameter agnostic stuff should be initialized.

Please review and test thoroughly, I have no idea what I'm doing.