### PR TITLE
Fix misaligned carets in the settings view

### DIFF
--- a/Toggl.Daneel/ViewControllers/Settings/SettingsViewController.xib
+++ b/Toggl.Daneel/ViewControllers/Settings/SettingsViewController.xib
@@ -90,14 +90,14 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icArrowRight" translatesAutoresizingMaskIntoConstraints="NO" id="cHK-dA-deg">
-                                                    <rect key="frame" x="399" y="17" width="5" height="10"/>
+                                                    <rect key="frame" x="393" y="17" width="5" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="10" id="Z8N-bm-gDr"/>
                                                         <constraint firstAttribute="width" constant="5" id="zga-AD-aAC"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="will@toggl.com" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g2O-kd-BSs">
-                                                    <rect key="frame" x="105" y="13" width="282" height="18"/>
+                                                    <rect key="frame" x="105" y="13" width="276" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -110,7 +110,7 @@
                                                 <constraint firstAttribute="height" constant="44" id="Am2-cM-GJL"/>
                                                 <constraint firstItem="g2O-kd-BSs" firstAttribute="leading" secondItem="cDT-0o-Tcp" secondAttribute="trailing" constant="10" id="J2H-DX-Tcu"/>
                                                 <constraint firstItem="cHK-dA-deg" firstAttribute="centerY" secondItem="x3h-xq-GmG" secondAttribute="centerY" id="l1f-aX-a6d"/>
-                                                <constraint firstAttribute="trailing" secondItem="cHK-dA-deg" secondAttribute="trailing" constant="10" id="nAi-3E-3Db"/>
+                                                <constraint firstAttribute="trailing" secondItem="cHK-dA-deg" secondAttribute="trailing" constant="16" id="nAi-3E-3Db"/>
                                                 <constraint firstItem="cDT-0o-Tcp" firstAttribute="centerY" secondItem="x3h-xq-GmG" secondAttribute="centerY" id="rkd-0K-TqM"/>
                                                 <constraint firstItem="g2O-kd-BSs" firstAttribute="centerY" secondItem="cHK-dA-deg" secondAttribute="centerY" id="uFn-eS-3Bo"/>
                                             </constraints>
@@ -135,14 +135,14 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icArrowRight" translatesAutoresizingMaskIntoConstraints="NO" id="ZSM-Lv-rdb">
-                                                    <rect key="frame" x="399" y="17" width="5" height="10"/>
+                                                    <rect key="frame" x="393" y="17" width="5" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="10" id="CfX-Bl-SEb"/>
                                                         <constraint firstAttribute="width" constant="5" id="MmR-UI-kdS"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Will's Workspace" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jyw-Ko-d1E">
-                                                    <rect key="frame" x="102.66666666666666" y="13" width="284.33333333333337" height="18"/>
+                                                    <rect key="frame" x="102.66666666666666" y="13" width="278.33333333333337" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -153,7 +153,7 @@
                                                 <constraint firstItem="jyw-Ko-d1E" firstAttribute="centerY" secondItem="ZSM-Lv-rdb" secondAttribute="centerY" id="0FS-s5-c6z"/>
                                                 <constraint firstItem="UxZ-v0-Q9w" firstAttribute="leading" secondItem="gKP-Qz-N9c" secondAttribute="leading" constant="16" id="FI1-dT-JSE"/>
                                                 <constraint firstItem="ZSM-Lv-rdb" firstAttribute="centerY" secondItem="gKP-Qz-N9c" secondAttribute="centerY" id="Zg2-yv-nLh"/>
-                                                <constraint firstAttribute="trailing" secondItem="ZSM-Lv-rdb" secondAttribute="trailing" constant="10" id="hl2-S7-5h2"/>
+                                                <constraint firstAttribute="trailing" secondItem="ZSM-Lv-rdb" secondAttribute="trailing" constant="16" id="hl2-S7-5h2"/>
                                                 <constraint firstItem="UxZ-v0-Q9w" firstAttribute="centerY" secondItem="gKP-Qz-N9c" secondAttribute="centerY" id="iwG-4C-8oN"/>
                                                 <constraint firstAttribute="height" constant="44" id="lmW-Ry-GFn"/>
                                                 <constraint firstItem="jyw-Ko-d1E" firstAttribute="leading" secondItem="UxZ-v0-Q9w" secondAttribute="trailing" constant="10" id="ySO-kR-Uxe"/>
@@ -474,7 +474,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icArrowRight" translatesAutoresizingMaskIntoConstraints="NO" id="pWp-T3-9af">
-                                                    <rect key="frame" x="399" y="17" width="5" height="10"/>
+                                                    <rect key="frame" x="393" y="17" width="5" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="5" id="33E-Fz-K1U"/>
                                                         <constraint firstAttribute="height" constant="10" id="Bk1-rD-Hcp"/>
@@ -487,7 +487,7 @@
                                                 <constraint firstItem="pWp-T3-9af" firstAttribute="centerY" secondItem="mmI-mx-iUP" secondAttribute="centerY" id="4Tt-Ks-3dP"/>
                                                 <constraint firstItem="7KY-Cw-c2h" firstAttribute="centerY" secondItem="mmI-mx-iUP" secondAttribute="centerY" id="goJ-ia-VCH"/>
                                                 <constraint firstAttribute="height" constant="44" id="oYf-Rw-XeP"/>
-                                                <constraint firstAttribute="trailing" secondItem="pWp-T3-9af" secondAttribute="trailing" constant="10" id="uVP-Qg-96b"/>
+                                                <constraint firstAttribute="trailing" secondItem="pWp-T3-9af" secondAttribute="trailing" constant="16" id="uVP-Qg-96b"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qYd-JE-jko" userLabel="Separator">
@@ -507,14 +507,14 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icArrowRight" translatesAutoresizingMaskIntoConstraints="NO" id="IGz-83-Twc">
-                                                    <rect key="frame" x="399" y="17" width="5" height="10"/>
+                                                    <rect key="frame" x="393" y="17" width="5" height="10"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="5" id="P4y-fU-OKZ"/>
                                                         <constraint firstAttribute="height" constant="10" id="VQL-eS-Y2Z"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RJm-Ug-MzA">
-                                                    <rect key="frame" x="371.66666666666669" y="13.333333333333371" width="19.333333333333314" height="18"/>
+                                                    <rect key="frame" x="365.66666666666669" y="13.333333333333371" width="19.333333333333314" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <color key="textColor" red="0.36862745098039218" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -522,7 +522,7 @@
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="IGz-83-Twc" secondAttribute="trailing" constant="10" id="30n-ut-Zo1"/>
+                                                <constraint firstAttribute="trailing" secondItem="IGz-83-Twc" secondAttribute="trailing" constant="16" id="30n-ut-Zo1"/>
                                                 <constraint firstAttribute="height" constant="44" id="M76-mt-hfZ"/>
                                                 <constraint firstItem="IGz-83-Twc" firstAttribute="centerY" secondItem="8oj-5n-iTi" secondAttribute="centerY" id="UnE-n9-hhg"/>
                                                 <constraint firstItem="oPI-UC-N6W" firstAttribute="leading" secondItem="8oj-5n-iTi" secondAttribute="leading" constant="16" id="b1k-2D-vGt"/>


### PR DESCRIPTION
Closes #2033

All carets are now properly spaced:
![screen](https://user-images.githubusercontent.com/6031512/39697613-279256f0-51fa-11e8-8536-d9cfa2b5c558.png)
Compared to the rest of the app:
![comparison](https://user-images.githubusercontent.com/6031512/39697629-36d4fe9c-51fa-11e8-99a1-61b378d88fd3.png)
