### PR TITLE
Prevent the duration from exceeding 999 hours

### DIFF
--- a/Toggl.Giskard/Resources/values/Strings.xml
+++ b/Toggl.Giskard/Resources/values/Strings.xml
@@ -61,6 +61,9 @@ your app to continue.</string>
     <string name="StopTimer">Stop timer</string>
     <string name="Start">Start</string>
     <string name="Stop">Stop</string>
+    <string name="StartTimeAfterStopTimeWarning">Start time must be before Stop time!</string>
+    <string name="StopTimeBeforeStartTimeWarning">Stop time must be after Start time!</string>
+    <string name="DurationTooLong">Duration can\'t exceed 999 hours!</string>
     
     <string name="MainTemplateSelector" translatable="false">Toggl.Giskard.TemplateSelectors.MainTemplateSelector, Toggl.Giskard</string>
     <string name="ReportsTemplateSelector" translatable="false">Toggl.Giskard.TemplateSelectors.ReportsTemplateSelector, Toggl.Giskard</string>


### PR DESCRIPTION
Implements the 999 hours constraint on duration in popup.

🚧 Also refactors the way events are generated for simplicity/readability

Branched from #2111, will rebase on `develop` after #2111 is merged.