### PR TITLE
Fix? Google login

### DIFF
--- a/Toggl.Giskard/google-services.json
+++ b/Toggl.Giskard/google-services.json
@@ -16,7 +16,11 @@
       "oauth_client": [
         {
           "client_id": "{TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID}",
-          "client_type": 3
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.toggl.giskard",
+            "certificate_hash": "{TOGGL_DROID_CERTIFICATE_HASH}"
+          }
         }
       ],
       "api_key": [

--- a/build.cake
+++ b/build.cake
@@ -177,6 +177,7 @@ private TemporaryFileTransformation GetAndroidGoogleServicesTransformation()
     var mobileSdkAppId = EnvironmentVariable("TOGGL_DROID_GOOGLE_SERVICES_MOBILE_SDK_APP_ID");
     var clientId = EnvironmentVariable("TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID");
     var apiKey = EnvironmentVariable("TOGGL_DROID_GOOGLE_SERVICES_API_KEY");
+    var certificateHash = EnvironmentVariable("TOGGL_DROID_CERTIFICATE_HASH");
 
     var filePath = GetFiles(path).Single();
     var file = TransformTextFile(filePath).ToString();
@@ -192,6 +193,7 @@ private TemporaryFileTransformation GetAndroidGoogleServicesTransformation()
                         .Replace("{TOGGL_DROID_GOOGLE_SERVICES_MOBILE_SDK_APP_ID}", mobileSdkAppId)
                         .Replace("{TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID}", clientId)
                         .Replace("{TOGGL_DROID_GOOGLE_SERVICES_API_KEY}", apiKey)
+                        .Replace("{TOGGL_DROID_CERTIFICATE_HASH}", certificateHash)
     };
 }
 


### PR DESCRIPTION
Closes #2361 

`TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID` used in Bitrise didn't match with the entry that has the correct certificate hash from the google-services.json downloaded from Firebase.

google-services.json also matches the structure from the configuration downloaded from Firebase, I've added `TOGGL_DROID_CERTIFICATE_HASH` as a secret.

Needs to be tested with a PlayStore build.

🦑 whenever