### PR TITLE
Fix perceived sluggishness when starting a time entry

### DIFF
--- a/Toggl.Giskard/Activities/StartTimeEntryActivity.cs
+++ b/Toggl.Giskard/Activities/StartTimeEntryActivity.cs
@@ -31,6 +31,8 @@ namespace Toggl.Giskard.Activities
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed partial class StartTimeEntryActivity : MvxAppCompatActivity<StartTimeEntryViewModel>, IReactiveBindingHolder
     {
+        private static readonly TimeSpan typingThrottleDuration = TimeSpan.FromMilliseconds(300);
+
         private PopupWindow onboardingPopupWindow;
 
         public CompositeDisposable DisposeBag { get; } = new CompositeDisposable();
@@ -51,8 +53,8 @@ namespace Toggl.Giskard.Activities
 
             editText.TextObservable
                 .SubscribeOn(ThreadPoolScheduler.Instance)
+                .Throttle(typingThrottleDuration)
                 .Select(text => text.AsImmutableSpans(editText.SelectionStart))
-                .ObserveOn(SynchronizationContext.Current)
                 .Subscribe(async spans => await ViewModel.OnTextFieldInfoFromView(spans))
                 .DisposedBy(DisposeBag);
         }


### PR DESCRIPTION
Closes #2619 

Marshalling wasn’t enough, so I’m adding a small throttle; long enough to allow continuing typing yet small enough to feel instant once the user stops typing.

Functional testing in a real device (preferably a low-end one) is mandatory.

Squash whenever