### PR TITLE
Fix missing ISchedulerProvider injection

### DIFF
--- a/Toggl.Foundation.MvvmCross/FoundationExtensions.cs
+++ b/Toggl.Foundation.MvvmCross/FoundationExtensions.cs
@@ -96,6 +96,7 @@ namespace Toggl.Foundation.MvvmCross
             Mvx.RegisterSingleton(foundation.LastTimeUsageStorage);
             Mvx.RegisterSingleton(foundation.ErrorHandlingService);
             Mvx.RegisterSingleton(foundation.PasswordManagerService ?? new StubPasswordManagerService());
+            Mvx.RegisterSingleton(foundation.SchedulerProvider);
 
             // Feedback service is obsolete and is used only in the Android App and should be removed soon
             if (foundation.FeedbackService != null)

--- a/Toggl.Foundation.MvvmCross/MvvmCrossFoundation.cs
+++ b/Toggl.Foundation.MvvmCross/MvvmCrossFoundation.cs
@@ -30,6 +30,7 @@ namespace Toggl.Foundation.MvvmCross
         public ILicenseProvider LicenseProvider { get; }
         public IAnalyticsService AnalyticsService { get; }
         public IBackgroundService BackgroundService { get; }
+        public ISchedulerProvider SchedulerProvider { get; }
         public IPlatformConstants PlatformConstants { get; }
         public IRemoteConfigService RemoteConfigService { get; }
         public IApplicationShortcutCreator ShortcutCreator { get; }
@@ -77,6 +78,7 @@ namespace Toggl.Foundation.MvvmCross
             ShortcutCreator = builder.Foundation.ShortcutCreator;
             AnalyticsService = builder.Foundation.AnalyticsService;
             PlatformConstants = builder.Foundation.PlatformConstants;
+            SchedulerProvider = builder.Foundation.SchedulerProvider;
             BackgroundService = builder.Foundation.BackgroundService;
             RemoteConfigService = builder.Foundation.RemoteConfigService;
             SuggestionProviderContainer = builder.Foundation.SuggestionProviderContainer;


### PR DESCRIPTION
## What's this?
It fixes the injection of the ISchedulerProvider that is crashing giskard at runtime.
 
### Relationships
Introduced by #2850 

Closes Nothing

## Why do we want this?
We need to keep the app running.

## How is it done?
It just uses the `Mvx.RegisterSingleton` that was missing.

### Why not another way?
I don't know of any other ways. Improvements are always welcome.

## Review hints
Please check that develop breaks for giskard and daneel and it doesn't after the change.

## :squid: Permissions
Anyone, after testing on both platforms.