### PR TITLE
🚧 Use 'InputDelegate`

### DIFF
--- a/Toggl.Daneel/ViewControllers/StartTimeEntryViewController.xib
+++ b/Toggl.Daneel/ViewControllers/StartTimeEntryViewController.xib
@@ -95,7 +95,7 @@
                         <constraint firstAttribute="height" constant="68" id="u0i-Qv-oYj"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences" autocorrectionType="no" spellCheckingType="no" keyboardType="twitter"/>
+                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences" spellCheckingType="no" keyboardType="twitter"/>
                 </textView>
                 <view userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jGg-N9-yt7" customClass="AutocompleteTextViewPlaceholder">
                     <rect key="frame" x="21" y="51" width="333" height="31"/>

--- a/Toggl.Daneel/Views/AutocompleteTextView.cs
+++ b/Toggl.Daneel/Views/AutocompleteTextView.cs
@@ -15,10 +15,13 @@ namespace Toggl.Daneel.Views
             get => base.AttributedText;
             set
             {
+                InputDelegate = inputDelegate;
                 base.AttributedText = value;
                 AutocompleteTextViewInfoDelegate.Changed(this);
             }
         }
+
+        private AutocompleteTextViewInputDelegate inputDelegate = new AutocompleteTextViewInputDelegate();
 
         public AutocompleteTextView(IntPtr handle) : base(handle)
         {
@@ -38,6 +41,25 @@ namespace Toggl.Daneel.Views
             if (!disposing) return;
 
             Delegate = null;
+        }
+    }
+
+    class AutocompleteTextViewInputDelegate : NSObject, IUITextInputDelegate
+    {
+        public void SelectionDidChange(IUITextInput uiTextInput)
+        {
+        }
+
+        public void SelectionWillChange(IUITextInput uiTextInput)
+        {
+        }
+
+        public void TextDidChange(IUITextInput textInput)
+        {
+        }
+
+        public void TextWillChange(IUITextInput textInput)
+        {
         }
     }
 }


### PR DESCRIPTION
closes #2338

I enabled the textView autocomplete and with the changes made it should work correctly. The solution is a bit obscure but is the best I could find. I set the `InputDelegate` of the textView to an empty implementation so the internal autocomplete logic does not get notified of the changes that we do internally to the textview, this helps with the issue where autocomplete is conflicting with the selection from the list below thus ending in setting the test from the selection and getting the autocompletion as well after the text as shown below
![jun-27-2018 18-18-55](https://user-images.githubusercontent.com/885122/42030144-866a7e7e-7ada-11e8-82b7-4a396e952dc9.gif)

After the fix the autocorrect still works as seen below:
![jun-28-2018 12-57-29](https://user-images.githubusercontent.com/885122/42030178-9eca7e74-7ada-11e8-8d34-16001a97b625.gif)

and the selection from the list as well
![jun-28-2018 12-56-55](https://user-images.githubusercontent.com/885122/42030207-b3e34f34-7ada-11e8-9ee4-de93d219d3e9.gif)

I set the `InputDelegate` every time the text changes because if set in `awakeFromNib` for some reason it becomes null after some characters are typed. So this needs some functional testing.

PS: to test this it helps to go into Settings > General > Keyboard > Text Replacement > Add new (like phrase: `Kettlebells` and shortcut: `Kett`)

🦑 whenever