### PR TITLE
Sanic boosters: Remove easy overdraw

### DIFF
--- a/Toggl.Giskard/Resources/layout/AboutActivity.axml
+++ b/Toggl.Giskard/Resources/layout/AboutActivity.axml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:local="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
-    android:background="@color/lightGray"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <android.support.v7.widget.Toolbar

--- a/Toggl.Giskard/Resources/layout/MainActivity.axml
+++ b/Toggl.Giskard/Resources/layout/MainActivity.axml
@@ -2,7 +2,6 @@
 <android.support.design.widget.CoordinatorLayout xmlns:local="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/MainCoordinatorLayout"
-    android:background="@color/lightGray"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <android.support.v4.widget.SwipeRefreshLayout

--- a/Toggl.Giskard/Resources/layout/ReportsActivity.axml
+++ b/Toggl.Giskard/Resources/layout/ReportsActivity.axml
@@ -3,7 +3,6 @@
     xmlns:local="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:animateLayoutChanges="true"
-    android:background="@color/lightGray"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <com.toggl.giskard.ReportsLinearLayout

--- a/Toggl.Giskard/Resources/layout/SettingsActivity.axml
+++ b/Toggl.Giskard/Resources/layout/SettingsActivity.axml
@@ -2,7 +2,6 @@
 <android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
     xmlns:local="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:background="@color/lightGray"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <android.support.v4.widget.NestedScrollView
@@ -13,7 +12,6 @@
             android:paddingTop="24dp"
             android:orientation="vertical"
             android:animateLayoutChanges="true"
-            android:background="@color/lightGray"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
             <LinearLayout

--- a/Toggl.Giskard/Resources/layout/TokenResetActivity.axml
+++ b/Toggl.Giskard/Resources/layout/TokenResetActivity.axml
@@ -5,7 +5,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:fitsSystemWindows="true"
     android:animateLayoutChanges="true"
-    android:background="@color/defaultBackground"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <TextView

--- a/Toggl.Giskard/Resources/values/Styles.xml
+++ b/Toggl.Giskard/Resources/values/Styles.xml
@@ -12,6 +12,7 @@
         <item name="android:statusBarColor">#2C2C2C</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowBackground">@color/lightGray</item>
     </style>
 
     <style name="AppTheme.BlueStatusBar">


### PR DESCRIPTION
## What's this?
This is an improvement to reduce overdraw on the main log, but also every other activity that had the background color set to `@color/lightGray`.

### Relationships
Closes #3412 

## Why do we want this?
We were overdrawing quite a lot in the main log. This simple change reduces that, slightly improving the general performance of the MainActivity (gotta measure that).

## How is it done?
The window background colour is set the colour of the root container in the activity, removing the need to re-set the background colour when inflating the view.

### Why not another way?
I don't know any other way.
There's more to do about the overdraw in the main log, but it will require more work and thought. So I'll add another PR just for that.

### Side effects
All other activities using the AppTheme were affected, so I've removed the background there as well, reducing overdraw in the other activities.

## Review hints
This is an easy one, there's only layout changes.
There shouldn't be any visual changes. If you want to check the difference, run the app from develop, then from this branch with `Debug GPU overdraw` developer option set to `Sho overdraw areas`.

How to read overdraw colours: https://developer.android.com/studio/profile/inspect-gpu-rendering#debug_overdraw.

The difference can be seen bellow:

| Before  | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/2173493/47117571-badc5600-d232-11e8-810c-66037fe631e8.png" width=240 />  | <img src="https://user-images.githubusercontent.com/2173493/47117405-3d184a80-d232-11e8-92f2-ff95662fc51a.png" width=240 />  |

## :squid: Permissions
:sanic: squad 🦑 