### PR TITLE
Prevent notification sounds in Oreo/Pie

### DIFF
--- a/Toggl.Giskard/Extensions/ActivityExtensions.cs
+++ b/Toggl.Giskard/Extensions/ActivityExtensions.cs
@@ -74,7 +74,7 @@ namespace Toggl.Giskard.Extensions
         {
             if (OreoApis.AreAvailable)
             {
-                var channel = new NotificationChannel(defaultChannelId, defaultChannelName, NotificationImportance.Default);
+                var channel = new NotificationChannel(defaultChannelId, defaultChannelName, NotificationImportance.Low);
                 channel.Description = defaultChannelDescription;
                 channel.EnableVibration(false);
                 channel.SetVibrationPattern(noNotificationVibrationPattern);


### PR DESCRIPTION
## What's this?

Fixes the Oreo problems with notification emitting the sound.
Please take a look at the issue to properly understand this solution.

### Relationships
Closes #3275 

## Why do we want this?
Cause the sounds are annoying for these notifications.

## How is it done?
Read the issue to understand.

### Why not another way?
Because Google thinks it's better to work on a new Pixel phone than fix their own bugs.

### Side effects
Zilch.

## Review hints
Read the issue!!!

## :squid: Permissions
Yeah, whatever.