### PR TITLE
Add *Undefined*Tools Rider's generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,3 +305,7 @@ Toggl.Daneel/service-account.json
 
 giskard.keystore
 Toggl.Giskard/**/Resource.designer.cs
+
+# macOS Rider creates this .dll folders
+Toggl.Giskard/\*Undefined\*Tools
+Toggl.PrimeRadiant.Realm/\*Undefined\*Tools


### PR DESCRIPTION
Rider keeps generating these folders.

🦑 whenever