### PR TITLE
Clean up sync entry point

### DIFF
--- a/Toggl.Foundation.Tests/Sync/StateMachineOrchestratorTests.cs
+++ b/Toggl.Foundation.Tests/Sync/StateMachineOrchestratorTests.cs
@@ -245,6 +245,13 @@ namespace Toggl.Foundation.Tests.Sync
                 protected override void CallMethod() => Orchestrator.Start(Push);
             }
 
+            public sealed class TheStartCleanUp : PullPushSyncMethodTests
+            {
+                protected override SyncState ExpectedState => CleanUp;
+                protected override StateResult EntryPoint => EntryPoints.StartCleanUp;
+                protected override void CallMethod() => Orchestrator.Start(CleanUp);
+            }
+
             public sealed class TheStartSleep : StateChangeMethodTests
             {
                 protected override SyncState ExpectedState => Sleep;

--- a/Toggl.Foundation.Tests/Sync/SyncManagerTests.cs
+++ b/Toggl.Foundation.Tests/Sync/SyncManagerTests.cs
@@ -373,6 +373,24 @@ namespace Toggl.Foundation.Tests.Sync
             }
         }
 
+        public sealed class TheCleanUpMethod : SyncMethodTests
+        {
+            protected override IObservable<SyncState> CallSyncMethod()
+                => SyncManager.CleanUp();
+
+            [Fact, LogIfTooSlow]
+            public void TellsQueueToStartSyncAfterQueingPush()
+            {
+                CallMethod();
+
+                Received.InOrder(() =>
+                {
+                    Queue.QueueCleanUp();
+                    Queue.Dequeue();
+                });
+            }
+        }
+
         public sealed class TheFreezeMethod : SyncManagerTestBase
         {
             [Fact, LogIfTooSlow]

--- a/Toggl.Foundation.Tests/Sync/SyncStateQueueTests.cs
+++ b/Toggl.Foundation.Tests/Sync/SyncStateQueueTests.cs
@@ -29,6 +29,9 @@ namespace Toggl.Foundation.Tests.Sync
                         case Push:
                             queue.QueuePushSync();
                             break;
+                        case CleanUp:
+                            queue.QueueCleanUp();
+                            break;
                         default:
                             throw new ArgumentOutOfRangeException();
                     }
@@ -99,6 +102,16 @@ namespace Toggl.Foundation.Tests.Sync
                 );
             }
 
+            [Fact, LogIfTooSlow]
+            public void StartsCleanUpIfOnlyCleanUpIsQueue()
+            {
+                QueueSyncs(CleanUp);
+
+                Dequeue();
+
+                DequeuedStates.ShouldBeSameEventsAs(CleanUp);
+            }
+
             [Property]
             public void AlwaysReturnsTheStateItRuns(bool[] pushPull)
             {
@@ -154,6 +167,18 @@ namespace Toggl.Foundation.Tests.Sync
                     Pull, Push, Pull, Push, Sleep
                 );
             }
+
+            [Fact, LogIfTooSlow]
+            public void RunsCleanUpJustBeforeSleepIfPullAndPushIsQueuedAsWell()
+            {
+                QueueSyncs(Pull, Push, CleanUp);
+
+                DequeueUntilSleep();
+
+                DequeuedStates.ShouldBeSameEventsAs(
+                    Pull, Push, CleanUp, Sleep
+                );
+            }
         }
 
         public sealed class TheClearMethod : BaseStateQueueTests
@@ -180,8 +205,19 @@ namespace Toggl.Foundation.Tests.Sync
                 returnValues.ShouldBeSameEventsAs(Sleep);
             }
 
+            [Fact, LogIfTooSlow]
+            public void ClearsCleanUp()
+            {
+                QueueSyncs(CleanUp);
+
+                Clear();
+                var returnValues = DequeueUntilSleep();
+
+                returnValues.ShouldBeSameEventsAs(Sleep);
+            }
+
             [Property]
-            public void RetursSleepAfterClearNoMatterWhatWasQueuedPreviously(NonEmptyArray<bool> pushPull)
+            public void RetursSleepAfterClearNoMatterHowManyPullsAndPushesWereQueuedPreviously(NonEmptyArray<bool> pushPull)
             {
                 DequeuedStates.Clear();
                 QueueSyncs(BoolToEnumValues(pushPull.Get));

--- a/Toggl.Foundation/DataSources/TogglDataSource.cs
+++ b/Toggl.Foundation/DataSources/TogglDataSource.cs
@@ -24,12 +24,14 @@ namespace Toggl.Foundation.DataSources
         private readonly ITogglDatabase database;
         private readonly IErrorHandlingService errorHandlingService;
         private readonly IBackgroundService backgroundService;
+        private readonly ITimeService timeService;
         private readonly IApplicationShortcutCreator shortcutCreator;
 
         private readonly TimeSpan minimumTimeInBackgroundForFullSync;
 
         private IDisposable errorHandlingDisposable;
         private IDisposable signalDisposable;
+        private IDisposable midnightDisposable;
 
         private bool isLoggedIn;
 
@@ -56,6 +58,7 @@ namespace Toggl.Foundation.DataSources
             this.database = database;
             this.errorHandlingService = errorHandlingService;
             this.backgroundService = backgroundService;
+            this.timeService = timeService;
             this.shortcutCreator = shortcutCreator;
 
             this.minimumTimeInBackgroundForFullSync = minimumTimeInBackgroundForFullSync;
@@ -101,12 +104,15 @@ namespace Toggl.Foundation.DataSources
             if (isLoggedIn == false)
                 throw new InvalidOperationException("Cannot start syncing after the user logged out of the app.");
 
-            if (signalDisposable != null)
+            if (signalDisposable != null || midnightDisposable != null)
                 throw new InvalidOperationException("The StartSyncing method has already been called.");
 
             signalDisposable = backgroundService.AppResumedFromBackground
                 .Where(timeInBackground => timeInBackground >= minimumTimeInBackgroundForFullSync)
                 .Subscribe((TimeSpan _) => SyncManager.ForceFullSync());
+
+            midnightDisposable = timeService.MidnightObservable
+                .Subscribe((DateTimeOffset _) => SyncManager.CleanUp());
 
             return SyncManager.ForceFullSync()
                 .Select(_ => Unit.Default);

--- a/Toggl.Foundation/Sync/ISyncManager.cs
+++ b/Toggl.Foundation/Sync/ISyncManager.cs
@@ -10,6 +10,8 @@ namespace Toggl.Foundation.Sync
 
         IObservable<SyncState> PushSync();
         IObservable<SyncState> ForceFullSync();
+        IObservable<SyncState> CleanUp();
+
         IObservable<SyncState> Freeze();
     }
 }

--- a/Toggl.Foundation/Sync/ISyncStateQueue.cs
+++ b/Toggl.Foundation/Sync/ISyncStateQueue.cs
@@ -4,6 +4,7 @@
     {
         void QueuePushSync();
         void QueuePullSync();
+        void QueueCleanUp();
 
         SyncState Dequeue();
         void Clear();

--- a/Toggl.Foundation/Sync/StateMachineEntryPoints.cs
+++ b/Toggl.Foundation/Sync/StateMachineEntryPoints.cs
@@ -4,5 +4,6 @@ namespace Toggl.Foundation.Sync
     {
         public StateResult StartPullSync { get; } = new StateResult();
         public StateResult StartPushSync { get; } = new StateResult();
+        public StateResult StartCleanUp { get; } = new StateResult();
     }
 }

--- a/Toggl.Foundation/Sync/StateMachineOrchestrator.cs
+++ b/Toggl.Foundation/Sync/StateMachineOrchestrator.cs
@@ -42,6 +42,9 @@ namespace Toggl.Foundation.Sync
                 case SyncState.Push:
                     startSync(SyncState.Push, entryPoints.StartPushSync);
                     break;
+                case SyncState.CleanUp:
+                    startSync(SyncState.CleanUp, entryPoints.StartCleanUp);
+                    break;
                 case SyncState.Sleep:
                     goToSleep();
                     break;

--- a/Toggl.Foundation/Sync/SyncManager.cs
+++ b/Toggl.Foundation/Sync/SyncManager.cs
@@ -75,6 +75,15 @@ namespace Toggl.Foundation.Sync
             }
         }
 
+        public IObservable<SyncState> CleanUp()
+        {
+            lock (stateLock)
+            {
+                queue.QueueCleanUp();
+                return startSyncIfNeededAndObserve();
+            }
+        }
+
         public IObservable<SyncState> Freeze()
         {
             lock (stateLock)

--- a/Toggl.Foundation/Sync/SyncState.cs
+++ b/Toggl.Foundation/Sync/SyncState.cs
@@ -4,6 +4,7 @@
     {
         Sleep = 0,
         Pull,
-        Push
+        Push,
+        CleanUp
     }
 }

--- a/Toggl.Foundation/Sync/SyncStateQueue.cs
+++ b/Toggl.Foundation/Sync/SyncStateQueue.cs
@@ -7,7 +7,8 @@ namespace Toggl.Foundation.Sync
         private bool pulledLast;
         private bool pullSyncQueued;
         private bool pushSyncQueued;
-        
+        private bool cleanUp;
+
         public void QueuePushSync()
         {
             pushSyncQueued = true;
@@ -16,6 +17,11 @@ namespace Toggl.Foundation.Sync
         public void QueuePullSync()
         {
             pullSyncQueued = true;
+        }
+
+        public void QueueCleanUp()
+        {
+            cleanUp = true;
         }
 
         public SyncState Dequeue()
@@ -29,7 +35,13 @@ namespace Toggl.Foundation.Sync
             if (pushSyncQueued)
                 return push();
 
-            return sleep();
+            if (cleanUp)
+            {
+                cleanUp = false;
+                return CleanUp;
+            }
+
+            return Sleep;
         }
 
         public void Clear()
@@ -37,6 +49,7 @@ namespace Toggl.Foundation.Sync
             pulledLast = false;
             pullSyncQueued = false;
             pushSyncQueued = false;
+            cleanUp = false;
         }
 
         private SyncState pull()
@@ -52,8 +65,5 @@ namespace Toggl.Foundation.Sync
             pulledLast = false;
             return Push;
         }
-
-        private SyncState sleep()
-            => Sleep;
     }
 }

--- a/Toggl.Foundation/TogglSyncManagerFactory.cs
+++ b/Toggl.Foundation/TogglSyncManagerFactory.cs
@@ -63,6 +63,7 @@ namespace Toggl.Foundation
         {
             configurePullTransitions(transitions, database, api, dataSource, timeService, analyticsService, scheduler, entryPoints.StartPullSync, delayCancellation);
             configurePushTransitions(transitions, api, dataSource, analyticsService, apiDelay, scheduler, entryPoints.StartPushSync, delayCancellation);
+            configureCleanUpTransitions(transitions, timeService, dataSource, entryPoints.StartCleanUp);
         }
 
         private static void configurePullTransitions(
@@ -136,8 +137,6 @@ namespace Toggl.Foundation
             var checkServerStatus = new CheckServerStatusState(api, scheduler, apiDelay, statusDelay, delayCancellation);
 
             var finished = new ResetAPIDelayState(apiDelay);
-            var deleteOlderEntries = new DeleteOldEntriesState(timeService, dataSource.TimeEntries);
-            var deleteNonReferencedGhostProjects = new DeleteNonReferencedProjectGhostsState(dataSource.Projects, dataSource.TimeEntries);
 
             transitions.ConfigureTransition(entryPoint, fetchAllSince);
             transitions.ConfigureTransition(fetchAllSince.FetchStarted, persistWorkspaces);
@@ -169,9 +168,6 @@ namespace Toggl.Foundation
             transitions.ConfigureTransition(persistTimeEntries.FinishedPersisting, updateTimeEntriesSinceDate);
             transitions.ConfigureTransition(updateTimeEntriesSinceDate.Finished, refetchInaccessibleProjects);
             transitions.ConfigureTransition(refetchInaccessibleProjects.FetchNext, refetchInaccessibleProjects);
-
-            transitions.ConfigureTransition(refetchInaccessibleProjects.FinishedPersisting, deleteOlderEntries);
-            transitions.ConfigureTransition(deleteOlderEntries.FinishedDeleting, deleteNonReferencedGhostProjects);
 
             transitions.ConfigureTransition(persistWorkspaces.ErrorOccured, retryOrThrow);
             transitions.ConfigureTransition(persistUser.ErrorOccured, retryOrThrow);
@@ -208,6 +204,19 @@ namespace Toggl.Foundation
             var pushingClientsFinished = configureCreateOnlyPush(transitions, pushingTagsFinished, dataSource.Clients, analyticsService, api.Clients, Client.Clean, Client.Unsyncable, api, scheduler, delayCancellation);
             var pushingProjectsFinished = configureCreateOnlyPush(transitions, pushingClientsFinished, dataSource.Projects, analyticsService, api.Projects, Project.Clean, Project.Unsyncable, api, scheduler, delayCancellation);
             configurePush(transitions, pushingProjectsFinished, dataSource.TimeEntries, analyticsService, api.TimeEntries, api.TimeEntries, api.TimeEntries, TimeEntry.Clean, TimeEntry.Unsyncable, api, apiDelay, scheduler, delayCancellation);
+        }
+
+        private static void configureCleanUpTransitions(
+            ITransitionConfigurator transitions,
+            ITimeService timeService,
+            ITogglDataSource dataSource,
+            StateResult entryPoint)
+        {
+            var deleteOlderEntries = new DeleteOldEntriesState(timeService, dataSource.TimeEntries);
+            var deleteNonReferencedGhostProjects = new DeleteNonReferencedProjectGhostsState(dataSource.Projects, dataSource.TimeEntries);
+
+            transitions.ConfigureTransition(entryPoint, deleteOlderEntries);
+            transitions.ConfigureTransition(deleteOlderEntries.FinishedDeleting, deleteNonReferencedGhostProjects);
         }
 
         private static IStateResult configurePush<TModel, TDatabase, TThreadsafe>(


### PR DESCRIPTION
## What's this?
This PR adds a new entry point for the syncing machine for the _clean up_. This part of syncing is meant mainly for pruning old data and removing data which were pulled but should no longer be stored on the device (like when the user loses access to a workspace).

### Relationships
Ref #2631

## Why do we want this?
Checking the database for items which are no longer needed might potentially include several complex queries which should not run on every pull or push sync. It is OK to prune the data every day or so. That is why a separate syncing entry point comes into play.

## How is it done?
The sync state queue is modified to include a new type of a sync state. The sync manager, state machine, and the state machine orchestrator are modified so that they support this new entry point. Two states which were part of the pull-sync are now moved to the sync clean-up.

### Side effects
We won't prune old data as often as we did so far, but that should not be a problem at all as we are doing that too often in the current release.

## Review hints
Change your time settings to see if the clean-up sync kicks in right after the date changes ("midnight" observable). Feel free to ask me how I test this myself in the simulator.

## :squid: Permissions
This is still a WIP (more testing is needed) and is not ready for merging.