### PR TITLE
Use DTO to create new Client

### DIFF
--- a/Toggl.Foundation/DTOs/ClientDTO.cs
+++ b/Toggl.Foundation/DTOs/ClientDTO.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Toggl.Foundation.Models.Interfaces;
+using Toggl.PrimeRadiant;
+using Toggl.PrimeRadiant.Models;
+
+namespace Toggl.Foundation.DTOs
+{
+    public class ClientDTO : IThreadSafeClient
+    {
+        public long Id { get; }
+        public DateTimeOffset? ServerDeletedAt { get; }
+        public DateTimeOffset At { get; }
+        public long WorkspaceId { get; }
+        public string Name { get; }
+        public SyncStatus SyncStatus { get; }
+        public string LastSyncErrorMessage { get; }
+        public bool IsDeleted { get; }
+
+        public IThreadSafeWorkspace Workspace { get; }
+        IDatabaseWorkspace IDatabaseClient.Workspace => Workspace;
+
+        public ClientDTO(long id, long workspaceId, string name, DateTimeOffset at, SyncStatus syncStatus)
+        {
+            Id = id;
+            WorkspaceId = workspaceId;
+            Name = name;
+            At = at;
+            SyncStatus = syncStatus;
+        }
+    }
+}

--- a/Toggl.Foundation/DataSources/ClientsDataSource.cs
+++ b/Toggl.Foundation/DataSources/ClientsDataSource.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Toggl.Foundation.DTOs;
 using Toggl.Foundation.Models;
 using Toggl.Foundation.Models.Interfaces;
 using Toggl.Foundation.Sync.ConflictResolution;
@@ -28,7 +29,7 @@ namespace Toggl.Foundation.DataSources
 
         public IObservable<IThreadSafeClient> Create(string name, long workspaceId)
         {
-            var client = new Client(
+            var client = new ClientDTO(
                 idProvider.GetNextIdentifier(),
                 workspaceId,
                 name,

--- a/Toggl.Foundation/Models/Client.cs
+++ b/Toggl.Foundation/Models/Client.cs
@@ -20,20 +20,23 @@ namespace Toggl.Foundation.Models
         public IThreadSafeWorkspace Workspace { get; }
         IDatabaseWorkspace IDatabaseClient.Workspace => Workspace;
 
-        private Client(IClient entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false, IThreadSafeWorkspace workspace = null)
-            : this(entity.Id, entity.WorkspaceId, entity.Name, entity.At, syncStatus, lastSyncErrorMessage, isDeleted, entity.ServerDeletedAt, workspace)
-        { }
-
-        public Client(long id, long workspaceId, string name, DateTimeOffset at, SyncStatus syncStatus, string lastSyncErrorMessage = "", bool isDeleted = false, DateTimeOffset? serverDeletedAt = null, IThreadSafeWorkspace workspace = null)
+        private Client(IClient entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false,
+            IThreadSafeWorkspace workspace = null)
         {
-            Id = id;
-            WorkspaceId = workspaceId;
-            Name = name;
-            At = at;
+            Ensure.Argument.IsNotNullOrEmpty(entity.Name, nameof(entity.Name));
+            Ensure.Argument.IsNotNull(entity.WorkspaceId, nameof(entity.WorkspaceId));
+            Ensure.Argument.IsNotNull(entity.At, nameof(entity.At));
+
+            Id = entity.Id;
+            WorkspaceId = entity.WorkspaceId;
+            Name = entity.Name;
+            At = entity.At;
+            ServerDeletedAt = entity.ServerDeletedAt;
+
             SyncStatus = syncStatus;
             LastSyncErrorMessage = lastSyncErrorMessage;
             IsDeleted = isDeleted;
-            ServerDeletedAt = serverDeletedAt;
+
             Workspace = workspace;
         }
 


### PR DESCRIPTION
This PR is mainly so we can discuss.

The primary goal is to have a `Client` in Foundation, which has validation of its mandatory fields. This is not possible at the moment because we use that object to send to the repository the necessary data for creation as well.

Ideally, in my opinion, we should send a different interface to the repository, but that change is very complicated for me at the moment.

So here comes another idea. Make a `ClientDTO` that implements `IThreadSafeClient` and doesn't have validation (we could add some for mandatory fields for creation).

Tests currently fail because somehow they are creating `IDatabaseClient` instances without `Name`.

Please discuss if this makes sense.