### PR TITLE
Nice database migrations

### DIFF
--- a/Toggl.PrimeRadiant.Realm/Database.cs
+++ b/Toggl.PrimeRadiant.Realm/Database.cs
@@ -82,13 +82,11 @@ namespace Toggl.PrimeRadiant.Realm
             => new RealmConfiguration
             {
                 SchemaVersion = 6,
-                MigrationCallback = (migration, oldSchemaVersion) =>
-                {
+                MigrationCallback = (realmMigration, oldSchemaVersion) =>
                     migrations
-                        .Where(m => oldSchemaVersion < m.TargetSchemaVersion)
-                        .OrderBy(m => m.TargetSchemaVersion)
-                        .ForEach(m => m.PerformMigration(migration.OldRealm, migration.NewRealm));
-                }
+                        .Where(migration => oldSchemaVersion < migration.TargetSchemaVersion)
+                        .OrderBy(migration => migration.TargetSchemaVersion)
+                        .ForEach(migration => migration.PerformMigration(realmMigration.OldRealm, realmMigration.NewRealm))
             };
     }
 }

--- a/Toggl.PrimeRadiant.Realm/Database.cs
+++ b/Toggl.PrimeRadiant.Realm/Database.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -14,7 +15,7 @@ namespace Toggl.PrimeRadiant.Realm
     {
         private readonly RealmConfiguration realmConfiguration;
 
-        private readonly IMigration[] migrations =
+        private IEnumerable<IMigration> migrations => new[]
         {
             new TagServerDeletedAt()
         };

--- a/Toggl.PrimeRadiant.Realm/Migrations/IMigration.cs
+++ b/Toggl.PrimeRadiant.Realm/Migrations/IMigration.cs
@@ -1,0 +1,9 @@
+namespace Toggl.PrimeRadiant.Realm.Migrations
+{
+    public interface IMigration
+    {
+        ulong TargetSchemaVersion { get; }
+
+        void PerformMigration(Realms.Realm oldRealm, Realms.Realm newRealm);
+    }
+}

--- a/Toggl.PrimeRadiant.Realm/Migrations/IMigration.cs
+++ b/Toggl.PrimeRadiant.Realm/Migrations/IMigration.cs
@@ -2,6 +2,8 @@ namespace Toggl.PrimeRadiant.Realm.Migrations
 {
     public interface IMigration
     {
+        ulong MinimumSchemaVersionToMigrateFrom { get; }
+
         ulong TargetSchemaVersion { get; }
 
         void PerformMigration(Realms.Realm oldRealm, Realms.Realm newRealm);

--- a/Toggl.PrimeRadiant.Realm/Migrations/TagServerDeletedAt.cs
+++ b/Toggl.PrimeRadiant.Realm/Migrations/TagServerDeletedAt.cs
@@ -4,9 +4,9 @@ namespace Toggl.PrimeRadiant.Realm.Migrations
 {
     public sealed class TagServerDeletedAt : IMigration
     {
-        public ulong MinimumSchemaVersionToMigrateFrom { get; } = 0;
+        public ulong MinimumSchemaVersionToMigrateFrom => 0;
 
-        public ulong TargetSchemaVersion { get; } = 4;
+        public ulong TargetSchemaVersion => 4;
 
         public void PerformMigration(Realms.Realm oldRealm, Realms.Realm newRealm)
         {

--- a/Toggl.PrimeRadiant.Realm/Migrations/TagServerDeletedAt.cs
+++ b/Toggl.PrimeRadiant.Realm/Migrations/TagServerDeletedAt.cs
@@ -4,6 +4,8 @@ namespace Toggl.PrimeRadiant.Realm.Migrations
 {
     public sealed class TagServerDeletedAt : IMigration
     {
+        public ulong MinimumSchemaVersionToMigrateFrom { get; } = 0;
+
         public ulong TargetSchemaVersion { get; } = 4;
 
         public void PerformMigration(Realms.Realm oldRealm, Realms.Realm newRealm)

--- a/Toggl.PrimeRadiant.Realm/Migrations/TagServerDeletedAt.cs
+++ b/Toggl.PrimeRadiant.Realm/Migrations/TagServerDeletedAt.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+
+namespace Toggl.PrimeRadiant.Realm.Migrations
+{
+    public sealed class TagServerDeletedAt : IMigration
+    {
+        public ulong TargetSchemaVersion { get; } = 4;
+
+        public void PerformMigration(Realms.Realm oldRealm, Realms.Realm newRealm)
+        {
+            var newTags = newRealm.All<RealmTag>();
+            var oldTags = oldRealm.All("RealmTag");
+            for (var i = 0; i < newTags.Count(); i++)
+            {
+                var oldTag = oldTags.ElementAt(i);
+                var newTag = newTags.ElementAt(i);
+                newTag.ServerDeletedAt = oldTag.DeletedAt;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What's this?
This PR simplifies the way we implement DB migrations and makes it easier to add new migrations in the future.

### Relationships

No directly related issue.

## Why do we want this?

Adding a migration is confusing at the moment, because we have a single method which has several if branches, some of them empty, and somebody who is not familiar with this code might be confused at first and might make a mistake, which would result in corrupting user's data if it was overlooked during code review.

## How is it done?

Migrations, which are independent, will now be separate classes with single responsibility: execute the migration from an old schema to the target schema version.

The `Database` class holds a list of migrations, which should be used, and applies them in a correct order (from lowest target schema versions to the highest).

There might be several classes targeting the same schema, but there must be no dependence between the migrations as the order of them is not guaranteed in any way.

Creating migrations will still be quite challenging and will require a lot of focus (when the schema changes, some of the old migrations might need to be replaced with different ones (e.g., when some property is renamed twice).

### Why not another way?
This is a nice and clean way which should be future-proof.

### Side effects
No side effects.

## Review hints

Try creating your own migration and change some of the `Realm*` classes and bump the schema version, then run the app and use Realm Studio (or the debugger) to see that the migration was applied correctly.

## :squid: Permissions

I will 🦑 this if we agree that it is a good thing to have.