### PR TITLE
show keyboard when edit view appears

### DIFF
--- a/Toggl.Daneel/ViewControllers/EditDurationViewController.cs
+++ b/Toggl.Daneel/ViewControllers/EditDurationViewController.cs
@@ -218,6 +218,8 @@ namespace Toggl.Daneel.ViewControllers
             base.ViewDidAppear(animated);
 
             viewDidAppear = true;
+
+            DurationInput.BecomeFirstResponder();
         }
 
         protected override void KeyboardWillShow(object sender, UIKeyboardEventArgs e)


### PR DESCRIPTION
Closes #1434, maybe related to #1436

Making the `DurationInput` first responder of the View Controller.  

I was wondering whether we should not replace the current duration with `00:00` since now the keyboard opens automatically. (See the attached GIF)

Thoughts would be appreciated.

![2018-06-11 11 08 17](https://user-images.githubusercontent.com/6994441/41212396-c50c43e0-6d67-11e8-9b02-09047f5f932d.gif)
