### PR TITLE
Refactor complex event metrics

### DIFF
--- a/Toggl.Foundation.Tests/AnalyticsService/TrackableEventsTests.cs
+++ b/Toggl.Foundation.Tests/AnalyticsService/TrackableEventsTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using FluentAssertions;
+using NSubstitute;
+using Toggl.Foundation.Analytics;
+using Xunit;
+
+namespace Toggl.Foundation.Tests.AnalyticsService
+{
+    public sealed class TrackableEventsTests
+    {
+        private const string OverriddenEventName = "Overridden";
+        private const string OverriddenParameterName = "CreationOrigin";
+
+        private class RandomEvent : ITrackableEvent
+        {
+            public int Ergalactic { get; } = 199;
+            public string Theory { get; } = "Quantum entanglement";
+            public bool George { get; } = true;
+            public DateTimeOffset Time { get; } = DateTimeOffset.Parse("2016-12-08 04:00");
+        }
+
+        [DisplayName(OverriddenEventName)]
+        private class StartTimeEntryEvent : ITrackableEvent
+        {
+            [DisplayName(OverriddenParameterName)]
+            public TimeEntryStartOrigin Origin { get; } = TimeEntryStartOrigin.Timer;
+
+            public bool IsDescriptionNotEmpty { get; } = true;
+            public bool HasProject { get; } = true;
+            public bool HasTask { get; } = false;
+            public int TagCount { get; } = 42;
+            public bool IsRunning { get; } = false;
+            public bool IsBillable { get; } = false;
+        }
+
+        public IAnalyticsService AnalyticsService { get; } = Substitute.For<IAnalyticsService>();
+
+        private RandomEvent createRandomEvent() => new RandomEvent();
+        private StartTimeEntryEvent createStartTimeEntryEvent() => new StartTimeEntryEvent();
+
+        public TrackableEventsTests()
+        {
+            AnalyticsService = Substitute.For<IAnalyticsService>();
+        }
+
+        [Fact]
+        public void CorrectlyTracksAnObject()
+        {
+            var randomEvent = createRandomEvent();
+
+            randomEvent.TrackWith(AnalyticsService);
+
+            AnalyticsService.Received().Track(nameof(RandomEvent),
+                Arg.Is<Dictionary<string, string>>(dict =>
+                                                   dict[nameof(randomEvent.Ergalactic)] == randomEvent.Ergalactic.ToString() &&
+                                                   dict[nameof(randomEvent.Theory)] == randomEvent.Theory.ToString() &&
+                                                   dict[nameof(randomEvent.George)] == randomEvent.George.ToString() &&
+                                                   dict[nameof(randomEvent.Time)] == randomEvent.Time.ToString()
+            ));
+        }
+
+        [Fact]
+        public void UsesOverridenEventName()
+        {
+            var randomEvent = createStartTimeEntryEvent();
+
+            randomEvent.TrackWith(AnalyticsService);
+
+            AnalyticsService.Received().Track(OverriddenEventName, Arg.Any<Dictionary<string, string>>());
+        }
+
+        [Fact]
+        public void UsesOverridenParameterName()
+        {
+            var randomEvent = createStartTimeEntryEvent();
+
+            randomEvent.TrackWith(AnalyticsService);
+
+            AnalyticsService.Received().Track(Arg.Any<string>(),
+                Arg.Is<Dictionary<string, string>>(d => d[OverriddenParameterName] == TimeEntryStartOrigin.Timer.ToString()
+            ));
+        }
+    }
+}

--- a/Toggl.Foundation.Tests/AnalyticsService/TrackableEventsTests.cs
+++ b/Toggl.Foundation.Tests/AnalyticsService/TrackableEventsTests.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
-using FluentAssertions;
 using NSubstitute;
 using Toggl.Foundation.Analytics;
 using Xunit;
@@ -14,7 +12,7 @@ namespace Toggl.Foundation.Tests.AnalyticsService
         private const string OverriddenEventName = "Overridden";
         private const string OverriddenParameterName = "CreationOrigin";
 
-        private class RandomEvent : ITrackableEvent
+        private sealed class RandomEvent : ITrackableEvent
         {
             public int Ergalactic { get; } = 199;
             public string Theory { get; } = "Quantum entanglement";
@@ -23,7 +21,7 @@ namespace Toggl.Foundation.Tests.AnalyticsService
         }
 
         [DisplayName(OverriddenEventName)]
-        private class StartTimeEntryEvent : ITrackableEvent
+        private sealed class StartTimeEntryEvent : ITrackableEvent
         {
             [DisplayName(OverriddenParameterName)]
             public TimeEntryStartOrigin Origin { get; } = TimeEntryStartOrigin.Timer;
@@ -36,14 +34,14 @@ namespace Toggl.Foundation.Tests.AnalyticsService
             public bool IsBillable { get; } = false;
         }
 
-        public IAnalyticsService AnalyticsService { get; } = Substitute.For<IAnalyticsService>();
+        private readonly IAnalyticsService analyticsService = Substitute.For<IAnalyticsService>();
 
         private RandomEvent createRandomEvent() => new RandomEvent();
         private StartTimeEntryEvent createStartTimeEntryEvent() => new StartTimeEntryEvent();
 
         public TrackableEventsTests()
         {
-            AnalyticsService = Substitute.For<IAnalyticsService>();
+            analyticsService = Substitute.For<IAnalyticsService>();
         }
 
         [Fact]
@@ -51,9 +49,9 @@ namespace Toggl.Foundation.Tests.AnalyticsService
         {
             var randomEvent = createRandomEvent();
 
-            randomEvent.TrackWith(AnalyticsService);
+            randomEvent.TrackWith(analyticsService);
 
-            AnalyticsService.Received().Track(nameof(RandomEvent),
+            analyticsService.Received().Track(nameof(RandomEvent),
                 Arg.Is<Dictionary<string, string>>(dict =>
                                                    dict[nameof(randomEvent.Ergalactic)] == randomEvent.Ergalactic.ToString() &&
                                                    dict[nameof(randomEvent.Theory)] == randomEvent.Theory.ToString() &&
@@ -67,9 +65,9 @@ namespace Toggl.Foundation.Tests.AnalyticsService
         {
             var randomEvent = createStartTimeEntryEvent();
 
-            randomEvent.TrackWith(AnalyticsService);
+            randomEvent.TrackWith(analyticsService);
 
-            AnalyticsService.Received().Track(OverriddenEventName, Arg.Any<Dictionary<string, string>>());
+            analyticsService.Received().Track(OverriddenEventName, Arg.Any<Dictionary<string, string>>());
         }
 
         [Fact]
@@ -77,9 +75,9 @@ namespace Toggl.Foundation.Tests.AnalyticsService
         {
             var randomEvent = createStartTimeEntryEvent();
 
-            randomEvent.TrackWith(AnalyticsService);
+            randomEvent.TrackWith(analyticsService);
 
-            AnalyticsService.Received().Track(Arg.Any<string>(),
+            analyticsService.Received().Track(Arg.Any<string>(),
                 Arg.Is<Dictionary<string, string>>(d => d[OverriddenParameterName] == TimeEntryStartOrigin.Timer.ToString()
             ));
         }

--- a/Toggl.Foundation/Analytics/AnalyticsEventCache.cs
+++ b/Toggl.Foundation/Analytics/AnalyticsEventCache.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using static System.Reflection.BindingFlags;
+
+namespace Toggl.Foundation.Analytics
+{
+    public static class AnalyticsEventCache
+    {
+        private static readonly Type displayNameType = typeof(DisplayNameAttribute);
+
+        private static readonly object cacheAccess = new object();
+
+        private static readonly Dictionary<string, TrackableEventTransformation> cache = new Dictionary<string, TrackableEventTransformation>();
+
+        public static void TrackWith(this ITrackableEvent trackableEvent, IAnalyticsService service)
+        {
+            var eventType = trackableEvent.GetType();
+            var typeName = eventType.Name;
+            var transformator = (TrackableEventTransformation)null;
+
+            lock (cacheAccess)
+            {
+                if (!cache.ContainsKey(typeName))
+                    cache[typeName] = new TrackableEventTransformation(trackableEvent);
+
+                transformator = cache[typeName];
+            }
+
+            var parameters = new Dictionary<string, string>();
+            var eventName = eventType.NameOrDisplayName();
+
+            if (transformator.IsValid)
+            {
+                parameters = transformator.Transform(trackableEvent, parameters);
+                eventName = transformator.EventName;
+            }
+            else
+            {
+                parameters = convertObjectToDictionary(trackableEvent);
+            }
+
+            service.Track(eventName, parameters);
+        }
+
+        private static Dictionary<string, string> convertObjectToDictionary(ITrackableEvent obj) 
+            => obj.GetType()
+                  .GetProperties(Public | Instance)
+                  .ToDictionary(
+                      prop => prop.NameOrDisplayName(),
+                      prop => prop.GetValue(obj).ToString());
+
+        public static string NameOrDisplayName(this MemberInfo member)
+        {
+            var attr = member
+                .GetCustomAttributes(displayNameType)
+                .FirstOrDefault() as DisplayNameAttribute;
+
+            return attr?.DisplayName ?? member.Name;
+        }
+    }
+}

--- a/Toggl.Foundation/Analytics/BaseAnalyticsService.cs
+++ b/Toggl.Foundation/Analytics/BaseAnalyticsService.cs
@@ -84,5 +84,10 @@ namespace Toggl.Foundation.Analytics
         public abstract void Track(string eventName, Dictionary<string, string> parameters = null);
 
         public abstract void Track(Exception exception);
+
+        public void Track(ITrackableEvent trackableEvent)
+        {
+            trackableEvent.TrackWith(this);
+        }
     }
 }

--- a/Toggl.Foundation/Analytics/EventTransformationHandler.cs
+++ b/Toggl.Foundation/Analytics/EventTransformationHandler.cs
@@ -1,0 +1,6 @@
+﻿using System.Collections.Generic;
+
+namespace Toggl.Foundation.Analytics
+{
+    internal delegate Dictionary<string, string> EventTransformationHandler(ITrackableEvent trackableEvent, Dictionary<string, string> parameters);
+}

--- a/Toggl.Foundation/Analytics/IAnalyticsService.cs
+++ b/Toggl.Foundation/Analytics/IAnalyticsService.cs
@@ -51,6 +51,8 @@ namespace Toggl.Foundation.Analytics
       
         IAnalyticsEvent<EditViewTapSource> EditViewTapped { get; }
 
+        void Track(ITrackableEvent trackableEvent);
+
         void Track(string eventName, Dictionary<string, string> parameters = null);
 
         void Track(Exception exception);

--- a/Toggl.Foundation/Analytics/ITrackableEvent.cs
+++ b/Toggl.Foundation/Analytics/ITrackableEvent.cs
@@ -1,0 +1,6 @@
+﻿namespace Toggl.Foundation.Analytics
+{
+    public interface ITrackableEvent
+    {
+    }
+}

--- a/Toggl.Foundation/Analytics/TrackableEventTransformation.cs
+++ b/Toggl.Foundation/Analytics/TrackableEventTransformation.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reflection;
+using static System.Reflection.BindingFlags;
+
+namespace Toggl.Foundation.Analytics
+{
+    internal sealed class TrackableEventTransformation
+    {
+        public string EventName { get; }
+        public bool IsValid { get; } = true;
+
+        public EventTransformationHandler Transform { get; }
+
+        private static readonly Type stringType = typeof(string);
+        private static readonly Type dictionaryType = typeof(Dictionary<string, string>);
+        private static readonly Type trackableEventType = typeof(ITrackableEvent);
+
+        public TrackableEventTransformation(ITrackableEvent trackableEvent)
+        {
+            var eventType = trackableEvent.GetType();
+            EventName = eventType.NameOrDisplayName();
+
+            var addMethod = dictionaryType.GetMethod("Add");
+            if (addMethod == null)
+            {
+                IsValid = false;
+                return;
+            }
+
+            try
+            {
+                var dictParameter = Expression.Parameter(dictionaryType, "parameters");
+                var trackableEventParameter = Expression.Parameter(trackableEventType, "trackableEvent");
+
+                var upCastExpression = Expression.Convert(trackableEventParameter, eventType);
+
+                var props = new List<Expression>();
+
+                foreach (var property in eventType.GetProperties(Public | Instance))
+                {
+                    var propertyName = property.NameOrDisplayName();
+                    var propertyNameExpression = Expression.Constant(propertyName, stringType);
+
+                    var propertyAccess = Expression.Property(upCastExpression, property);
+                    var toStringCallExpression = Expression.Call(propertyAccess, "ToString", Type.EmptyTypes);
+
+                    var call = Expression.Call(dictParameter, addMethod, propertyNameExpression, toStringCallExpression);
+                    props.Add(call);
+                }
+
+                var returnTarget = Expression.Label(dictionaryType);
+                var returnExpression = Expression.Return(returnTarget, dictParameter, dictionaryType);
+                var returnLabel = Expression.Label(returnTarget, Expression.Constant(new Dictionary<string, string>()));
+                props.Add(returnExpression);
+                props.Add(returnLabel);
+
+                var block = Expression.Block(props);
+
+                var func = Expression.Lambda<EventTransformationHandler>(block, trackableEventParameter, dictParameter).Compile();
+
+                Transform = func;
+            }
+            catch
+            {
+                IsValid = false;
+            }
+        }
+
+    }
+}

--- a/Toggl.Foundation/Extensions/ObservableExtensions.cs
+++ b/Toggl.Foundation/Extensions/ObservableExtensions.cs
@@ -17,5 +17,8 @@ namespace Toggl.Foundation.Extensions
 
         public static IObservable<T> Track<T, T1, T2>(this IObservable<T> observable, IAnalyticsEvent<T1, T2> analyticsEvent, T1 param1, T2 param2)
             => observable.Do(_ => analyticsEvent.Track(param1, param2));
+
+        public static IObservable<T> Track<T>(this IObservable<T> observable, ITrackableEvent trackableEvent, IAnalyticsService analyticsService)
+            => observable.Do(_ => trackableEvent.TrackWith(analyticsService));
     }
 }


### PR DESCRIPTION
If it was up to me, I would change all events into types. I like types. Types represent categories of things. Events are a thing. Methods are work, not things. 😛 

Anyways, an event class has to implement `ITrackableEvent`, and then

```cs
new RandomEvent(some, params, here)
    .TrackWith(analyticsService);
```
or
```cs
someObservable
    .Track(new RandomEvent(some, params, here), analyticsService)
    .Subscribe(...);
```
or
```cs
analyticsService.Track(new RandomEvent(some, params, here));
```

#### What's going on?
Basically, the first time tracking for an event type is requested, the lambda that gets stuff from the object into a dictionary gets compiled and cached. 

Then, the next time the same event is being tracked, the lambda from the cache is run.

If for some reason, compilation of lambda fails, the system will fall back to getting the properties from the object by simple reflection's `GetValue`.

#### Names and values
The default name for an event is its name, and the default name for a parameter is its name as well. However, `[DisplayName("OverriddenName")]` can be used on both event class or any of its parameters to output an event with any other name.

Values are calculated by calling `ToString` on every `(public|instance)` property of the class.

#### Performance
Basically, the first call (lambda creation and caching) to an event takes around `30ms` on my device (in debug mode)... Every subsequent call takes a `few microseconds` (it's just a normal call at that point). The first call is not that good (it's not bad either), but amortized over several calls it gets rather good.

#### iOS
iOS does not JIT. That means that `Reflection.Emit` is 💥 on iOS. However, I am not sure how much of Emit does `Expression.Lambda().Compile()` use, if any. This needs to be tested on iOS. As far as I could read, there are some fallbacks within mono that will do the job, but somebody who has an actual iOS device should try running this in a debug mode and see if it breaks. (Ping me if you want to pair-test this).