### PR TITLE
Giskard 1.3.2 hotfix

### DIFF
--- a/Toggl.Giskard/Activities/AboutActivity.cs
+++ b/Toggl.Giskard/Activities/AboutActivity.cs
@@ -1,6 +1,5 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Support.V7.Widget;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -17,8 +16,6 @@ namespace Toggl.Giskard.Activities
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#2C2C2C"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.AboutActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_right, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/BrowserActivity.cs
+++ b/Toggl.Giskard/Activities/BrowserActivity.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Support.V7.Widget;
 using Android.Webkit;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 using Toggl.Multivac;
 using static Android.Support.V7.Widget.Toolbar;
 using static Toggl.Foundation.Resources;
@@ -25,8 +23,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#2C2C2C"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.BrowserActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_right, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/EditProjectActivity.cs
+++ b/Toggl.Giskard/Activities/EditProjectActivity.cs
@@ -1,22 +1,19 @@
 ﻿using System.Linq;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
 using Android.Support.V7.Widget;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 using Toggl.Giskard.Fragments;
 using static Android.Support.V7.Widget.Toolbar;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.BlueStatusBar",
               WindowSoftInputMode = SoftInput.AdjustResize,
               ScreenOrientation = ScreenOrientation.Portrait,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
@@ -24,8 +21,6 @@ namespace Toggl.Giskard.Activities
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.blueStatusBarBackground)));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.EditProjectActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/EditTimeEntryActivity.cs
+++ b/Toggl.Giskard/Activities/EditTimeEntryActivity.cs
@@ -1,9 +1,7 @@
 ﻿using System.Reactive.Disposables;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
 using Android.Views;
 using Android.Widget;
 using MvvmCross.Droid.Support.V7.AppCompat;
@@ -18,7 +16,7 @@ using static Toggl.Foundation.MvvmCross.Parameters.SelectTimeParameters.Origin;
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.BlueStatusBar",
               ScreenOrientation = ScreenOrientation.Portrait,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed partial class EditTimeEntryActivity : MvxAppCompatActivity<EditTimeEntryViewModel>, IReactiveBindingHolder
@@ -29,8 +27,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.blueStatusBarBackground)));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.EditTimeEntryActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);
@@ -43,13 +39,13 @@ namespace Toggl.Giskard.Activities
         {
             base.OnResume();
 
-            projectTooltip = projectTooltip 
+            projectTooltip = projectTooltip
                 ?? PopupWindowFactory.PopupWindowWithText(
                     this,
                     Resource.Layout.TooltipWithLeftTopArrow,
                     Resource.Id.TooltipText,
                     Resource.String.CategorizeWithProjects);
-            
+
             prepareOnboarding();
         }
 
@@ -66,9 +62,9 @@ namespace Toggl.Giskard.Activities
 
             new CategorizeTimeUsingProjectsOnboardingStep(storage, ViewModel.HasProject)
                 .ManageDismissableTooltip(
-                    projectTooltip, 
-                    projectContainer, 
-                    (window, view) => PopupOffsets.FromDp(16, 8, this), 
+                    projectTooltip,
+                    projectContainer,
+                    (window, view) => PopupOffsets.FromDp(16, 8, this),
                     storage)
                 .DisposedBy(DisposeBag);
         }

--- a/Toggl.Giskard/Activities/ForgotPasswordActivity.cs
+++ b/Toggl.Giskard/Activities/ForgotPasswordActivity.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Views;
 using Android.Widget;
@@ -16,7 +15,7 @@ using Toolbar = Android.Support.V7.Widget.Toolbar;
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.WhiteStatusBar",
         ScreenOrientation = ScreenOrientation.Portrait,
         WindowSoftInputMode = SoftInput.StateVisible,
         ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
@@ -28,8 +27,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.White, true);
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.ForgotPasswordActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_right, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/LoginActivity.cs
+++ b/Toggl.Giskard/Activities/LoginActivity.cs
@@ -1,8 +1,6 @@
-using System.Linq;
 using System.Reactive.Linq;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Views;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
@@ -13,7 +11,7 @@ using Toggl.Multivac;
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.WhiteStatusBar",
               ScreenOrientation = ScreenOrientation.Portrait,
               WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
@@ -21,8 +19,6 @@ namespace Toggl.Giskard.Activities
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.White, true);
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.LoginActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/MainActivity.cs
+++ b/Toggl.Giskard/Activities/MainActivity.cs
@@ -4,7 +4,6 @@ using System.Reactive.Disposables;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Support.Design.Widget;
 using Android.Views;
@@ -50,8 +49,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#2C2C2C"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.MainActivity);
             OverridePendingTransition(Resource.Animation.abc_fade_in, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/OnboardingActivity.cs
+++ b/Toggl.Giskard/Activities/OnboardingActivity.cs
@@ -1,26 +1,20 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.OnboardingStatusBarColor",
               ScreenOrientation = ScreenOrientation.Portrait,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class OnboardingActivity : MvxAppCompatActivity<OnboardingViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {
-            var statusBarColor = new Color(ContextCompat.GetColor(this, Resource.Color.onboardingStatusBarColor));
-            this.ChangeStatusBarColor(statusBarColor);
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.OnboardingActivity);
             OverridePendingTransition(Resource.Animation.abc_fade_in, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/OutdatedAppActivity.cs
+++ b/Toggl.Giskard/Activities/OutdatedAppActivity.cs
@@ -1,24 +1,20 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.OutdatedAppStatusBarColor",
               ScreenOrientation = ScreenOrientation.Portrait,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class OutdatedAppActivity : MvxAppCompatActivity<OutdatedAppViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#BDBDBD"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.OutdatedAppActivity);
             OverridePendingTransition(Resource.Animation.abc_fade_in, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/ReportsActivity.cs
+++ b/Toggl.Giskard/Activities/ReportsActivity.cs
@@ -1,12 +1,10 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Support.V7.Widget;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 using Toggl.Giskard.Views;
 
 namespace Toggl.Giskard.Activities
@@ -22,8 +20,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#2C2C2C"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.ReportsActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_right, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/SelectClientActivity.cs
+++ b/Toggl.Giskard/Activities/SelectClientActivity.cs
@@ -1,28 +1,21 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
-using Android.Support.V7.Widget;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
-using static Android.Support.V7.Widget.Toolbar;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.BlueStatusBar",
               ScreenOrientation = ScreenOrientation.Portrait,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class SelectClientActivity : MvxAppCompatActivity<SelectClientViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.blueStatusBarBackground)));
-            
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.SelectClientActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/SelectCountryActivity.cs
+++ b/Toggl.Giskard/Activities/SelectCountryActivity.cs
@@ -1,26 +1,21 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.WhiteStatusBarLightIcons",
         ScreenOrientation = ScreenOrientation.Portrait,
         ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class SelectCountryActivity : MvxAppCompatActivity<SelectCountryViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.lightToolbarBackground)));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.SelectCountryActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_right, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/SelectProjectActivity.cs
+++ b/Toggl.Giskard/Activities/SelectProjectActivity.cs
@@ -1,26 +1,21 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.BlueStatusBar",
         ScreenOrientation = ScreenOrientation.Portrait,
         ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class SelectProjectActivity : MvxAppCompatActivity<SelectProjectViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.blueStatusBarBackground)));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.SelectProjectActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/SelectTagsActivity.cs
+++ b/Toggl.Giskard/Activities/SelectTagsActivity.cs
@@ -1,27 +1,21 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
-using Android.Support.V7.Widget;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.BlueStatusBar",
         ScreenOrientation = ScreenOrientation.Portrait,
         ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class SelectTagsActivity : MvxAppCompatActivity<SelectTagsViewModel>
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.blueStatusBarBackground)));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.SelectTagsActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/SettingsActivity.cs
+++ b/Toggl.Giskard/Activities/SettingsActivity.cs
@@ -10,7 +10,6 @@ using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Giskard.Adapters;
 using Toggl.Giskard.Extensions;
 using Toggl.Giskard.ViewHolders;
-using Toggl.Multivac.Extensions;
 using Toolbar = Android.Support.V7.Widget.Toolbar;
 
 namespace Toggl.Giskard.Activities
@@ -23,8 +22,6 @@ namespace Toggl.Giskard.Activities
     {
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#2C2C2C"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.SettingsActivity);
 

--- a/Toggl.Giskard/Activities/SignUpActivity.cs
+++ b/Toggl.Giskard/Activities/SignUpActivity.cs
@@ -1,26 +1,22 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.WhiteStatusBar",
               ScreenOrientation = ScreenOrientation.Portrait,
               WindowSoftInputMode = SoftInput.AdjustPan | SoftInput.StateHidden,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
     public sealed class SignUpActivity : MvxAppCompatActivity<SignupViewModel>
     {
         protected override void OnCreate(Bundle bundle)
-        { 
-            this.ChangeStatusBarColor(Color.White, true);
-
+        {
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.SignUpActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/StartTimeEntryActivity.cs
+++ b/Toggl.Giskard/Activities/StartTimeEntryActivity.cs
@@ -2,30 +2,25 @@ using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
-using System.Threading;
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
-using Android.Support.V4.Content;
 using Android.Views;
 using Android.Widget;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.Autocomplete;
-using Toggl.Foundation.MvvmCross.Extensions;
 using Toggl.Foundation.MvvmCross.Onboarding.StartTimeEntryView;
 using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Giskard.Extensions;
 using Toggl.Giskard.Helper;
-using Toggl.Giskard.Views;
 using Toggl.Multivac.Extensions;
 using static Toggl.Foundation.MvvmCross.Parameters.SelectTimeParameters.Origin;
 
 namespace Toggl.Giskard.Activities
 {
     [MvxActivityPresentation]
-    [Activity(Theme = "@style/AppTheme",
+    [Activity(Theme = "@style/AppTheme.BlueStatusBar",
               ScreenOrientation = ScreenOrientation.Portrait,
               WindowSoftInputMode = SoftInput.StateVisible,
               ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
@@ -40,8 +35,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(new Color(ContextCompat.GetColor(this, Resource.Color.blueStatusBarBackground)));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.StartTimeEntryActivity);
             OverridePendingTransition(Resource.Animation.abc_slide_in_bottom, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Activities/TokenResetActivity.cs
+++ b/Toggl.Giskard/Activities/TokenResetActivity.cs
@@ -1,12 +1,10 @@
 ﻿using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
 using Android.OS;
 using Android.Support.V7.Widget;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using Toggl.Giskard.Extensions;
 using static Toggl.Foundation.Resources;
 
 namespace Toggl.Giskard.Activities
@@ -21,8 +19,6 @@ namespace Toggl.Giskard.Activities
 
         protected override void OnCreate(Bundle bundle)
         {
-            this.ChangeStatusBarColor(Color.ParseColor("#2C2C2C"));
-
             base.OnCreate(bundle);
             SetContentView(Resource.Layout.TokenResetActivity);
             OverridePendingTransition(Resource.Animation.abc_fade_in, Resource.Animation.abc_fade_out);

--- a/Toggl.Giskard/Properties/AndroidManifest.xml
+++ b/Toggl.Giskard/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="987654321" android:versionName="1.3" package="com.toggl.giskard.debug">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="987654321" android:versionName="1.3.2" package="com.toggl.giskard.debug">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="27" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />

--- a/Toggl.Giskard/Resources/values-v23/Styles.xml
+++ b/Toggl.Giskard/Resources/values-v23/Styles.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <style name="AppTheme.WhiteStatusBar">
+        <item name="android:statusBarColor">@android:color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>

--- a/Toggl.Giskard/Resources/values/Styles.xml
+++ b/Toggl.Giskard/Resources/values/Styles.xml
@@ -9,7 +9,34 @@
         <item name="android:windowDisablePreview">true</item>
         <item name="android:colorAccent">#328FFF</item>
         <item name="colorControlActivated">#328FFF</item>
+        <item name="android:statusBarColor">#2C2C2C</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
     </style>
+
+    <style name="AppTheme.BlueStatusBar">
+        <item name="android:statusBarColor">@color/blueStatusBarBackground</item>
+    </style>
+
+    <style name="AppTheme.WhiteStatusBar">
+    </style>
+
+    <style name="AppTheme.WhiteStatusBarLightIcons">
+        <item name="android:statusBarColor">@android:color/white</item>
+    </style>
+
+    <style name="AppTheme.LighGrayStatusBar">
+        <item name="android:statusBarColor">@color/lightGray</item>
+    </style>
+    
+    <style name="AppTheme.OnboardingStatusBarColor">
+        <item name="android:statusBarColor">@color/onboardingStatusBarColor</item>
+    </style>
+
+    <style name="AppTheme.OutdatedAppStatusBarColor">
+        <item name="android:statusBarColor">#BDBDBD</item>
+    </style>
+    
     <style name="AppTheme.TransparentActionBar">
         <item name="windowActionBarOverlay">true</item>
         <item name="android:windowActionBarOverlay">true</item>

--- a/Toggl.Giskard/Startup/Setup.cs
+++ b/Toggl.Giskard/Startup/Setup.cs
@@ -115,6 +115,8 @@ namespace Toggl.Giskard
 
             foundation.RevokeNewUserIfNeeded().Initialize();
 
+            ensureDataSourceInitializationIfLoggedIn();
+
             base.InitializeApp(pluginManager, app);
         }
 
@@ -124,6 +126,19 @@ namespace Toggl.Giskard
             var activityLifecycleCallbacksManager = new QueryableMvxLifecycleMonitorCurrentTopActivity();
             mvxApplication.RegisterActivityLifecycleCallbacks(activityLifecycleCallbacksManager);
             return activityLifecycleCallbacksManager;
+        }
+
+        private void ensureDataSourceInitializationIfLoggedIn()
+        {
+            /* Why? The ITogglDataSource is lazily initialized by the login manager
+             * during some of it's methods calls.
+             * The App.cs code that makes those calls don't have time to
+             * do so during rehydration and on starup on some phones.
+             * This call makes sure the ITogglDataSource singleton is registered
+             * and ready to be injected during those times.
+             */
+            var loginManager = Mvx.Resolve<ILoginManager>();
+            var dataSource = loginManager.GetDataSourceIfLoggedIn();
         }
     }
 }

--- a/Toggl.Giskard/Startup/SplashScreen.cs
+++ b/Toggl.Giskard/Startup/SplashScreen.cs
@@ -1,14 +1,10 @@
 using Android.App;
 using Android.Content.PM;
-using Android.Graphics;
-using Android.Support.V4.Content;
-using Toggl.Giskard.Extensions;
 using Android.OS;
 using Toggl.Foundation.MvvmCross;
 using Toggl.Foundation.MvvmCross.ViewModels;
 using MvvmCross;
 using MvvmCross.Droid.Support.V7.AppCompat;
-using MvvmCross.Platforms.Android.Core;
 using MvvmCross.Navigation;
 
 namespace Toggl.Giskard
@@ -40,17 +36,6 @@ namespace Toggl.Giskard
                 return;
 
             Mvx.Resolve<IMvxNavigationService>().Navigate(navigationUrl);
-        }
-
-        protected override void OnCreate(Bundle bundle)
-        {
-            var MvxSetup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
-            MvxSetup.EnsureInitialized();
-
-            base.OnCreate(bundle);
-
-            var statusBarColor = new Color(ContextCompat.GetColor(this, Resource.Color.lightGray));
-            this.ChangeStatusBarColor(statusBarColor);
         }
     }
 }

--- a/Toggl.Giskard/Startup/SplashScreen.cs
+++ b/Toggl.Giskard/Startup/SplashScreen.cs
@@ -6,8 +6,9 @@ using Toggl.Giskard.Extensions;
 using Android.OS;
 using Toggl.Foundation.MvvmCross;
 using Toggl.Foundation.MvvmCross.ViewModels;
-using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross;
+using MvvmCross.Droid.Support.V7.AppCompat;
+using MvvmCross.Platforms.Android.Core;
 using MvvmCross.Navigation;
 
 namespace Toggl.Giskard
@@ -23,7 +24,7 @@ namespace Toggl.Giskard
         Categories = new[] { "android.intent.category.BROWSABLE", "android.intent.category.DEFAULT" },
         DataSchemes = new[] { "toggl" },
         DataHost = "*")]
-    public class SplashScreen : MvxSplashScreenAppCompatActivity
+    public class SplashScreen : MvxSplashScreenAppCompatActivity<Setup, App<LoginViewModel>>
     {
         public SplashScreen()
             : base(Resource.Layout.SplashScreen)
@@ -43,6 +44,9 @@ namespace Toggl.Giskard
 
         protected override void OnCreate(Bundle bundle)
         {
+            var MvxSetup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext);
+            MvxSetup.EnsureInitialized();
+
             base.OnCreate(bundle);
 
             var statusBarColor = new Color(ContextCompat.GetColor(this, Resource.Color.lightGray));

--- a/Toggl.Giskard/Toggl.Giskard.csproj
+++ b/Toggl.Giskard/Toggl.Giskard.csproj
@@ -494,6 +494,7 @@
     <AndroidResource Include="Resources\layout\OnboardingActivity.axml" />
     <AndroidResource Include="Resources\layout\LoginActivity.axml" />
     <AndroidResource Include="Resources\values\Styles.xml" />
+    <AndroidResource Include="Resources\values-v23\Styles.xml" />
     <AndroidResource Include="Resources\layout\SplashScreen.axml" />
     <AndroidResource Include="Resources\drawable-hdpi\arrow_back.png" />
     <AndroidResource Include="Resources\drawable-hdpi\billable.png" />


### PR DESCRIPTION
## What's this?
This is another attempt to fix the startup crashes on giskard

### Relationships
This undoes what was done on giskard-1.3.1-hotfix.

Closes #2923

## Why do we want this?
Because it stops our startup crashes o/

## How is it done?
1. The calls to `ChangeStatusBarColor` were all removed in favour to xml theming configuration.
2. The method `ensureDataSourceInitializationIfLoggedIn` was added to giskard's setup. This makes sure the ITogglDataSource is registered on the Mvx IoC handler. This removes the second crash unveiled by (1). More on #2932
 
### Why not another way?
We could do 
```
var mvxSetup = MvxAndroidSetupSingleton.EnsureSingletonAvailable(ApplicationContext); mvxSetup.EnsureInitialized();
```
before each call to `ChangeStatusBarColor` on every activity that uses it. But that's just ugly. Using xml to configure themes is the standard way of doing this kind of stuff on Android. We were not doing anything magical there, xml is fine for that.

### Side effects
Rehydration will take more time execute, but it works.
The initial startup should be a tad slower because of the `ensureDataSourceInitializationIfLoggedIn` call.

This will unveil other bugs related to rehydration, now the app shouldn't crash before the activities can be resumed, ViewModel saving and restoring has to be done at some point.

## Review hints
Enable `Don't keep activities` and set `Limit background processes` to `No background processes` and you should be able to cause tombstoning basically every time you change screens.

With that configuration done, you should see some bugs/crashes when creating TEs, Projects, Clients, etc.

Disable the said configurations and you should able to use the app as it was before, no crashes and all status bars still have their right colours, pre-lollipop inclusive.
 
## :squid: Permissions
Don't. I'm not sure I did the right branching/PR process here. I'll wait for @amulware for some guidance. Also `giskard-1.3.1-hotfix` is @dshr's.