### PR TITLE
Use system proxy settings

### DIFF
--- a/Toggl.Daneel.SiriExtension/Helper/APIHelper.cs
+++ b/Toggl.Daneel.SiriExtension/Helper/APIHelper.cs
@@ -24,7 +24,8 @@ namespace SiriExtension
             var version = NSBundle.MainBundle.InfoDictionary["CFBundleShortVersionString"].ToString();
             var userAgent = new UserAgent("Daneel", $"{version} SiriExtension");
             var apiConfiguration = new ApiConfiguration(environment, Credentials.WithApiToken(apiToken), userAgent);
-            return TogglApiFactory.WithConfiguration(apiConfiguration);
+            var proxy = CoreFoundation.CFNetwork.GetDefaultProxy();
+            return TogglApiFactory.WithConfiguration(apiConfiguration, proxy);
         }
     }
 }

--- a/Toggl.Daneel/Startup/Setup.cs
+++ b/Toggl.Daneel/Startup/Setup.cs
@@ -100,6 +100,7 @@ namespace Toggl.Daneel
             var schedulerProvider = new IOSSchedulerProvider();
             var calendarService = new CalendarService(permissionsService);
             var notificationService = new NotificationService(permissionsService, timeService);
+            var proxy = CoreFoundation.CFNetwork.GetDefaultProxy();
 
             var foundation =
                 TogglFoundation
@@ -117,7 +118,7 @@ namespace Toggl.Daneel
                     .WithPlatformConstants(platformConstants)
                     .WithRemoteConfigService(remoteConfigService)
                     .WithNotificationService(notificationService)
-                    .WithApiFactory(new ApiFactory(environment, userAgent))
+                    .WithApiFactory(new ApiFactory(environment, userAgent, proxy))
                     .WithBackgroundService(new BackgroundService(timeService))
                     .WithApplicationShortcutCreator<ApplicationShortcutCreator>()
                     .WithSuggestionProviderContainer(suggestionProviderContainer)

--- a/Toggl.Foundation/Login/ApiFactory.cs
+++ b/Toggl.Foundation/Login/ApiFactory.cs
@@ -1,4 +1,5 @@
-﻿using Toggl.Multivac;
+﻿using System.Net;
+using Toggl.Multivac;
 using Toggl.Ultrawave;
 using Toggl.Ultrawave.Network;
 
@@ -10,18 +11,22 @@ namespace Toggl.Foundation.Login
 
         public ApiEnvironment Environment { get; }
 
-        public ApiFactory(ApiEnvironment apiEnvironment, UserAgent userAgent)
+        public IWebProxy Proxy { get; }
+
+        public ApiFactory(ApiEnvironment apiEnvironment, UserAgent userAgent, IWebProxy proxy)
         {
             Ensure.Argument.IsNotNull(userAgent, nameof(userAgent));
+            Ensure.Argument.IsNotNull(proxy, nameof(proxy));
 
             UserAgent = userAgent;
             Environment = apiEnvironment;
+            Proxy = proxy;
         }
 
         public ITogglApi CreateApiWith(Credentials credentials)
         {
             var configuration = new ApiConfiguration(Environment, credentials, UserAgent);
-            return TogglApiFactory.WithConfiguration(configuration);
+            return TogglApiFactory.WithConfiguration(configuration, Proxy);
         }
     }
 }

--- a/Toggl.Ultrawave.Tests.Integration/Helper/TogglApiFactory.cs
+++ b/Toggl.Ultrawave.Tests.Integration/Helper/TogglApiFactory.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Toggl.Ultrawave.Network;
 
 namespace Toggl.Ultrawave.Tests.Integration.Helper
@@ -7,7 +8,7 @@ namespace Toggl.Ultrawave.Tests.Integration.Helper
         public static ITogglApi TogglApiWith(Credentials credentials)
         {
             var apiConfiguration = configurationFor(credentials);
-            var apiClient = Ultrawave.TogglApiFactory.CreateDefaultApiClient(apiConfiguration.UserAgent);
+            var apiClient = Ultrawave.TogglApiFactory.CreateDefaultApiClient(apiConfiguration.UserAgent, proxy: null);
             var retryingApiClient = new RetryingApiClient(apiClient);
 
             return new TogglApi(apiConfiguration, retryingApiClient);

--- a/Toggl.Ultrawave/TogglApi.cs
+++ b/Toggl.Ultrawave/TogglApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using Toggl.Multivac;
 using Toggl.Ultrawave.ApiClients;
 using Toggl.Ultrawave.ApiClients.Interfaces;
@@ -55,16 +56,21 @@ namespace Toggl.Ultrawave
 
     public static class TogglApiFactory
     {
-        internal static IApiClient CreateDefaultApiClient(UserAgent userAgent)
+        internal static IApiClient CreateDefaultApiClient(UserAgent userAgent, IWebProxy proxy)
         {
-            var httpHandler = new HttpClientHandler { AutomaticDecompression = GZip | Deflate };
+            var httpHandler = new HttpClientHandler
+            {
+                AutomaticDecompression = GZip | Deflate,
+                Proxy = proxy,
+                UseProxy = proxy != null
+            };
             var httpClient = new HttpClient(httpHandler);
             return new ApiClient(httpClient, userAgent);
         }
 
-        public static ITogglApi WithConfiguration(ApiConfiguration configuration)
+        public static ITogglApi WithConfiguration(ApiConfiguration configuration, IWebProxy proxy)
         {
-            var apiClient = CreateDefaultApiClient(configuration.UserAgent);
+            var apiClient = CreateDefaultApiClient(configuration.UserAgent, proxy);
             return new TogglApi(configuration, apiClient);
         }
     }


### PR DESCRIPTION
## What's this?
This PR tries to implement usage of system proxy correctly.

### Relationships

Closes #3588 

## Why do we want this?
There are actually two reasons:
- we should let our users use proxies if they want to/need to
- we can use tools like Charles to debug our HTTP traffic

## How is it done?
The `HttpClientHandler` can take an instance of `IWebProxy` and use it.
- on iOS (Daneel + SiriExtensions) - I fetch the default system proxy (at the time of app startup) and use it
- on Android - the global settings are used 
- integration tests do not use the proxy at all

What I think might be a problem:
- what happens when user wants to changes/disables the proxy in the system while the App is running? We should change it too or all HTTP communication will still go through the old proxy. How do we do this? We might need to "soft restart" the whole app.
- what if the proxy is configured incorrectly? Can we somehow show the user that our app might not be working correctly because of the proxy settings?

### Why not another way?
This seems like a way to go, but it's not done yet. I think we must create a new `SyncManager` with a new `ITogglApi` when the system proxy settings change.

### Side effects
This might break how network connections work on different platforms with different system settings. We should test it carefully and thoroughly before merging.

## Review hints
Try configuring some proxy and check that your traffic is going through the proxy (use e.g., Charles Proxy on iOS).

## :squid: Permissions
Let's not 🦑 this just yet