### PR TITLE
Pull to refresh refactoring - do not show it all the time

### DIFF
--- a/Toggl.Daneel/ViewSources/SwipeToRefreshTableViewDelegate.cs
+++ b/Toggl.Daneel/ViewSources/SwipeToRefreshTableViewDelegate.cs
@@ -36,6 +36,7 @@ namespace Toggl.Daneel.ViewSources
         private bool shouldCalculateOnDeceleration;
         private int syncIndicatorLastShown;
         private bool shouldRefreshOnTap;
+        private bool showBarAutomatically;
 
         public SyncProgress SyncProgress
         {
@@ -124,15 +125,19 @@ namespace Toggl.Daneel.ViewSources
             if (SyncProgress == Unknown)
                 return;
 
+            var showBar = showBarAutomatically || SyncProgress == OfflineModeDetected || SyncProgress == Failed;
             var hideBarAutomatically = SyncProgress == Synced;
             var showSpinner = SyncProgress == Syncing;
             var showDismissButton = SyncProgress == OfflineModeDetected || SyncProgress == Failed;
             shouldRefreshOnTap = SyncProgress == OfflineModeDetected;
+            showBarAutomatically = SyncProgress != Synced && showBarAutomatically;
 
             var (text, backgroundColor) = getSyncIndicatorTextAndBackgroundBasedOnCurrentProgress();
             setSyncIndicatorTextAndBackground(text, backgroundColor);
             setActivityIndicatorVisible(showSpinner);
             dismissSyncBarButton.Hidden = !showDismissButton;
+
+            if (!showBar) return;
 
             int syncIndicatorShown = showSyncBar();
 
@@ -188,6 +193,7 @@ namespace Toggl.Daneel.ViewSources
 
             needsRefresh = false;
             shouldCalculateOnDeceleration = false;
+            showBarAutomatically = true;
 
             if (SyncProgress == Syncing)
             {


### PR DESCRIPTION
Ref #2281 

The syncing bar is now not show when we sync stuff without user's explicit interaction (after opening the app after > 5 minutes, when user starts/stops/continues a TE, ...) and everything goes well - the bar will be always shown when user is offline or if the sync fails.

This PR also refactors the delegate a bit...

This PR isn't meant to be merged into develop just yet.