### PR TITLE
Add suggestions setting in the options screen

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
@@ -48,6 +48,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
         public IObservable<IThreadSafeTimeEntry> CurrentRunningTimeEntry { get; private set; }
         public IObservable<bool> ShouldShowRunningTimeEntryNotification { get; private set; }
         public IObservable<bool> ShouldShowStoppedTimeEntryNotification { get; private set; }
+        public IObservable<bool> IsShowingSuggestions { get; private set; }
 
         public TimeSpan CurrentTimeEntryElapsedTime { get; private set; } = TimeSpan.Zero;
         public DurationFormat CurrentTimeEntryElapsedTimeFormat { get; } = DurationFormat.Improved;
@@ -221,6 +222,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             ShouldShowRunningTimeEntryNotification = userPreferences.AreRunningTimerNotificationsEnabledObservable;
             ShouldShowStoppedTimeEntryNotification = userPreferences.AreStoppedTimerNotificationsEnabledObservable;
+
+            IsShowingSuggestions = userPreferences.IsShowingSuggestionsObservable;
 
             CurrentRunningTimeEntry = dataSource
                 .TimeEntries

--- a/Toggl.Foundation.MvvmCross/ViewModels/Settings/SettingsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Settings/SettingsViewModel.cs
@@ -74,6 +74,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
         public IObservable<string> DurationFormat { get; }
 
         public IObservable<string> BeginningOfWeek { get; }
+       
+        public IObservable<bool> IsShowingSuggestions { get; }
 
         public IObservable<bool> IsManualModeEnabled { get; }
 
@@ -146,6 +148,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             IsManualModeEnabled = userPreferences.IsManualModeEnabledObservable;
             AreRunningTimerNotificationsEnabled = userPreferences.AreRunningTimerNotificationsEnabledObservable;
             AreStoppedTimerNotificationsEnabled = userPreferences.AreStoppedTimerNotificationsEnabledObservable;
+            IsShowingSuggestions = userPreferences.IsShowingSuggestionsObservable;
 
             WorkspaceName =
                 dataSource.User.Current
@@ -266,6 +269,12 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             {
                 userPreferences.EnableManualMode();
             }
+        }
+
+        public void ToggleShowingSuggestions()
+        {
+            var newState = !userPreferences.IsShowingSuggestions;
+            userPreferences.SetIsShowingSuggestions(newState);
         }
 
         public void ToggleRunningTimerNotifications()

--- a/Toggl.Giskard/Activities/MainActivity.cs
+++ b/Toggl.Giskard/Activities/MainActivity.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
@@ -12,6 +13,7 @@ using Android.Support.V7.Widget.Helper;
 using Android.Views;
 using MvvmCross.Droid.Support.V7.AppCompat;
 using MvvmCross.Platforms.Android.Presenters.Attributes;
+using Toggl.Foundation.MvvmCross.Collections.Changes;
 using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Foundation.Sync;
 using Toggl.Giskard.Adapters;
@@ -82,6 +84,11 @@ namespace Toggl.Giskard.Activities
                 .IsTimeEntryRunning
                 .ObserveOn(SynchronizationContext.Current);
             this.Bind(isTimeEntryRunning, updateRecyclerViewPadding);
+
+            var isShowingSuggestions = ViewModel
+                .IsShowingSuggestions
+                .ObserveOn(SynchronizationContext.Current);
+            this.Bind(isShowingSuggestions, mainRecyclerAdapter.UpdateShowingSuggestions);
 
             notificationManager = GetSystemService(NotificationService) as NotificationManager;
             this.BindRunningTimeEntry(notificationManager, ViewModel.CurrentRunningTimeEntry, ViewModel.ShouldShowRunningTimeEntryNotification);

--- a/Toggl.Giskard/Activities/SettingsActivity.ViewBinds.cs
+++ b/Toggl.Giskard/Activities/SettingsActivity.ViewBinds.cs
@@ -16,6 +16,7 @@ namespace Toggl.Giskard.Activities
         private View stoppedTimerNotificationsView;
         private View avatarContainer;
         private View beginningOfWeekView;
+        private View isShowingSuggestionsView;
 
         private TextView nameTextView;
         private TextView emailTextView;
@@ -27,6 +28,7 @@ namespace Toggl.Giskard.Activities
         private Switch manualModeSwitch;
         private Switch runningTimerNotificationsSwitch;
         private Switch stoppedTimerNotificationsSwitch;
+        private Switch isShowingSuggestionsSwitch;
 
         private RecyclerView workspacesRecyclerView;
 
@@ -51,6 +53,9 @@ namespace Toggl.Giskard.Activities
             manualModeSwitch = FindViewById<Switch>(Resource.Id.SettingsIsManualModeEnabledSwitch);
             runningTimerNotificationsSwitch = FindViewById<Switch>(Resource.Id.SettingsAreRunningTimerNotificationsEnabledSwitch);
             stoppedTimerNotificationsSwitch = FindViewById<Switch>(Resource.Id.SettingsAreStoppedTimerNotificationsEnabledSwitch);
+
+            isShowingSuggestionsView = FindViewById(Resource.Id.SettingsShowSuggestions);
+            isShowingSuggestionsSwitch = FindViewById<Switch>(Resource.Id.SettingsIsShowingSuggestionsSwitch);
 
             workspacesRecyclerView = FindViewById<RecyclerView>(Resource.Id.SettingsWorkspacesRecyclerView);
         }

--- a/Toggl.Giskard/Activities/SettingsActivity.cs
+++ b/Toggl.Giskard/Activities/SettingsActivity.cs
@@ -45,6 +45,7 @@ namespace Toggl.Giskard.Activities
             this.Bind(ViewModel.Email, emailTextView.Rx().TextObserver());
             this.Bind(ViewModel.Workspaces, adapter.Rx().Items());
             this.Bind(ViewModel.IsManualModeEnabled, manualModeSwitch.Rx().Checked());
+            this.Bind(ViewModel.IsShowingSuggestions, isShowingSuggestionsSwitch.Rx().Checked());
             this.Bind(ViewModel.AreRunningTimerNotificationsEnabled, runningTimerNotificationsSwitch.Rx().Checked());
             this.Bind(ViewModel.AreStoppedTimerNotificationsEnabled, stoppedTimerNotificationsSwitch.Rx().Checked());
             this.Bind(ViewModel.BeginningOfWeek, beginningOfWeekTextView.Rx().TextObserver());
@@ -62,6 +63,7 @@ namespace Toggl.Giskard.Activities
             this.Bind(aboutView.Rx().Tap(), ViewModel.OpenAboutView);
             this.Bind(feedbackView.Rx().Tap(), ViewModel.SubmitFeedback);
             this.BindVoid(manualModeView.Rx().Tap(), ViewModel.ToggleManualMode);
+            this.BindVoid(isShowingSuggestionsView.Rx().Tap(), ViewModel.ToggleShowingSuggestions);
             this.BindVoid(runningTimerNotificationsView.Rx().Tap(), ViewModel.ToggleRunningTimerNotifications);
             this.BindVoid(stoppedTimerNotificationsView.Rx().Tap(), ViewModel.ToggleStoppedTimerNotifications);
             this.Bind(beginningOfWeekView.Rx().Tap(), ViewModel.SelectBeginningOfWeek);

--- a/Toggl.Giskard/Adapters/MainRecyclerAdapter.cs
+++ b/Toggl.Giskard/Adapters/MainRecyclerAdapter.cs
@@ -30,6 +30,8 @@ namespace Toggl.Giskard.Adapters
 
         public SuggestionsViewModel SuggestionsViewModel { get; set; }
 
+        public bool IsShowingSuggestions { get; set; }
+
         private Subject<TimeEntryViewModel> timeEntryTappedSubject = new Subject<TimeEntryViewModel>();
         private Subject<TimeEntryViewModel> continueTimeEntrySubject = new Subject<TimeEntryViewModel>();
         private Subject<TimeEntryViewModel> deleteTimeEntrySubject = new Subject<TimeEntryViewModel>();
@@ -51,7 +53,7 @@ namespace Toggl.Giskard.Adapters
             deleteTimeEntrySubject.OnNext(deletedTimeEntry);
         }
 
-        public override int HeaderOffset => 1;
+        public override int HeaderOffset => IsShowingSuggestions ? 1 : 0;
 
         protected override bool TryBindCustomViewType(RecyclerView.ViewHolder holder, int position)
         {
@@ -62,6 +64,12 @@ namespace Toggl.Giskard.Adapters
             }
 
             return false;
+        }
+
+        public void UpdateShowingSuggestions(bool isShowingSuggestions) 
+        {
+            IsShowingSuggestions = isShowingSuggestions;
+            NotifyDataSetChanged();
         }
 
         public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
@@ -77,10 +85,8 @@ namespace Toggl.Giskard.Adapters
 
         public override int GetItemViewType(int position)
         {
-            if (position == 0)
-            {
+            if (IsShowingSuggestions && position == 0)
                 return SuggestionViewType;
-            }
 
             return base.GetItemViewType(position);
         }

--- a/Toggl.Giskard/Resources/layout/SettingsActivity.axml
+++ b/Toggl.Giskard/Resources/layout/SettingsActivity.axml
@@ -123,7 +123,50 @@
             <View
                 android:background="@color/separator"
                 android:layout_height="0.5dp"
+                android:layout_width="match_parent" />
+            <TextView
+                android:textSize="12sp"
+                android:paddingLeft="16dp"
+                android:textAllCaps="true"
+                android:letterSpacing="0.04"
+                android:gravity="center_vertical"
+                android:text="@string/Behaviour"
+                android:textColor="@color/defaultText"
+                android:fontFamily="sans-serif-medium"
+                android:layout_height="48dp"
                 android:layout_marginTop="24dp"
+                android:layout_width="match_parent" />
+            <View
+                android:background="@color/separator"
+                android:layout_height="0.5dp"
+                android:layout_width="match_parent" />
+            <FrameLayout
+                android:id="@+id/SettingsShowSuggestions"
+                android:clickable="true"
+                android:background="?attr/selectableItemBackground"
+                android:layout_height="48dp"
+                android:layout_width="match_parent">
+                <TextView
+                    android:textSize="15sp"
+                    android:textAllCaps="false"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical"
+                    android:text="@string/ShowSuggestions"
+                    android:textColor="@android:color/black"
+                    android:layout_gravity="start"
+                    android:layout_height="match_parent"
+                    android:layout_width="wrap_content" />
+                <Switch
+                    android:id="@+id/SettingsIsShowingSuggestionsSwitch"
+                    android:clickable="false"
+                    android:paddingRight="18dp"
+                    android:layout_gravity="right"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent" />
+            </FrameLayout>
+            <View
+                android:background="@color/separator"
+                android:layout_height="0.5dp"
                 android:layout_width="match_parent" />
             <FrameLayout
                 android:id="@+id/SettingsToggleManualModeView"

--- a/Toggl.Giskard/Resources/values/Strings.xml
+++ b/Toggl.Giskard/Resources/values/Strings.xml
@@ -111,6 +111,8 @@ understand and agree to Toggl\'s</string>
     <string name="CreateWorkspace">Create Workspace</string>
     <string name="NoWorkspaceHelperText">Seems someone has removed you from their workspace.\nNo worries. Create a new workspace to continue.</string>
     <string name="Uhoh">Uh oh.</string>
+    <string name="Behaviour">Behaviour</string>
+    <string name="ShowSuggestions">Show suggestions on main screen</string>
 
     <string name="ReportsTemplateSelector" translatable="false">Toggl.Giskard.TemplateSelectors.ReportsTemplateSelector, Toggl.Giskard</string>
     <string name="CalendarTemplateSelector" translatable="false">Toggl.Giskard.TemplateSelectors.CalendarTemplateSelector, Toggl.Giskard</string>

--- a/Toggl.PrimeRadiant/Settings/IUserPreferences.cs
+++ b/Toggl.PrimeRadiant/Settings/IUserPreferences.cs
@@ -4,6 +4,8 @@ namespace Toggl.PrimeRadiant.Settings
 {
     public interface IUserPreferences
     {
+        IObservable<bool> IsShowingSuggestionsObservable { get; }
+
         IObservable<bool> IsManualModeEnabledObservable { get; }
 
         IObservable<bool> AreRunningTimerNotificationsEnabledObservable { get; }
@@ -16,9 +18,13 @@ namespace Toggl.PrimeRadiant.Settings
 
         bool AreStoppedTimerNotificationsEnabled { get; }
 
+        bool IsShowingSuggestions { get; }
+
         void EnableManualMode();
 
         void EnableTimerMode();
+
+        void SetIsShowingSuggestions(bool state);
 
         void SetRunningTimerNotifications(bool state);
 

--- a/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
+++ b/Toggl.PrimeRadiant/Settings/SettingsStorage.cs
@@ -42,6 +42,8 @@ namespace Toggl.PrimeRadiant.Settings
         private const string lastSuccessfulSyncKey = "LastSuccessfulSync";
         private const string lastLoginKey = "LastLogin";
 
+        private const string isShowingSuggestionsKey = "IsShowingSuggestions";
+
         private readonly Version version;
         private readonly IKeyValueStorage keyValueStorage;
 
@@ -58,6 +60,7 @@ namespace Toggl.PrimeRadiant.Settings
         private readonly ISubject<bool> areStoppedTimerNotificationsEnabledSubject;
         private readonly ISubject<bool> navigatedAwayFromMainViewAfterTappingStopButtonSubject;
         private readonly ISubject<bool> hasTimeEntryBeenContinuedSubject;
+        private readonly ISubject<bool> isShowingSuggestionsSubject;
 
         public SettingsStorage(Version version, IKeyValueStorage keyValueStorage)
         {
@@ -79,6 +82,7 @@ namespace Toggl.PrimeRadiant.Settings
             (projectOrTagWasAddedSubject, ProjectOrTagWasAddedBefore) = prepareSubjectAndObservable(projectOrTagWasAddedBeforeKey);
             (navigatedAwayFromMainViewAfterTappingStopButtonSubject, NavigatedAwayFromMainViewAfterTappingStopButton) = prepareSubjectAndObservable(navigatedAwayFromMainViewAfterTappingStopButtonKey);
             (hasTimeEntryBeenContinuedSubject, HasTimeEntryBeenContinued) = prepareSubjectAndObservable(hasTimeEntryBeenContinuedKey);
+            (isShowingSuggestionsSubject, IsShowingSuggestionsObservable) = prepareSubjectAndObservable(isShowingSuggestionsKey);
         }
 
         #region IAccessRestrictionStorage
@@ -313,12 +317,16 @@ namespace Toggl.PrimeRadiant.Settings
 
         #region IUserPreferences
 
+        public IObservable<bool> IsShowingSuggestionsObservable { get; }
         public IObservable<bool> IsManualModeEnabledObservable { get; }
         public IObservable<bool> AreRunningTimerNotificationsEnabledObservable { get; }
         public IObservable<bool> AreStoppedTimerNotificationsEnabledObservable { get; }
 
         public bool IsManualModeEnabled
             => keyValueStorage.GetBool(preferManualModeKey);
+
+        public bool IsShowingSuggestions
+            => keyValueStorage.GetBool(isShowingSuggestionsKey);
 
         public bool AreRunningTimerNotificationsEnabled
             => keyValueStorage.GetBool(runningTimerNotificationsKey);
@@ -342,6 +350,12 @@ namespace Toggl.PrimeRadiant.Settings
         {
             keyValueStorage.SetBool(runningTimerNotificationsKey, state);
             areRunningTimerNotificationsEnabledSubject.OnNext(state);
+        }
+
+        public void SetIsShowingSuggestions(bool state)
+        {
+            keyValueStorage.SetBool(isShowingSuggestionsKey, state);
+            isShowingSuggestionsSubject.OnNext(state);
         }
 
         public void SetStoppedTimerNotifications(bool state)


### PR DESCRIPTION
## What's this?
Adds an option to show/hide suggestions from the options screen.
Until we make different suggestion providers, it will help declutter the main screen.

`needs-design` label added: Copy `Show suggestions on the main screen` may not be the best copy. Summoning @pe0ny.

## Why do we want this?

Users wanted it. I want it.

## How is it done?

The typical way.

### Side effects
I don't think so, but yell if you find something!

## :squid: Permissions
To exercise control, only me.