### PR TITLE
Speed up opening the select project view

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/SelectProjectViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/SelectProjectViewModel.cs
@@ -34,7 +34,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
         private readonly IInteractorFactory interactorFactory;
         private readonly IMvxNavigationService navigationService;
         private readonly Subject<string> infoSubject = new Subject<string>();
-        private readonly ISchedulerProvider schedulerProvider;
 
         private long? taskId;
         private long? projectId;
@@ -95,20 +94,17 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             ITogglDataSource dataSource,
             IInteractorFactory interactorFactory,
             IMvxNavigationService navigationService,
-            IDialogService dialogService,
-            ISchedulerProvider schedulerProvider)
+            IDialogService dialogService)
         {
             Ensure.Argument.IsNotNull(dataSource, nameof(dataSource));
             Ensure.Argument.IsNotNull(dialogService, nameof(dialogService));
             Ensure.Argument.IsNotNull(interactorFactory, nameof(interactorFactory));
             Ensure.Argument.IsNotNull(navigationService, nameof(navigationService));
-            Ensure.Argument.IsNotNull(schedulerProvider, nameof(schedulerProvider));
 
             this.dataSource = dataSource;
             this.dialogService = dialogService;
             this.interactorFactory = interactorFactory;
             this.navigationService = navigationService;
-            this.schedulerProvider = schedulerProvider;
 
             CloseCommand = new MvxAsyncCommand(close);
             CreateProjectCommand = new MvxAsyncCommand(createProject);


### PR DESCRIPTION
## What's this?
This will speed up opening the Select Project view, which now lags for a bit when opening.
Before: ~600ms
After: stopwatch shows ~370ms, but feels much faster 🤔 

### Relationships
Closes #3420 (it was named like that based on some poor wording I used when taking notes)

## Why do we want this?
Gotta go fast!

## How is it done?
By moving one slow subscription into a background thread.

### Why not another way?
This seems like the better way to do this, since we want to present the view as ASAP as possible.

### Side effects
When loading _**a lot**_ of data, the user might not get suggestions right away, so we might need some kind of loading indicator down the way.

## Review hints
Try on base branch, try here.

## :squid: Permissions
Go for it!