### PR TITLE
Debounce clicks in main log items to avoid EditTimeEntryActivity presented twice

### DIFF
--- a/Toggl.Giskard/Adapters/MainRecyclerAdapter.cs
+++ b/Toggl.Giskard/Adapters/MainRecyclerAdapter.cs
@@ -60,7 +60,7 @@ namespace Toggl.Giskard.Adapters
                 case MainTemplateSelector.Item:
                     return new MainRecyclerViewLogViewHolder(inflatedView, itemBindingContext)
                     {
-                        Click = TimeEntriesLogViewModel.EditCommand,
+                        EditCommand = TimeEntriesLogViewModel.EditCommand,
                         ContinueCommand = TimeEntriesLogViewModel.ContinueTimeEntryCommand
                     };
 


### PR DESCRIPTION
Closes nothing, needs testing in a device.

Squash whenever.