### PR TITLE
🚧 Fix date checking for experiment based on first install instead of last update

### DIFF
--- a/Toggl.Daneel/Startup/AppDelegate.cs
+++ b/Toggl.Daneel/Startup/AppDelegate.cs
@@ -14,6 +14,9 @@ using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Foundation.Services;
 using Toggl.Foundation.Shortcuts;
 using UIKit;
+using Toggl.PrimeRadiant.Settings;
+using Toggl.Foundation;
+
 
 #if USE_ANALYTICS
 using System.Linq;
@@ -27,6 +30,8 @@ namespace Toggl.Daneel
         private IAnalyticsService analyticsService;
         private IBackgroundService backgroundService;
         private IMvxNavigationService navigationService;
+        private IOnboardingStorage onboardingStorage;
+        private ITimeService timeService;
 
         public override UIWindow Window { get; set; }
 
@@ -61,7 +66,10 @@ namespace Toggl.Daneel
             analyticsService = Mvx.Resolve<IAnalyticsService>();
             backgroundService = Mvx.Resolve<IBackgroundService>();
             navigationService = Mvx.Resolve<IMvxNavigationService>();
+            onboardingStorage = Mvx.Resolve<IOnboardingStorage>();
+            timeService = Mvx.Resolve<ITimeService>();
             setupNavigationBar();
+            checkForUpdate();
         }
 
         #if USE_ANALYTICS
@@ -163,6 +171,15 @@ namespace Toggl.Daneel
                 Font = UIFont.SystemFontOfSize(14, UIFontWeight.Medium),
                 ForegroundColor = UIColor.Black
             };
+        }
+
+        private void checkForUpdate()
+        {
+            if (onboardingStorage.DidAppUpdate())
+            {
+                onboardingStorage.SetNewAppVersion();
+                onboardingStorage.SetFirstOpenedAfterUpdate(timeService.CurrentDateTime);
+            }
         }
     }
 }

--- a/Toggl.Foundation/Experiments/RatingViewExperiment.cs
+++ b/Toggl.Foundation/Experiments/RatingViewExperiment.cs
@@ -40,12 +40,12 @@ namespace Toggl.Foundation.Experiments
 
         private bool dayCountPassed(RatingViewConfiguration ratingViewConfiguration)
         {
-            var firstOpened = onboardingStorage.GetFirstOpened();
-            if (firstOpened == null)
+            var firstOpenedAfterUpdate = onboardingStorage.GetFirstOpenedAfterUpdate();
+            if (firstOpenedAfterUpdate == null)
                 return false;
 
             var targetDayCount = ratingViewConfiguration.DayCount;
-            var actualDayCount = (timeService.CurrentDateTime - firstOpened.Value).TotalDays;
+            var actualDayCount = (timeService.CurrentDateTime - firstOpenedAfterUpdate.Value).TotalDays;
             return actualDayCount >= targetDayCount;
         }
 

--- a/Toggl.PrimeRadiant/Settings/IOnboardingStorage.cs
+++ b/Toggl.PrimeRadiant/Settings/IOnboardingStorage.cs
@@ -20,13 +20,17 @@ namespace Toggl.PrimeRadiant.Settings
         void SetIsNewUser(bool isNewUser);
         void SetLastOpened(DateTimeOffset dateString);
         void SetFirstOpened(DateTimeOffset dateTime);
+        void SetFirstOpenedAfterUpdate(DateTimeOffset dateTime);
         void SetUserSignedUp();
         void SetNavigatedAwayFromMainViewAfterStopButton();
         void SetTimeEntryContinued();
+        void SetNewAppVersion();
 
         string GetLastOpened();
         DateTimeOffset? GetFirstOpened();
+        DateTimeOffset? GetFirstOpenedAfterUpdate();
         bool CompletedOnboarding();
+        bool DidAppUpdate();
 
         void StartButtonWasTapped();
         void TimeEntryWasTapped();

--- a/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
+++ b/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
@@ -11,10 +11,12 @@ namespace Toggl.PrimeRadiant.Settings
         private const string outdatedApiKey = "OutdatedApi";
         private const string outdatedClientKey = "OutdatedClient";
         private const string unauthorizedAccessKey = "UnauthorizedAccessForApiToken";
+        private const string lastAppVersionKey = "LastAppVersion";
 
         private const string userSignedUpUsingTheAppKey = "UserSignedUpUsingTheApp";
         private const string isNewUserKey = "IsNewUser";
         private const string lastAccessDateKey = "LastAccessDate";
+        private const string firstRunAfterUpdateDateKey = "FirstRunAfterUpdateDate";
         private const string firstAccessDateKey = "FirstAccessDate";
         private const string completedOnboardingKey = "CompletedOnboarding";
 
@@ -91,6 +93,11 @@ namespace Toggl.PrimeRadiant.Settings
             keyValueStorage.SetString(unauthorizedAccessKey, apiToken);
         }
 
+        public void SetNewAppVersion()
+        {
+            keyValueStorage.SetString(lastAppVersionKey, version.ToString());
+        }
+
         public bool IsClientOutdated()
             => isOutdated(outdatedClientKey);
 
@@ -99,6 +106,9 @@ namespace Toggl.PrimeRadiant.Settings
 
         public bool IsUnauthorized(string apiToken)
             => apiToken == keyValueStorage.GetString(unauthorizedAccessKey);
+
+        public bool DidAppUpdate()
+            => version != getStoredVersion(lastAppVersionKey);
 
         private bool isOutdated(string key)
         {
@@ -148,6 +158,11 @@ namespace Toggl.PrimeRadiant.Settings
                 keyValueStorage.SetString(firstAccessDateKey, dateTime.ToString());
         }
 
+        public void SetFirstOpenedAfterUpdate(DateTimeOffset dateTime)
+        {
+            keyValueStorage.SetString(firstRunAfterUpdateDateKey, dateTime.ToString());
+        }
+
         public void SetUserSignedUp()
         {
             userSignedUpUsingTheAppSubject.OnNext(true);
@@ -184,6 +199,16 @@ namespace Toggl.PrimeRadiant.Settings
         public DateTimeOffset? GetFirstOpened()
         {
             var dateString = keyValueStorage.GetString(firstAccessDateKey);
+
+            if (string.IsNullOrEmpty(dateString))
+                return null;
+
+            return DateTimeOffset.Parse(dateString);
+        }
+
+        public DateTimeOffset? GetFirstOpenedAfterUpdate()
+        {
+            var dateString = keyValueStorage.GetString(firstRunAfterUpdateDateKey);
 
             if (string.IsNullOrEmpty(dateString))
                 return null;


### PR DESCRIPTION
<!-- This template is a guideline, use your own judgement to write a description that is easy to read and will help get the PR reviewed quickly and accurately -->

## What's this?
<!-- Describe clearly and concisely what this PR changes -->
Is a fix for the day count calculations of the rating view experiment.

### Relationships
<!-- Mention any issues or PRs that are connected to this -->

Closes #2827

## Why do we want this?
<!-- Describe the reason for making this change -->
So that calculations do not start from install date.

## How is it done?
<!-- Describe how the changes are implemented, list the different parts the changes consist of if it's more than one -->
It keeps track of the first date the app was run after being updated and uses it to calculate days in the rating view experiment.

### Why not another way?
<!-- Are there other possible solutions that might seem more obvious? Tell us why you didn't go with those -->
-

### Side effects
<!-- If there are (possible) side effects, something left unfinished or otherwise affected -->
-

## Review hints
<!-- Give pointers to help reviewers validate the changes, give a list of things that should be tested, show before/after screenshots, etc. -->
Use tutorial in from [this issue](https://github.com/toggl/mobileapp/issues/2620) to test it.

## :squid: Permissions
<!-- Is anybody else allowed to merge this? If so, who? -->
Whenever