### PR TITLE
🚧 Add override to fix pop glitch

### DIFF
--- a/Toggl.Daneel/Views/LoginTextField.cs
+++ b/Toggl.Daneel/Views/LoginTextField.cs
@@ -119,6 +119,9 @@ namespace Toggl.Daneel.Views
             return resignFirstResponder;
         }
 
+        public override bool CanBecomeFirstResponder 
+            => true;
+
         private void updateBottomLine()
         {
             underlineLayer.Frame = new CGRect(


### PR DESCRIPTION
Possible fix to close #1981

I personally can't reproduce the issues, but this looks like a possible fix in the case of subclassed UITextFields. It goes without saying ( but i am saying it anyways), if you can't reproduce the issues you can't review this PR.

If it works, 🦑 whenever. If not I will look deeper into this