### PR TITLE
Another attempt to fix the login with Google

### DIFF
--- a/Toggl.Giskard/Properties/AndroidManifest.xml
+++ b/Toggl.Giskard/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="987654321" android:versionName="0.5" package="com.toggl.giskard.debug">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="987654321" android:versionName="0.5.1" package="com.toggl.giskard.debug">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />

--- a/Toggl.Giskard/google-services.json
+++ b/Toggl.Giskard/google-services.json
@@ -16,7 +16,11 @@
       "oauth_client": [
         {
           "client_id": "{TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID}",
-          "client_type": 3
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.toggl.giskard",
+            "certificate_hash": "{TOGGL_DROID_CERTIFICATE_HASH}"
+          }
         }
       ],
       "api_key": [

--- a/build.cake
+++ b/build.cake
@@ -176,6 +176,7 @@ private TemporaryFileTransformation GetAndroidGoogleServicesTransformation()
     var storageBucket = EnvironmentVariable("TOGGL_STORAGE_BUCKET");
     var mobileSdkAppId = EnvironmentVariable("TOGGL_DROID_GOOGLE_SERVICES_MOBILE_SDK_APP_ID");
     var clientId = EnvironmentVariable("TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID");
+    var certificateHash = EnvironmentVariable("TOGGL_DROID_CERTIFICATE_HASH");
     var apiKey = EnvironmentVariable("TOGGL_DROID_GOOGLE_SERVICES_API_KEY");
 
     var filePath = GetFiles(path).Single();
@@ -191,6 +192,7 @@ private TemporaryFileTransformation GetAndroidGoogleServicesTransformation()
                         .Replace("{TOGGL_STORAGE_BUCKET}", storageBucket)
                         .Replace("{TOGGL_DROID_GOOGLE_SERVICES_MOBILE_SDK_APP_ID}", mobileSdkAppId)
                         .Replace("{TOGGL_DROID_GOOGLE_SERVICES_CLIENT_ID}", clientId)
+                        .Replace("{TOGGL_DROID_CERTIFICATE_HASH}", certificateHash)
                         .Replace("{TOGGL_DROID_GOOGLE_SERVICES_API_KEY}", apiKey)
     };
 }


### PR DESCRIPTION
This may work or not 👀 

Based on [this](https://stackoverflow.com/questions/39318370/google-sign-in-not-working-after-publishing-in-play-store) post in StackOverflow, I think we’re using a wrong client id for play store builds only.
In theory, if I’m correct (and that’s a big if), all we need to do is replace the secret in Bitrise (I already did that), client id setting in the `google-services.json` now has the same structure for the client id that I think we should use.

Only way to test this is releasing a build in play store.