### PR TITLE
Nicer tokens

### DIFF
--- a/Toggl.Daneel/Autocomplete/ImageTokenTextAttachment.cs
+++ b/Toggl.Daneel/Autocomplete/ImageTokenTextAttachment.cs
@@ -1,0 +1,51 @@
+using System;
+using CoreGraphics;
+using Foundation;
+using Toggl.Daneel.Extensions;
+using Toggl.Daneel.Services;
+using UIKit;
+
+namespace Toggl.Daneel.Autocomplete
+{
+    public abstract class ImageTokenTextAttachment : TokenTextAttachment
+    {
+        protected ImageTokenTextAttachment(
+            NSAttributedString stringToDraw,
+            nfloat textVerticalOffset,
+            UIColor foregroundColor,
+            UIColor backgroundColor,
+            int imageWidth,
+            int imageHeight,
+            UIImage image,
+            nfloat fontDescender)
+            : base(fontDescender)
+        {
+            var size = CalculateSize(stringToDraw, imageWidth + TokenPadding);
+
+            UIGraphics.BeginImageContextWithOptions(size, opaque: false, scale: 0.0f);
+            using (var context = UIGraphics.GetCurrentContext())
+            {
+                var tokenPath = CalculateTokenPath(size);
+                context.DrawTokenShape(
+                    tokenPath.CGPath, foregroundColor.CGColor, backgroundColor.CGColor);
+
+                stringToDraw.DrawString(
+                    new CGPoint(
+                        x: TokenMargin + TokenPadding + imageWidth + TokenPadding,
+                        y: textVerticalOffset));
+
+                var rect = new CGRect(
+                    x: TokenMargin + TokenPadding,
+                    y: (size.Height - imageHeight) / 2,
+                    width: imageWidth,
+                    height: imageHeight);
+
+                context.DrawColoredImage(rect, image.CGImage, foregroundColor.CGColor);
+
+                var finalImage = UIGraphics.GetImageFromCurrentImageContext();
+                UIGraphics.EndImageContext();
+                Image = finalImage;
+            }
+        }
+    }
+}

--- a/Toggl.Daneel/Autocomplete/ProjectTextAttachment.cs
+++ b/Toggl.Daneel/Autocomplete/ProjectTextAttachment.cs
@@ -5,43 +5,31 @@ using UIKit;
 
 namespace Toggl.Daneel.Autocomplete
 {
-    public sealed class ProjectTextAttachment : TokenTextAttachment
+    public sealed class ProjectTextAttachment : ImageTokenTextAttachment
     {
-        private const int dotPadding = 6;
-        private const int dotDiameter = 4;
-        private const int dotRadius = dotDiameter / 2;
-        private const int circleWidth = dotDiameter + dotPadding;
-        private const int dotYOffset = (LineHeight / 2) - dotRadius;
+        private const int imageWidth = 12;
 
-        public ProjectTextAttachment(NSAttributedString stringToDraw, UIColor projectColor, nfloat textVerticalOffset, nfloat fontDescender)
-            : base(fontDescender)
+        private const int imageHeight = 9;
+
+        private static nfloat backgroundAlpha = 0.12f;
+
+        private static UIImage image => UIImage.FromBundle("icProjects");
+
+        public ProjectTextAttachment(
+            NSAttributedString stringToDraw,
+            UIColor projectColor,
+            nfloat textVerticalOffset,
+            nfloat fontDescender)
+            : base(
+                stringToDraw,
+                textVerticalOffset,
+                projectColor,
+                projectColor.ColorWithAlpha(backgroundAlpha),
+                imageWidth,
+                imageHeight,
+                image,
+                fontDescender)
         {
-            var size = CalculateSize(stringToDraw, circleWidth);
-
-            UIGraphics.BeginImageContextWithOptions(size, false, 0.0f);
-            using (var context = UIGraphics.GetCurrentContext())
-            {
-                var tokenPath = CalculateTokenPath(size);
-                context.AddPath(tokenPath.CGPath);
-                context.SetFillColor(projectColor.ColorWithAlpha(0.12f).CGColor);
-                context.FillPath();
-
-                var dot = UIBezierPath.FromRoundedRect(new CGRect(
-                    x: dotPadding + TokenMargin,
-                    y: dotYOffset,
-                    width: dotDiameter,
-                    height: dotDiameter
-                ), dotRadius);
-                context.AddPath(dot.CGPath);
-                context.SetFillColor(projectColor.CGColor);
-                context.FillPath();
-
-                stringToDraw.DrawString(new CGPoint(circleWidth + TokenMargin + TokenPadding, textVerticalOffset));
-
-                var image = UIGraphics.GetImageFromCurrentImageContext();
-                UIGraphics.EndImageContext();
-                Image = image;
-            }
         }
     }
 }

--- a/Toggl.Daneel/Autocomplete/TagTextAttachment.cs
+++ b/Toggl.Daneel/Autocomplete/TagTextAttachment.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using CoreGraphics;
 using Foundation;
 using MvvmCross.Plugin.Color.Platforms.Ios;
 using Toggl.Foundation.MvvmCross.Helper;
@@ -7,29 +6,30 @@ using UIKit;
 
 namespace Toggl.Daneel.Autocomplete
 {
-    public sealed class TagTextAttachment : TokenTextAttachment 
+    public sealed class TagTextAttachment : ImageTokenTextAttachment
     {
         private static readonly UIColor borderColor = Color.StartTimeEntry.TokenBorder.ToNativeColor();
 
-        public TagTextAttachment(NSAttributedString stringToDraw, nfloat textVerticalOffset, nfloat fontDescender)
-            : base (fontDescender)
+        private const int tagImageWidth = 12;
+
+        private const int tagImageHeight = 12;
+
+        private static UIImage image => UIImage.FromBundle("icTags");
+
+        public TagTextAttachment(
+            NSAttributedString stringToDraw,
+            nfloat textVerticalOffset,
+            nfloat fontDescender)
+            : base(
+                stringToDraw,
+                textVerticalOffset,
+                borderColor,
+                borderColor.ColorWithAlpha(0.12f),
+                tagImageWidth,
+                tagImageHeight,
+                image,
+                fontDescender)
         {
-            var size = CalculateSize(stringToDraw);
-
-            UIGraphics.BeginImageContextWithOptions(size, false, 0.0f);
-            using (var context = UIGraphics.GetCurrentContext())
-            {
-                var tokenPath = CalculateTokenPath(size);
-                context.AddPath(tokenPath.CGPath);
-                context.SetStrokeColor(borderColor.CGColor);
-                context.StrokePath();
-
-                stringToDraw.DrawString(new CGPoint(TokenMargin + TokenPadding, textVerticalOffset));
-
-                var image = UIGraphics.GetImageFromCurrentImageContext();
-                UIGraphics.EndImageContext();
-                Image = image;
-            }
         }
     }
 }

--- a/Toggl.Daneel/Extensions/CGContextExtensions.cs
+++ b/Toggl.Daneel/Extensions/CGContextExtensions.cs
@@ -1,0 +1,38 @@
+using CoreGraphics;
+
+namespace Toggl.Daneel.Extensions
+{
+    public static class CGContextExtensions
+    {
+        public static void DrawTokenShape(
+            this CGContext context,
+            CGPath tokenPath,
+            CGColor foregroundColor,
+            CGColor backgroundColor)
+        {
+            context.AddPath(tokenPath);
+            context.SetFillColor(backgroundColor);
+            context.FillPath();
+
+            context.AddPath(tokenPath);
+            context.SetStrokeColor(foregroundColor);
+            context.StrokePath();
+        }
+
+        public static void DrawColoredImage(
+            this CGContext context,
+            CGRect rect,
+            CGImage image,
+            CGColor color)
+        {
+            // prevent the image from being flipped vertically
+            context.TranslateCTM(0, 2 * rect.Y + rect.Height);
+            context.ScaleCTM(1.0f, -1.0f);
+            context.ClipToMask(rect, image);
+            context.SetFillColor(color);
+            context.FillRect(rect);
+            context.TranslateCTM(0.0f, 0.0f);
+            context.ScaleCTM(1.0f, 1.0f);
+        }
+    }
+}

--- a/Toggl.Daneel/Extensions/CGContextExtensions.cs
+++ b/Toggl.Daneel/Extensions/CGContextExtensions.cs
@@ -25,14 +25,22 @@ namespace Toggl.Daneel.Extensions
             CGImage image,
             CGColor color)
         {
-            // prevent the image from being flipped vertically
-            context.TranslateCTM(0, 2 * rect.Y + rect.Height);
-            context.ScaleCTM(1.0f, -1.0f);
-            context.ClipToMask(rect, image);
-            context.SetFillColor(color);
-            context.FillRect(rect);
-            context.TranslateCTM(0.0f, 0.0f);
-            context.ScaleCTM(1.0f, 1.0f);
+            try
+            {
+                // prevent the image from being flipped vertically
+                context.TranslateCTM(0, 2 * rect.Y + rect.Height);
+                context.ScaleCTM(1.0f, -1.0f);
+
+                context.ClipToMask(rect, image);
+                context.SetFillColor(color);
+                context.FillRect(rect);
+            }
+            finally
+            {
+                // reset translation and scaling in the global context
+                context.TranslateCTM(0.0f, 0.0f);
+                context.ScaleCTM(1.0f, 1.0f);
+            }
         }
     }
 }

--- a/Toggl.Daneel/Toggl.Daneel.csproj
+++ b/Toggl.Daneel/Toggl.Daneel.csproj
@@ -648,8 +648,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Autocomplete\ImageTokenTextAttachment.cs" />
     <Compile Include="Binding\DatePickerDateTimeOffsetTargetBinding.cs" />
     <Compile Include="Extensions\Binders\ReactiveTableViewBinder.cs" />
+    <Compile Include="Extensions\CGContextExtensions.cs" />
     <Compile Include="Extensions\IntentPeriod.cs" />
     <Compile Include="Extensions\SectionedIndexExtensions.cs" />
     <Compile Include="Services\PermissionsService.cs" />

--- a/Toggl.Daneel/Views/StartTimeEntry/TagSuggestionViewCell.xib
+++ b/Toggl.Daneel/Views/StartTimeEntry/TagSuggestionViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,8 +18,15 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icTags" translatesAutoresizingMaskIntoConstraints="NO" id="FcN-tU-xu9">
+                        <rect key="frame" x="16" y="16" width="12" height="12"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="12" id="Jvz-OB-3Wz"/>
+                            <constraint firstAttribute="width" constant="12" id="PJn-Xn-qb8"/>
+                        </constraints>
+                    </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X5g-yZ-UGQ">
-                        <rect key="frame" x="16" y="14" width="33" height="16"/>
+                        <rect key="frame" x="32" y="14" width="33" height="16"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -32,10 +39,14 @@
                         </constraints>
                     </view>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="FcN-tU-xu9" firstAttribute="leading" secondItem="YTl-1W-gDM" secondAttribute="leading" constant="16" id="SF6-Ge-lq6"/>
+                    <constraint firstItem="FcN-tU-xu9" firstAttribute="centerY" secondItem="YTl-1W-gDM" secondAttribute="centerY" id="lX4-Uf-PKC"/>
+                </constraints>
             </tableViewCellContentView>
             <constraints>
                 <constraint firstItem="wn4-JZ-hoh" firstAttribute="leading" secondItem="cxk-wN-pdQ" secondAttribute="leading" id="3ZW-df-dc1"/>
-                <constraint firstItem="X5g-yZ-UGQ" firstAttribute="leading" secondItem="cxk-wN-pdQ" secondAttribute="leading" constant="16" id="TLO-0V-j99"/>
+                <constraint firstItem="X5g-yZ-UGQ" firstAttribute="leading" secondItem="FcN-tU-xu9" secondAttribute="trailing" constant="4" id="TLO-0V-j99"/>
                 <constraint firstAttribute="bottom" secondItem="wn4-JZ-hoh" secondAttribute="bottom" id="j1N-ho-asJ"/>
                 <constraint firstAttribute="trailing" secondItem="wn4-JZ-hoh" secondAttribute="trailing" id="p2z-WE-tnR"/>
                 <constraint firstItem="X5g-yZ-UGQ" firstAttribute="centerY" secondItem="cxk-wN-pdQ" secondAttribute="centerY" id="r6w-lh-sxb"/>
@@ -45,4 +56,7 @@
             </connections>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="icTags" width="14" height="13"/>
+    </resources>
 </document>


### PR DESCRIPTION
## What's this?
This PR tries to make tokes we use in the creation view and in the edit view nicer. Especially the ones we use for tags (now they have no icon and they have clear background).

### Relationships

There is no issue with the design. This is my own initiative (I was stuck at an airport for too long).

## Why do we want this?
I think this makes it a bit nicer than right now.

## How is it done?
- tag tokens now have an 🏷 icon
- project tokens now have an icon (📁) instead of a dot
- both tokens now have border

### Side effects
No side effects.

## :squid: Permissions
We should not merge this without @amulware's approval.