### PR TITLE
Add idle/running notification settings

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/Settings/SettingsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Settings/SettingsViewModel.cs
@@ -270,26 +270,14 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public void ToggleRunningTimerNotifications()
         {
-            if (userPreferences.AreRunningTimerNotificationsEnabled)
-            {
-                userPreferences.DisableRunningTimerNotifications();
-            }
-            else
-            {
-                userPreferences.EnableRunningTimerNotifications();
-            }
+            var newState = !userPreferences.AreRunningTimerNotificationsEnabled;
+            userPreferences.SetRunningTimerNotifications(newState);
         }
 
         public void ToggleStoppedTimerNotifications()
         {
-            if (userPreferences.AreStoppedTimerNotificationsEnabled)
-            {
-                userPreferences.DisableStoppedTimerNotifications();
-            }
-            else
-            {
-                userPreferences.EnableStoppedTimerNotifications();
-            }
+            var newState = !userPreferences.AreStoppedTimerNotificationsEnabled;
+            userPreferences.SetStoppedTimerNotifications(newState);
         }
 
         public async Task TryLogout()

--- a/Toggl.Foundation.MvvmCross/ViewModels/Settings/SettingsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Settings/SettingsViewModel.cs
@@ -77,6 +77,10 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public IObservable<bool> IsManualModeEnabled { get; }
 
+        public IObservable<bool> AreRunningTimerNotificationsEnabled { get; }
+
+        public IObservable<bool> AreStoppedTimerNotificationsEnabled { get; }
+
         public IObservable<bool> UseTwentyFourHourFormat { get; }
 
         public IObservable<IList<SelectableWorkspaceViewModel>> Workspaces { get; }
@@ -140,6 +144,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                     .DistinctUntilChanged();
 
             IsManualModeEnabled = userPreferences.IsManualModeEnabledObservable;
+            AreRunningTimerNotificationsEnabled = userPreferences.AreRunningTimerNotificationsEnabledObservable;
+            AreStoppedTimerNotificationsEnabled = userPreferences.AreStoppedTimerNotificationsEnabledObservable;
 
             WorkspaceName =
                 dataSource.User.Current
@@ -259,6 +265,30 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             else
             {
                 userPreferences.EnableManualMode();
+            }
+        }
+
+        public void ToggleRunningTimerNotifications()
+        {
+            if (userPreferences.AreRunningTimerNotificationsEnabled)
+            {
+                userPreferences.DisableRunningTimerNotifications();
+            }
+            else
+            {
+                userPreferences.EnableRunningTimerNotifications();
+            }
+        }
+
+        public void ToggleStoppedTimerNotifications()
+        {
+            if (userPreferences.AreStoppedTimerNotificationsEnabled)
+            {
+                userPreferences.DisableStoppedTimerNotifications();
+            }
+            else
+            {
+                userPreferences.EnableStoppedTimerNotifications();
             }
         }
 

--- a/Toggl.Giskard/Activities/SettingsActivity.ViewBinds.cs
+++ b/Toggl.Giskard/Activities/SettingsActivity.ViewBinds.cs
@@ -12,6 +12,8 @@ namespace Toggl.Giskard.Activities
         private View logoutView;
         private View feedbackView;
         private View manualModeView;
+        private View runningTimerNotificationsView;
+        private View stoppedTimerNotificationsView;
         private View avatarContainer;
         private View beginningOfWeekView;
 
@@ -23,6 +25,8 @@ namespace Toggl.Giskard.Activities
         private ImageView avatarView;
 
         private Switch manualModeSwitch;
+        private Switch runningTimerNotificationsSwitch;
+        private Switch stoppedTimerNotificationsSwitch;
 
         private RecyclerView workspacesRecyclerView;
 
@@ -35,6 +39,8 @@ namespace Toggl.Giskard.Activities
             manualModeView = FindViewById(Resource.Id.SettingsToggleManualModeView);
             avatarContainer = FindViewById(Resource.Id.SettingsViewAvatarImageContainer);
             beginningOfWeekView = FindViewById(Resource.Id.SettingsSelectBeginningOfWeekView);
+            runningTimerNotificationsView = FindViewById(Resource.Id.SettingsRunningTimerNotificationsView);
+            stoppedTimerNotificationsView = FindViewById(Resource.Id.SettingsStoppedTimerNotificationsView);
 
             nameTextView = FindViewById<TextView>(Resource.Id.SettingsNameTextView);
             emailTextView = FindViewById<TextView>(Resource.Id.SettingsEmailTextView);
@@ -43,6 +49,8 @@ namespace Toggl.Giskard.Activities
 
             avatarView = FindViewById<ImageView>(Resource.Id.SettingsViewAvatarImage);
             manualModeSwitch = FindViewById<Switch>(Resource.Id.SettingsIsManualModeEnabledSwitch);
+            runningTimerNotificationsSwitch = FindViewById<Switch>(Resource.Id.SettingsAreRunningTimerNotificationsEnabledSwitch);
+            stoppedTimerNotificationsSwitch = FindViewById<Switch>(Resource.Id.SettingsAreStoppedTimerNotificationsEnabledSwitch);
 
             workspacesRecyclerView = FindViewById<RecyclerView>(Resource.Id.SettingsWorkspacesRecyclerView);
         }

--- a/Toggl.Giskard/Activities/SettingsActivity.cs
+++ b/Toggl.Giskard/Activities/SettingsActivity.cs
@@ -43,6 +43,8 @@ namespace Toggl.Giskard.Activities
             this.Bind(ViewModel.Email, emailTextView.BindText());
             this.Bind(ViewModel.Workspaces, adapter.BindItems());
             this.Bind(ViewModel.IsManualModeEnabled, manualModeSwitch.BindChecked());
+            this.Bind(ViewModel.AreRunningTimerNotificationsEnabled, runningTimerNotificationsSwitch.BindChecked());
+            this.Bind(ViewModel.AreStoppedTimerNotificationsEnabled, stoppedTimerNotificationsSwitch.BindChecked());
             this.Bind(ViewModel.BeginningOfWeek, beginningOfWeekTextView.BindText());
             this.Bind(ViewModel.UserAvatar.Select(userImageFromBytes), bitmap =>
             {
@@ -55,6 +57,8 @@ namespace Toggl.Giskard.Activities
             this.Bind(aboutView.Tapped(), ViewModel.OpenAboutView);
             this.Bind(feedbackView.Tapped(), ViewModel.SubmitFeedbackUsingEmail);
             this.BindVoid(manualModeView.Tapped(), ViewModel.ToggleManualMode);
+            this.BindVoid(runningTimerNotificationsView.Tapped(), ViewModel.ToggleRunningTimerNotifications);
+            this.BindVoid(stoppedTimerNotificationsView.Tapped(), ViewModel.ToggleStoppedTimerNotifications);
             this.Bind(beginningOfWeekView.Tapped(), ViewModel.SelectBeginningOfWeek);
 
             setupToolbar();

--- a/Toggl.Giskard/Resources/layout/SettingsActivity.axml
+++ b/Toggl.Giskard/Resources/layout/SettingsActivity.axml
@@ -180,6 +180,78 @@
                 android:paddingLeft="16dp"
                 android:textAllCaps="true"
                 android:letterSpacing="0.04"
+                android:text="@string/Notifications"
+                android:gravity="center_vertical"
+                android:fontFamily="sans-serif-medium"
+                android:textColor="@color/defaultText"
+                android:layout_height="48dp"
+                android:layout_marginTop="24dp"
+                android:layout_width="match_parent" />
+            <View
+                android:background="@color/separator"
+                android:layout_height="0.5dp"
+                android:layout_width="match_parent" />
+            <FrameLayout
+                android:id="@+id/SettingsRunningTimerNotificationsView"
+                android:clickable="true"
+                android:background="?attr/selectableItemBackground"
+                android:layout_height="48dp"
+                android:layout_width="match_parent">
+                <TextView
+                    android:textSize="15sp"
+                    android:textAllCaps="false"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical"
+                    android:text="@string/NotificationsRunningTimer"
+                    android:textColor="@android:color/black"
+                    android:layout_gravity="start"
+                    android:layout_height="match_parent"
+                    android:layout_width="wrap_content" />
+                <Switch
+                    android:id="@+id/SettingsAreRunningTimerNotificationsEnabledSwitch"
+                    android:clickable="false"
+                    android:paddingRight="18dp"
+                    android:layout_gravity="right"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent" />
+            </FrameLayout>
+            <View
+                android:background="@color/separator"
+                android:layout_height="0.5dp"
+                android:layout_width="match_parent" />
+            <FrameLayout
+                android:id="@+id/SettingsStoppedTimerNotificationsView"
+                android:clickable="true"
+                android:background="?attr/selectableItemBackground"
+                android:layout_height="48dp"
+                android:layout_width="match_parent">
+                <TextView
+                    android:textSize="15sp"
+                    android:textAllCaps="false"
+                    android:lineSpacingExtra="5sp"
+                    android:gravity="center_vertical"
+                    android:text="@string/NotificationsStoppedTimer"
+                    android:textColor="@android:color/black"
+                    android:layout_marginLeft="16dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent" />
+                <Switch
+                    android:id="@+id/SettingsAreStoppedTimerNotificationsEnabledSwitch"
+                    android:clickable="false"
+                    android:layout_gravity="right"
+                    android:layout_marginRight="18dp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent" />
+            </FrameLayout>
+            <View
+                android:background="@color/separator"
+                android:layout_height="0.5dp"
+                android:layout_width="match_parent" />
+            <TextView
+                android:textSize="12sp"
+                android:paddingLeft="16dp"
+                android:textAllCaps="true"
+                android:letterSpacing="0.04"
                 android:text="@string/General"
                 android:gravity="center_vertical"
                 android:fontFamily="sans-serif-medium"

--- a/Toggl.Giskard/Resources/values/Strings.xml
+++ b/Toggl.Giskard/Resources/values/Strings.xml
@@ -83,6 +83,9 @@ your app to continue.</string>
     <string name="ReviewTheTerms">Review the Terms</string>
     <string name="TermsMessage">By tapping "I Agree", you
 understand and agree to Toggl\'s</string>
+    <string name="Notifications">Notifications</string>
+    <string name="NotificationsRunningTimer">Running timer</string>
+    <string name="NotificationsStoppedTimer">Stopped timer</string>
     <string name="NothingHere">Nothing here</string>
     <string name="NoTimeEntries">You have no time entries\nfor selected time period.</string>
     <string name="AboutTermsOfService">Terms of Service</string>

--- a/Toggl.PrimeRadiant/Settings/IUserPreferences.cs
+++ b/Toggl.PrimeRadiant/Settings/IUserPreferences.cs
@@ -6,11 +6,27 @@ namespace Toggl.PrimeRadiant.Settings
     {
         IObservable<bool> IsManualModeEnabledObservable { get; }
 
+        IObservable<bool> AreRunningTimerNotificationsEnabledObservable { get; }
+
+        IObservable<bool> AreStoppedTimerNotificationsEnabledObservable { get; }
+
         bool IsManualModeEnabled { get; }
+
+        bool AreRunningTimerNotificationsEnabled { get; }
+
+        bool AreStoppedTimerNotificationsEnabled { get; }
 
         void EnableManualMode();
 
         void EnableTimerMode();
+
+        void EnableRunningTimerNotifications();
+
+        void DisableRunningTimerNotifications();
+
+        void EnableStoppedTimerNotifications();
+
+        void DisableStoppedTimerNotifications();
 
         void Reset();
     }

--- a/Toggl.PrimeRadiant/Settings/IUserPreferences.cs
+++ b/Toggl.PrimeRadiant/Settings/IUserPreferences.cs
@@ -20,13 +20,9 @@ namespace Toggl.PrimeRadiant.Settings
 
         void EnableTimerMode();
 
-        void EnableRunningTimerNotifications();
+        void SetRunningTimerNotifications(bool state);
 
-        void DisableRunningTimerNotifications();
-
-        void EnableStoppedTimerNotifications();
-
-        void DisableStoppedTimerNotifications();
+        void SetStoppedTimerNotifications(bool state);
 
         void Reset();
     }

--- a/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
+++ b/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
@@ -19,6 +19,8 @@ namespace Toggl.PrimeRadiant.Settings
         private const string completedOnboardingKey = "CompletedOnboarding";
 
         private const string preferManualModeKey = "PreferManualMode";
+        private const string runningTimerNotificationsKey = "RunningTimerNotifications";
+        private const string stoppedTimerNotificationsKey = "StoppedTimerNotifications";
 
         private const string startButtonWasTappedBeforeKey = "StartButtonWasTappedBefore";
         private const string hasTappedTimeEntryKey = "HasTappedTimeEntry";
@@ -51,6 +53,8 @@ namespace Toggl.PrimeRadiant.Settings
         private readonly ISubject<bool> stopButtonWasTappedSubject;
         private readonly ISubject<bool> hasSelectedProjectSubject;
         private readonly ISubject<bool> isManualModeEnabledSubject;
+        private readonly ISubject<bool> areRunningTimerNotificationsEnabledSubject;
+        private readonly ISubject<bool> areStoppedTimerNotificationsEnabledSubject;
         private readonly ISubject<bool> navigatedAwayFromMainViewAfterTappingStopButtonSubject;
         private readonly ISubject<bool> hasTimeEntryBeenContinuedSubject;
 
@@ -63,6 +67,8 @@ namespace Toggl.PrimeRadiant.Settings
 
             (isNewUserSubject, IsNewUser) = prepareSubjectAndObservable(isNewUserKey);
             (isManualModeEnabledSubject, IsManualModeEnabledObservable) = prepareSubjectAndObservable(preferManualModeKey);
+            (areRunningTimerNotificationsEnabledSubject, AreRunningTimerNotificationsEnabledObservable) = prepareSubjectAndObservable(runningTimerNotificationsKey);
+            (areStoppedTimerNotificationsEnabledSubject, AreStoppedTimerNotificationsEnabledObservable) = prepareSubjectAndObservable(stoppedTimerNotificationsKey);
             (hasTappedTimeEntrySubject, HasTappedTimeEntry) = prepareSubjectAndObservable(hasTappedTimeEntryKey);
             (hasEditedTimeEntrySubject, HasEditedTimeEntry) = prepareSubjectAndObservable(hasEditedTimeEntryKey);
             (hasSelectedProjectSubject, HasSelectedProject) = prepareSubjectAndObservable(hasSelectedProjectKey);
@@ -293,9 +299,17 @@ namespace Toggl.PrimeRadiant.Settings
         #region IUserPreferences
 
         public IObservable<bool> IsManualModeEnabledObservable { get; }
+        public IObservable<bool> AreRunningTimerNotificationsEnabledObservable { get; }
+        public IObservable<bool> AreStoppedTimerNotificationsEnabledObservable { get; }
 
         public bool IsManualModeEnabled
             => keyValueStorage.GetBool(preferManualModeKey);
+
+        public bool AreRunningTimerNotificationsEnabled
+            => keyValueStorage.GetBool(runningTimerNotificationsKey);
+
+        public bool AreStoppedTimerNotificationsEnabled
+            => keyValueStorage.GetBool(stoppedTimerNotificationsKey);
 
         public void EnableManualMode()
         {
@@ -309,9 +323,35 @@ namespace Toggl.PrimeRadiant.Settings
             isManualModeEnabledSubject.OnNext(false);
         }
 
+        public void EnableRunningTimerNotifications()
+        {
+            keyValueStorage.SetBool(runningTimerNotificationsKey, true);
+            areRunningTimerNotificationsEnabledSubject.OnNext(true);
+        }
+
+        public void DisableRunningTimerNotifications()
+        {
+            keyValueStorage.SetBool(runningTimerNotificationsKey, false);
+            areRunningTimerNotificationsEnabledSubject.OnNext(false);
+        }
+
+        public void EnableStoppedTimerNotifications()
+        {
+            keyValueStorage.SetBool(stoppedTimerNotificationsKey, true);
+            areStoppedTimerNotificationsEnabledSubject.OnNext(true);
+        }
+
+        public void DisableStoppedTimerNotifications()
+        {
+            keyValueStorage.SetBool(stoppedTimerNotificationsKey, false);
+            areStoppedTimerNotificationsEnabledSubject.OnNext(false);
+        }
+
         void IUserPreferences.Reset()
         {
             EnableTimerMode();
+            DisableStoppedTimerNotifications();
+            DisableRunningTimerNotifications();
             isManualModeEnabledSubject.OnNext(false);
         }
 

--- a/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
+++ b/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
@@ -323,35 +323,23 @@ namespace Toggl.PrimeRadiant.Settings
             isManualModeEnabledSubject.OnNext(false);
         }
 
-        public void EnableRunningTimerNotifications()
+        public void SetRunningTimerNotifications(bool state)
         {
-            keyValueStorage.SetBool(runningTimerNotificationsKey, true);
-            areRunningTimerNotificationsEnabledSubject.OnNext(true);
+            keyValueStorage.SetBool(runningTimerNotificationsKey, state);
+            areRunningTimerNotificationsEnabledSubject.OnNext(state);
         }
 
-        public void DisableRunningTimerNotifications()
+        public void SetStoppedTimerNotifications(bool state)
         {
-            keyValueStorage.SetBool(runningTimerNotificationsKey, false);
-            areRunningTimerNotificationsEnabledSubject.OnNext(false);
-        }
-
-        public void EnableStoppedTimerNotifications()
-        {
-            keyValueStorage.SetBool(stoppedTimerNotificationsKey, true);
-            areStoppedTimerNotificationsEnabledSubject.OnNext(true);
-        }
-
-        public void DisableStoppedTimerNotifications()
-        {
-            keyValueStorage.SetBool(stoppedTimerNotificationsKey, false);
-            areStoppedTimerNotificationsEnabledSubject.OnNext(false);
+            keyValueStorage.SetBool(stoppedTimerNotificationsKey, state);
+            areStoppedTimerNotificationsEnabledSubject.OnNext(state);
         }
 
         void IUserPreferences.Reset()
         {
             EnableTimerMode();
-            DisableStoppedTimerNotifications();
-            DisableRunningTimerNotifications();
+            SetStoppedTimerNotifications(false);
+            SetRunningTimerNotifications(false);
             isManualModeEnabledSubject.OnNext(false);
         }
 


### PR DESCRIPTION
## What's this?
We're adding the running timer/stopped timer notifications from the old app. This is the first step, where we add the settings checkboxes for them.

### Relationships
Closes #3054

## Why do we want this?
So the users can turn them on and off.

## How is it done?
By adding the appropriate fields to the `SettingsStorage` in `PrimeRadiant`

### Why not another way?
This is the simplest way tbh.

### Side effects
None that I've noticed.

## Review hints
Go to settings, click the switches around; close the app, open it — they should be there; log out — the settings should be forgotten.

## :squid: Permissions
All yours!