### PR TITLE
Filter calendar items longer than 24 hours

### DIFF
--- a/Toggl.Daneel/Services/CalendarService.cs
+++ b/Toggl.Daneel/Services/CalendarService.cs
@@ -5,48 +5,24 @@ using System.Reactive.Linq;
 using EventKit;
 using Toggl.Foundation.Calendar;
 using Toggl.Foundation.MvvmCross.Services;
-using Toggl.Foundation.Services;
 using Toggl.Multivac;
 using Toggl.PrimeRadiant.Settings;
 
 namespace Toggl.Daneel.Services
 {
-    public sealed class CalendarService : ICalendarService
+    public sealed class CalendarService : BaseCalendarService
     {
-        private readonly IUserPreferences userPreferences;
-        private readonly IPermissionsService permissionsService;
         private readonly EKEventStore eventStore = new EKEventStore();
 
-        public CalendarService(
-            IUserPreferences userPreferences,
-            IPermissionsService permissionsService)
+        public CalendarService(IPermissionsService permissionsService)
+            : base (permissionsService)
         {
-            Ensure.Argument.IsNotNull(userPreferences, nameof(userPreferences));
-            Ensure.Argument.IsNotNull(permissionsService, nameof(permissionsService));
-
-            this.userPreferences = userPreferences;
-            this.permissionsService = permissionsService;
         }
 
-        public IObservable<IEnumerable<CalendarItem>> GetEventsForDate(DateTime date)
+        public override IObservable<IEnumerable<CalendarItem>> GetEventsForDate(DateTime date)
             => Observable.Return(new List<CalendarItem>());
 
-        public IObservable<IEnumerable<UserCalendar>> UserCalendars
-            => Observable.DeferAsync(async (cancellactionToken) =>
-                {
-                    var isAuthorized = await permissionsService.CalendarAuthorizationStatus;
-                    if (!isAuthorized)
-                    {
-                        return Observable.Throw<IEnumerable<UserCalendar>>(
-                            new NotAuthorizedException("You don't have permission to access calendars")
-                        );
-                    }
-
-                    var enabledIds = userPreferences.EnabledCalendarIds().ToHashSet();
-                    return Observable.Return(selectCalendars(enabledIds));
-                });
-
-        private IEnumerable<UserCalendar> selectCalendars(HashSet<string> selectedIds)
+        protected override IEnumerable<UserCalendar> NativeGetUserCalendars()
             => eventStore
                 .GetCalendars(EKEntityType.Event)
                 .Select(ekCalendar => userCalendarFromEKCalendar(

--- a/Toggl.Daneel/Services/CalendarService.cs
+++ b/Toggl.Daneel/Services/CalendarService.cs
@@ -25,16 +25,13 @@ namespace Toggl.Daneel.Services
         protected override IEnumerable<UserCalendar> NativeGetUserCalendars()
             => eventStore
                 .GetCalendars(EKEntityType.Event)
-                .Select(ekCalendar => userCalendarFromEKCalendar(
-                    calendar: ekCalendar,
-                    selected: selectedIds.Contains(ekCalendar.CalendarIdentifier))
-                );
+                .Select(userCalendarFromEKCalendar);
         
-        private UserCalendar userCalendarFromEKCalendar(EKCalendar calendar, bool selected)
+        private UserCalendar userCalendarFromEKCalendar(EKCalendar calendar)
             => new UserCalendar(
                 calendar.CalendarIdentifier,
                 calendar.Title,
-                calendar.Source.Title,
-                selected);
+                calendar.Source.Title
+            );
     }
 }

--- a/Toggl.Daneel/Startup/Setup.cs
+++ b/Toggl.Daneel/Startup/Setup.cs
@@ -88,7 +88,7 @@ namespace Toggl.Daneel
             var permissionsService = new PermissionsService();
             var userAgent = new UserAgent(clientName, version);
             var settingsStorage = new SettingsStorage(Version.Parse(version), keyValueStorage);
-            var calendarService = new CalendarService(settingsStorage, permissionsService);
+            var calendarService = new CalendarService(permissionsService);
 
             var foundation =
                 TogglFoundation

--- a/Toggl.Foundation.MvvmCross/Services/BaseCalendarService.cs
+++ b/Toggl.Foundation.MvvmCross/Services/BaseCalendarService.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using Toggl.Foundation.MvvmCross.Services;
+using Toggl.Foundation.Services;
+using Toggl.Multivac;
+
+namespace Toggl.Foundation.Calendar
+{
+    public abstract class BaseCalendarService : ICalendarService
+    {
+        private readonly IPermissionsService permissionsService;
+
+        public BaseCalendarService(IPermissionsService permissionsService)
+        {
+            Ensure.Argument.IsNotNull(permissionsService, nameof(permissionsService));
+
+            this.permissionsService = permissionsService;
+        }
+
+        public IObservable<IEnumerable<UserCalendar>> GetUserCalendars()
+            => Observable.DeferAsync(async (cancellactionToken) =>
+            {
+                var isAuthorized = await permissionsService.CalendarAuthorizationStatus;
+                if (!isAuthorized)
+                {
+                    return Observable.Throw<IEnumerable<UserCalendar>>(
+                        new NotAuthorizedException("You don't have permission to access calendars")
+                    );
+                }
+
+                var calendars = NativeGetUserCalendars();
+                return Observable.Return(calendars);
+            });
+
+        public abstract IObservable<IEnumerable<CalendarItem>> GetEventsForDate(DateTime date);
+
+        protected abstract IEnumerable<UserCalendar> NativeGetUserCalendars();
+    }
+}

--- a/Toggl.Foundation.Tests/Interactors/Calendar/GetCalendarItemsForDateInteractorTests.cs
+++ b/Toggl.Foundation.Tests/Interactors/Calendar/GetCalendarItemsForDateInteractorTests.cs
@@ -105,6 +105,34 @@ namespace Toggl.Foundation.Tests.Interactors.Calendar
 
                 calendarItems.Should().BeInAscendingOrder(calendarItem => calendarItem.StartTime);
             }
+
+            [Fact, LogIfTooSlow]
+            public async Task FiltersElementsLongerThanTwentyFourHours()
+            {
+                var newCalendarEvents = calendarEvents
+                    .Append(
+                        new CalendarItem(CalendarItemSource.Calendar,
+                            new DateTimeOffset(2018, 08, 06, 10, 30, 00, TimeSpan.Zero),
+                            TimeSpan.FromHours(24),
+                            "Day off",
+                            "#0000ff"))
+                    .Append(
+                        new CalendarItem(CalendarItemSource.Calendar,
+                            new DateTimeOffset(2018, 08, 06, 10, 30, 00, TimeSpan.Zero),
+                            TimeSpan.FromDays(7),
+                            "Team meetup",
+                            "#0000ff")
+                    );
+
+                CalendarService
+                    .GetEventsForDate(Arg.Is(date))
+                    .Returns(Observable.Return(newCalendarEvents));
+                
+                var calendarItems = await interactor.Execute();
+
+                calendarItems.Should().HaveCount(newCalendarEvents.Count() - 2);
+                calendarItems.Should().NotContain(calendarItem => calendarItem.Description == "Day off" || calendarItem.Description == "Team meetup");
+            }
         }
     }
 }

--- a/Toggl.Foundation.Tests/Interactors/Calendar/GetUserCalendarsInteractorTests.cs
+++ b/Toggl.Foundation.Tests/Interactors/Calendar/GetUserCalendarsInteractorTests.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using Toggl.Foundation.Interactors.Calendar;
+using Toggl.Foundation.Tests.Generators;
 using Toggl.Multivac;
 using Xunit;
 
@@ -12,10 +16,15 @@ namespace Toggl.Foundation.Tests.Interactors.Calendar
     {
         public sealed class TheConstructor : BaseInteractorTests
         {
-            [Fact]
-            public void ThrowsIfTheArgumentIsNull()
+            [Theory]
+            [ConstructorData]
+            public void ThrowsIfTheArgumentIsNull(bool useCalendarService, bool useUserPreferences)
             {
-                Action tryingToConstructWithNulls = () => new GetUserCalendarsInteractor(null);
+                var calendarService = useCalendarService ? CalendarService : null;
+                var userPreferences = useUserPreferences ? UserPreferences : null;
+
+                Action tryingToConstructWithNulls =
+                    () => new GetUserCalendarsInteractor(calendarService, userPreferences);
 
                 tryingToConstructWithNulls.Should().Throw<ArgumentNullException>();
             }
@@ -23,13 +32,36 @@ namespace Toggl.Foundation.Tests.Interactors.Calendar
 
         public sealed class TheExecuteMethod : BaseInteractorTests
         {
-            [Fact]
-            public void ReturnsTheObservableFromCalendarService()
+            private static readonly IEnumerable<UserCalendar> calendarsFromService = new List<UserCalendar>
             {
-                var observable = Substitute.For<IObservable<IEnumerable<UserCalendar>>>();
-                CalendarService.UserCalendars.Returns(observable);
+                new UserCalendar("foo", "foo", "Google Calendar"),
+                new UserCalendar("bar", "bar", "Google Calendar"),
+                new UserCalendar("baz", "baz", "Google Calendar")
+            };
 
-                InteractorFactory.GetUserCalendars().Execute().Should().BeSameAs(observable);
+            private static readonly IEnumerable<string> selectedCalendars = new List<string> { "foo", "bar" };
+
+            [Fact]
+            public async Task ReturnsAllCalendarsFromTheCalendarService()
+            {
+                var observable = Observable.Return(calendarsFromService);
+                CalendarService.GetUserCalendars().Returns(observable);
+
+                var calendars = await InteractorFactory.GetUserCalendars().Execute();
+                calendars.Should().HaveCount(calendarsFromService.Count());
+            }
+
+            [Fact]
+            public async Task SetsTheCalendarsToSelectedWhenTheyWereSelectedByTheUser()
+            {
+
+                var observable = Observable.Return(calendarsFromService);
+                CalendarService.GetUserCalendars().Returns(observable);
+                UserPreferences.EnabledCalendarIds().Returns(selectedCalendars);
+
+                var calendars = await InteractorFactory.GetUserCalendars().Execute();
+
+                calendars.Where(c => c.IsSelected).Should().HaveCount(selectedCalendars.Count());
             }
         }
     }

--- a/Toggl.Foundation/Interactors/Calendar/GetUserCalendarsInteractor.cs
+++ b/Toggl.Foundation/Interactors/Calendar/GetUserCalendarsInteractor.cs
@@ -1,22 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
 using Toggl.Foundation.Services;
 using Toggl.Multivac;
+using Toggl.Multivac.Extensions;
+using Toggl.PrimeRadiant.Settings;
 
 namespace Toggl.Foundation.Interactors.Calendar
 {
     public sealed class GetUserCalendarsInteractor : IInteractor<IObservable<IEnumerable<UserCalendar>>>
     {
+        private readonly IUserPreferences userPreferences;
         private readonly ICalendarService calendarService;
 
-        public GetUserCalendarsInteractor(ICalendarService calendarService)
+        public GetUserCalendarsInteractor(ICalendarService calendarService, IUserPreferences userPreferences)
         {
             Ensure.Argument.IsNotNull(calendarService, nameof(calendarService));
+            Ensure.Argument.IsNotNull(userPreferences, nameof(userPreferences));
 
             this.calendarService = calendarService;
+            this.userPreferences = userPreferences;
         }
 
         public IObservable<IEnumerable<UserCalendar>> Execute()
-            => calendarService.UserCalendars;
+        {
+            var enabledIds = userPreferences.EnabledCalendarIds().ToHashSet();
+            
+            return calendarService.GetUserCalendars()
+                .Select(calendarsWithTheSelectedProperty(enabledIds));
+        }
+
+        private Func<IEnumerable<UserCalendar>, IEnumerable<UserCalendar>> calendarsWithTheSelectedProperty(HashSet<string> enabledIds)
+            => userCalendars => userCalendars.Select(calendar => calendar.WithSelected(enabledIds.Contains(calendar.Id)));
     }
 }

--- a/Toggl.Foundation/Interactors/InteractorFactory.Calendar.cs
+++ b/Toggl.Foundation/Interactors/InteractorFactory.Calendar.cs
@@ -13,7 +13,7 @@ namespace Toggl.Foundation.Interactors
             => new GetCalendarItemsForDateInteractor(dataSource.TimeEntries, calendarService, date);
 
         public IInteractor<IObservable<IEnumerable<UserCalendar>>> GetUserCalendars()
-            => new GetUserCalendarsInteractor(calendarService);
+            => new GetUserCalendarsInteractor(calendarService, userPreferences);
 
         public IInteractor<Unit> SetEnabledCalendars(params string[] ids)
             => new SetEnabledCalendarsInteractor(userPreferences, ids);

--- a/Toggl.Foundation/Services/ICalendarService.cs
+++ b/Toggl.Foundation/Services/ICalendarService.cs
@@ -9,6 +9,6 @@ namespace Toggl.Foundation.Services
     {
         IObservable<IEnumerable<CalendarItem>> GetEventsForDate(DateTime date);
 
-        IObservable<IEnumerable<UserCalendar>> UserCalendars { get; }
+        IObservable<IEnumerable<UserCalendar>> GetUserCalendars();
     }
 }

--- a/Toggl.Giskard/Services/CalendarService.cs
+++ b/Toggl.Giskard/Services/CalendarService.cs
@@ -2,17 +2,24 @@
 using System.Collections.Generic;
 using System.Reactive.Linq;
 using Toggl.Foundation.Calendar;
+using Toggl.Foundation.MvvmCross.Services;
 using Toggl.Foundation.Services;
 using Toggl.Multivac;
+using Toggl.PrimeRadiant.Settings;
 
 namespace Toggl.Giskard.Services
 {
-    public sealed class CalendarService : ICalendarService
+    public sealed class CalendarService : BaseCalendarService
     {
-        public IObservable<IEnumerable<UserCalendar>> UserCalendars
-            => Observable.Return(new List<UserCalendar>());
+        public CalendarService(IPermissionsService permissionsService) 
+            : base(permissionsService)
+        {
+        }
 
-        public IObservable<IEnumerable<CalendarItem>> GetEventsForDate(DateTime date)
+        public override IObservable<IEnumerable<CalendarItem>> GetEventsForDate(DateTime date)
             => Observable.Return(new List<CalendarItem>());
+
+        protected override IEnumerable<UserCalendar> NativeGetUserCalendars()
+            => new List<UserCalendar>();
     }
 }

--- a/Toggl.Giskard/Startup/Setup.cs
+++ b/Toggl.Giskard/Startup/Setup.cs
@@ -80,6 +80,8 @@ namespace Toggl.Giskard
             var keyValueStorage = new SharedPreferencesStorage(sharedPreferences);
             var settingsStorage = new SettingsStorage(appVersion, keyValueStorage);
             var feedbackService = new FeedbackService(userAgent, mailService, dialogService, platformConstants);
+            var permissionsService = new PermissionsService();
+            var calendarService = new CalendarService(permissionsService);
 
             var foundation =
                 TogglFoundation
@@ -105,14 +107,14 @@ namespace Toggl.Giskard
                     .WithFeedbackService(feedbackService)
                     .WithLastTimeUsageStorage(settingsStorage)
                     .WithBrowserService<BrowserService>()
+                    .WithCalendarService(calendarService)
                     .WithKeyValueStorage(keyValueStorage)
                     .WithUserPreferences(settingsStorage)
                     .WithOnboardingStorage(settingsStorage)
                     .WithNavigationService(navigationService)
+                    .WithPermissionsService(permissionsService)
                     .WithAccessRestrictionStorage(settingsStorage)
                     .WithErrorHandlingService(new ErrorHandlingService(navigationService, settingsStorage))
-                    .WithPermissionsService<PermissionsService>()
-                    .WithCalendarService<CalendarService>()
                     .Build();
 
             foundation.RevokeNewUserIfNeeded().Initialize();

--- a/Toggl.Multivac/UserCalendar.cs
+++ b/Toggl.Multivac/UserCalendar.cs
@@ -13,6 +13,17 @@
         public UserCalendar(
             string id,
             string name,
+            string sourceName)
+        {
+            Id = id;
+            Name = name;
+            IsSelected = false;
+            SourceName = sourceName;
+        }
+
+        public UserCalendar(
+            string id,
+            string name,
             string sourceName,
             bool isSelected)
         {
@@ -21,5 +32,8 @@
             SourceName = sourceName;
             IsSelected = isSelected;
         }
+
+        public UserCalendar WithSelected(bool selected)
+            => new UserCalendar(Id, Name, SourceName, selected);
     }
 }


### PR DESCRIPTION
<!-- This template is a guideline, use your own judgement to write a description that is easy to read and will help get the PR reviewed quickly and accurately -->

## What's this?
<!-- Describe clearly and concisely what this PR changes -->
This adds the BaseCalendarService and adds the filters to remove long events.

### Relationships
<!-- Mention any issues or PRs that are connected to this -->

Closes #2890

## Why do we want this?
<!-- Describe the reason for making this change -->
It has been decided and it's in the specs.

## How is it done?
<!-- Describe how the changes are implemented, list the different parts the changes consist of if it's more than one -->
I'm filtering stuff in the interactor and checking for OS permissions in the service

### Why not another way?
<!-- Are there other possible solutions that might seem more obvious? Tell us why you didn't go with those -->
The filter is a business rule and should be in the interactor. This way. should any other part of our system need the unfiltered time entries, the service is still able to provide them. Should the filter rule change, we only need to change code once.

The permissions are meant to be checked in the service because this is a OS intricacy rather than a business rule.

## Review hints
<!-- Give pointers to help reviewers validate the changes, give a list of things that should be tested, show before/after screenshots, etc. -->
Ensure that I tested everything that could be tested and that there are no edge cases uncovered.

## :squid: Permissions
<!-- Is anybody else allowed to merge this? If so, who? -->
Only myself.