### PR TITLE
Add more rating view events

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/RatingViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/RatingViewModel.cs
@@ -94,10 +94,16 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             impressionSubject.OnNext(isPositive);
             analyticsService.UserFinishedRatingViewFirstStep.Track(isPositive);
 
-            var outcome = isPositive
-                ? RatingViewOutcome.PositiveImpression
-                : RatingViewOutcome.NegativeImpression;
-            onboardingStorage.SetRatingViewOutcome(outcome, timeService.CurrentDateTime);
+            if (isPositive)
+            {
+                analyticsService.RatingViewFirstStepLike.Track();
+                onboardingStorage.SetRatingViewOutcome(RatingViewOutcome.PositiveImpression, timeService.CurrentDateTime);
+            }
+            else
+            {
+                analyticsService.RatingViewFirstStepDislike.Track();
+                onboardingStorage.SetRatingViewOutcome(RatingViewOutcome.NegativeImpression, timeService.CurrentDateTime);
+            }
         }
 
         private string ctaTitle(bool? impressionIsPositive)
@@ -141,6 +147,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                 ratingService.AskForRating();
                 //We can't really know whether the user actually rated
                 //We only know that we presented the iOS rating view
+                analyticsService.RatingViewSecondStepRate.Track();
                 analyticsService.UserFinishedRatingViewSecondStep.Track(RatingViewSecondStepOutcome.AppWasRated);
                 onboardingStorage.SetRatingViewOutcome(RatingViewOutcome.AppWasRated, timeService.CurrentDateTime);
             }
@@ -148,6 +155,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             {
                 var sendFeedbackSucceed = await navigationService.Navigate<SendFeedbackViewModel, bool>();
                 isFeedbackSuccessViewShowing.OnNext(sendFeedbackSucceed);
+                analyticsService.RatingViewSecondStepSendFeedback.Track();
                 analyticsService.UserFinishedRatingViewSecondStep.Track(RatingViewSecondStepOutcome.FeedbackWasLeft);
                 onboardingStorage.SetRatingViewOutcome(RatingViewOutcome.FeedbackWasLeft, timeService.CurrentDateTime);
             }
@@ -164,11 +172,13 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             if (impressionSubject.Value.Value)
             {
                 onboardingStorage.SetRatingViewOutcome(RatingViewOutcome.AppWasNotRated, timeService.CurrentDateTime);
+                analyticsService.RatingViewSecondStepDontRate.Track();
                 analyticsService.UserFinishedRatingViewSecondStep.Track(RatingViewSecondStepOutcome.AppWasNotRated);
             }
             else
             {
                 onboardingStorage.SetRatingViewOutcome(RatingViewOutcome.FeedbackWasNotLeft, timeService.CurrentDateTime);
+                analyticsService.RatingViewSecondStepDontSendFeedback.Track();
                 analyticsService.UserFinishedRatingViewSecondStep.Track(RatingViewSecondStepOutcome.FeedbackWasNotLeft);
             }
 

--- a/Toggl.Foundation.Tests/MvvmCross/ViewModels/RatingViewModelTests.cs
+++ b/Toggl.Foundation.Tests/MvvmCross/ViewModels/RatingViewModelTests.cs
@@ -106,6 +106,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 protected abstract string ExpectedCtaDescription { get; }
                 protected abstract string ExpectedCtaButtonTitle { get; }
                 protected abstract RatingViewOutcome ExpectedStorageOucome { get; }
+                protected abstract IAnalyticsEvent ExpectedEvent { get; }
 
                 [Fact, LogIfTooSlow]
                 public void SetsTheAppropriateCtaTitle()
@@ -156,6 +157,14 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
 
                     OnboardingStorage.Received().SetRatingViewOutcome(ExpectedStorageOucome, CurrentDateTime);
                 }
+
+                [Fact, LogIfTooSlow]
+                public void TracksTheCorrectEvent()
+                {
+                    ViewModel.RegisterImpression(ImpressionIsPositive);
+
+                    ExpectedEvent.Received().Track();
+                }
             }
 
             public sealed class WhenImpressionIsPositive : RegisterImpressionMethodTest
@@ -165,6 +174,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 protected override string ExpectedCtaDescription => Resources.RatingViewPositiveCTADescription;
                 protected override string ExpectedCtaButtonTitle => Resources.RatingViewPositiveCTAButtonTitle;
                 protected override RatingViewOutcome ExpectedStorageOucome => RatingViewOutcome.PositiveImpression;
+                protected override IAnalyticsEvent ExpectedEvent => AnalyticsService.RatingViewFirstStepLike;
             }
 
             public sealed class WhenImpressionIsNegative : RegisterImpressionMethodTest
@@ -174,6 +184,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 protected override string ExpectedCtaDescription => Resources.RatingViewNegativeCTADescription;
                 protected override string ExpectedCtaButtonTitle => Resources.RatingViewNegativeCTAButtonTitle;
                 protected override RatingViewOutcome ExpectedStorageOucome => RatingViewOutcome.NegativeImpression;
+                protected override IAnalyticsEvent ExpectedEvent => AnalyticsService.RatingViewFirstStepDislike;
             }
         }
 
@@ -181,9 +192,16 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
         {
             public abstract class PerformMainActionMethodTest : RatingViewModelTest
             {
+                protected abstract bool ImpressionIsPositive { get; }
                 protected abstract void EnsureCorrectActionWasPerformed();
                 protected abstract RatingViewSecondStepOutcome ExpectedEventParameterToTrack { get; }
                 protected abstract RatingViewOutcome ExpectedStoragetOutcome { get; }
+                protected abstract IAnalyticsEvent ExpectedEvent { get; }
+
+                protected override void AdditionalViewModelSetup()
+                {
+                    ViewModel.RegisterImpression(ImpressionIsPositive);
+                }
 
                 [Fact, LogIfTooSlow]
                 public async Task PerformsTheCorrectAction()
@@ -205,6 +223,14 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 }
 
                 [Fact, LogIfTooSlow]
+                public async Task TracksTheCorrectEvent()
+                {
+                    await ViewModel.PerformMainAction();
+
+                    ExpectedEvent.Received().Track();
+                }
+
+                [Fact, LogIfTooSlow]
                 public async Task StoresTheAppropriateRatingViewOutcomeAndTime()
                 {
                     await ViewModel.PerformMainAction();
@@ -217,17 +243,28 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
 
             public sealed class WhenImpressionIsPositive : PerformMainActionMethodTest
             {
+                protected override bool ImpressionIsPositive => true;
                 protected override RatingViewOutcome ExpectedStoragetOutcome => RatingViewOutcome.AppWasRated;
                 protected override RatingViewSecondStepOutcome ExpectedEventParameterToTrack => RatingViewSecondStepOutcome.AppWasRated;
-
-                protected override void AdditionalViewModelSetup()
-                {
-                    ViewModel.RegisterImpression(true);
-                }
+                protected override IAnalyticsEvent ExpectedEvent => AnalyticsService.RatingViewSecondStepRate;
 
                 protected override void EnsureCorrectActionWasPerformed()
                 {
                     RatingService.Received().AskForRating();
+                }
+            }
+
+            public sealed class WhenImpressionIsNegative : PerformMainActionMethodTest
+            {
+                protected override bool ImpressionIsPositive => false;
+                protected override RatingViewOutcome ExpectedStoragetOutcome => RatingViewOutcome.FeedbackWasLeft;
+                protected override RatingViewSecondStepOutcome ExpectedEventParameterToTrack => RatingViewSecondStepOutcome.FeedbackWasLeft;
+                protected override IAnalyticsEvent ExpectedEvent => AnalyticsService.RatingViewSecondStepSendFeedback;
+
+                protected override void EnsureCorrectActionWasPerformed()
+                {
+                    NavigationService.Received().Navigate<SendFeedbackViewModel, bool>()
+                        .Wait();
                 }
             }
 
@@ -277,6 +314,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 protected abstract bool ImpressionIsPositive { get; }
                 protected abstract RatingViewOutcome ExpectedStorageOutcome { get; }
                 protected abstract RatingViewSecondStepOutcome ExpectedEventParameterToTrack { get; }
+                protected abstract IAnalyticsEvent ExpectedEvent { get; }
 
                 protected override void AdditionalViewModelSetup()
                 {
@@ -298,6 +336,14 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
 
                     AnalyticsService.UserFinishedRatingViewSecondStep.Received().Track(ExpectedEventParameterToTrack);
                 }
+
+                [Fact, LogIfTooSlow]
+                public async Task TracksTheCorrectEvent()
+                {
+                    ViewModel.Dismiss();
+
+                    ExpectedEvent.Received().Track();
+                }
             }
 
             public sealed class WhenImpressionIsPositive : DismissMethodTest
@@ -305,6 +351,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 protected override bool ImpressionIsPositive => true;
                 protected override RatingViewOutcome ExpectedStorageOutcome => RatingViewOutcome.AppWasNotRated;
                 protected override RatingViewSecondStepOutcome ExpectedEventParameterToTrack => RatingViewSecondStepOutcome.AppWasNotRated;
+                protected override IAnalyticsEvent ExpectedEvent => AnalyticsService.RatingViewSecondStepDontRate;
             }
 
             public sealed class WhenImpressionIsNegative : DismissMethodTest
@@ -312,6 +359,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 protected override bool ImpressionIsPositive => false;
                 protected override RatingViewOutcome ExpectedStorageOutcome => RatingViewOutcome.FeedbackWasNotLeft;
                 protected override RatingViewSecondStepOutcome ExpectedEventParameterToTrack => RatingViewSecondStepOutcome.FeedbackWasNotLeft;
+                protected override IAnalyticsEvent ExpectedEvent => AnalyticsService.RatingViewSecondStepDontSendFeedback;
             }
 
             public sealed class TheIsFeedBackSuccessViewShowingProperty : RatingViewModelTest

--- a/Toggl.Foundation/Analytics/BaseAnalyticsService.cs
+++ b/Toggl.Foundation/Analytics/BaseAnalyticsService.cs
@@ -67,9 +67,6 @@ namespace Toggl.Foundation.Analytics
 
         [AnalyticsEvent("Source")]
         public IAnalyticsEvent<ProjectTagSuggestionSource> StartEntrySelectTag { get; protected set; }
-
-        [AnalyticsEvent]
-        public IAnalyticsEvent AppWasRated { get; protected set; }
       
         [AnalyticsEvent]
         public IAnalyticsEvent RatingViewWasShown { get; protected set; }
@@ -79,6 +76,24 @@ namespace Toggl.Foundation.Analytics
       
         [AnalyticsEvent("outcome")]
         public IAnalyticsEvent<RatingViewSecondStepOutcome> UserFinishedRatingViewSecondStep { get; protected set; }
+
+        [AnalyticsEvent]
+        public IAnalyticsEvent RatingViewFirstStepLike { get; protected set; }
+
+        [AnalyticsEvent]
+        public IAnalyticsEvent RatingViewFirstStepDislike { get; protected set; }
+
+        [AnalyticsEvent]
+        public IAnalyticsEvent RatingViewSecondStepRate { get; protected set; }
+        
+        [AnalyticsEvent]
+        public IAnalyticsEvent RatingViewSecondStepDontRate { get; protected set; }
+
+        [AnalyticsEvent]
+        public IAnalyticsEvent RatingViewSecondStepSendFeedback { get; protected set; }
+
+        [AnalyticsEvent]
+        public IAnalyticsEvent RatingViewSecondStepDontSendFeedback { get; protected set; }
 
         [AnalyticsEvent("Source", "TotalDays", "ProjectsNotSynced", "LoadingTime")]
         public IAnalyticsEvent<ReportsSource, int, int, double> ReportsSuccess { get; protected set; }

--- a/Toggl.Foundation/Analytics/IAnalyticsService.cs
+++ b/Toggl.Foundation/Analytics/IAnalyticsService.cs
@@ -31,14 +31,24 @@ namespace Toggl.Foundation.Analytics
         IAnalyticsEvent<Type> CurrentPage { get; }
 
         IAnalyticsEvent<TimeEntryStartOrigin> TimeEntryStarted { get; }
-
-        IAnalyticsEvent AppWasRated { get; }
       
         IAnalyticsEvent RatingViewWasShown { get; }
       
         IAnalyticsEvent<bool> UserFinishedRatingViewFirstStep { get; }
       
         IAnalyticsEvent<RatingViewSecondStepOutcome> UserFinishedRatingViewSecondStep { get; }
+
+        IAnalyticsEvent RatingViewFirstStepLike { get; }
+
+        IAnalyticsEvent RatingViewFirstStepDislike { get; }
+
+        IAnalyticsEvent RatingViewSecondStepRate { get; }
+
+        IAnalyticsEvent RatingViewSecondStepDontRate { get; }
+
+        IAnalyticsEvent RatingViewSecondStepSendFeedback { get; }
+
+        IAnalyticsEvent RatingViewSecondStepDontSendFeedback { get; }
 
         IAnalyticsEvent DeleteTimeEntry { get; }
 


### PR DESCRIPTION
## What's this?
This adds more rating view events. This was already done in 1.8.2 and released to users, so we better have the same change here too!

### Relationships
Cherry pick of #2987

## Why do we want this?
Because this was released with 1.8.2, while 1.9 was branched from 1.8.1 and we don't want to lose the events until 1.10 again.

## How is it done?
git fu

## Review hints
Make sure I didn't do git poo.

## :squid: Permissions
Whoever is handling 1.9.