### PR TITLE
⏰ handle stop timer intent when user invoke by tapping

### DIFF
--- a/Toggl.Daneel/Startup/AppDelegate.cs
+++ b/Toggl.Daneel/Startup/AppDelegate.cs
@@ -1,11 +1,14 @@
 using System;
 using Foundation;
+using Intents;
 using MvvmCross;
 using MvvmCross.Navigation;
 using MvvmCross.Platforms.Ios.Core;
 using MvvmCross.Plugin.Color.Platforms.Ios;
 using MvvmCross.ViewModels;
 using Toggl.Daneel.Extensions;
+using Toggl.Daneel.Intents;
+using Toggl.Foundation;
 using Toggl.Foundation.Analytics;
 using Toggl.Foundation.Interactors;
 using Toggl.Foundation.MvvmCross;
@@ -134,6 +137,21 @@ namespace Toggl.Daneel
                     navigationService.Navigate<MainViewModel>();
                     navigationService.Navigate<StartTimeEntryViewModel>();
                     break;
+            }
+        }
+
+        public override bool ContinueUserActivity(UIApplication application, NSUserActivity userActivity,
+            UIApplicationRestorationHandler completionHandler)
+        {
+            var intent = userActivity.GetInteraction()?.Intent;
+
+            switch (intent)
+            {
+                case StopTimerIntent _:
+                    navigationService.Navigate(ApplicationUrls.Main.StopTimeEntry);
+                    return true;
+                default:
+                    return false;
             }
         }
 


### PR DESCRIPTION
## What's this?
There are 2 ways to invoke a siri intent, by speaking to Siri, and by tapping the Shortcut, this PR will handle the case
when user taps it

### Relationships
<!-- Mention any issues or PRs that are connected to this -->

Closes #3153

## Why do we want this?
Cover all the cases

## How is it done?
By open the "stop deeplink" when manually invoking intent

### Why not another way?
This is probably the easiest way.

### Side effects
Not that I know of.

## Review hints
- Start a time entry
- Invoke the stop shortcut by tapping on it

## :squid: Permissions
Anyone