### PR TITLE
Global main scheduler

### DIFF
--- a/Toggl.Daneel/Startup/Setup.cs
+++ b/Toggl.Daneel/Startup/Setup.cs
@@ -24,6 +24,7 @@ using MvvmCross.Platforms.Ios.Presenters;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
+using Toggl.Multivac;
 using ColorPlugin = MvvmCross.Plugin.Color.Platforms.Ios.Plugin;
 using VisibilityPlugin = MvvmCross.Plugin.Visibility.Platforms.Ios.Plugin;
 using Toggl.Multivac.Extensions;
@@ -99,6 +100,7 @@ namespace Toggl.Daneel
             var remoteConfigService = new RemoteConfigServiceIos();
             remoteConfigService.SetupDefaults(remoteConfigDefaultsFileName);
             var schedulerProvider = new IOSSchedulerProvider();
+            RxApp.MainScheduler = schedulerProvider.MainScheduler;
             var calendarService = new CalendarServiceIos(permissionsService);
             var notificationService = new NotificationServiceIos(permissionsService, timeService);
 

--- a/Toggl.Daneel/ViewSources/TimeEntriesLogViewSource.cs
+++ b/Toggl.Daneel/ViewSources/TimeEntriesLogViewSource.cs
@@ -68,7 +68,7 @@ namespace Toggl.Daneel.ViewSources
                 deleteTableViewRowAction.BackgroundColor = Color.TimeEntriesLog.DeleteSwipeActionBackground.ToNativeColor();
             }
 
-            FirstCell = firstCellSubject.AsDriver(schedulerProvider);
+            FirstCell = firstCellSubject.AsDriver();
         }
 
         public override UIView GetViewForFooter(UITableView tableView, nint section)

--- a/Toggl.Foundation.MvvmCross/Extensions/ObservableExtensions.cs
+++ b/Toggl.Foundation.MvvmCross/Extensions/ObservableExtensions.cs
@@ -10,8 +10,8 @@ namespace Toggl.Foundation.MvvmCross.Extensions
 {
     public static class ObservableExtensions
     {
-        public static IObservable<T> AsDriver<T>(this IObservable<T> observable, ISchedulerProvider schedulerProvider)
-            => observable.AsDriver(default(T), schedulerProvider);
+        public static IObservable<T> AsDriver<T>(this IObservable<T> observable)
+            => observable.AsDriver(default(T));
 
         public static IDisposable VoidSubscribe<T>(this IObservable<T> observable, Action onNext)
             => observable.Subscribe((T _) => onNext());

--- a/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
@@ -111,7 +111,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
                 .AsObservable()
                 .DistinctUntilChanged();
 
-            ShouldShowOnboarding = onboardingObservable.AsDriver(false, schedulerProvider);
+            ShouldShowOnboarding = onboardingObservable.AsDriver(false);
 
             TimeOfDayFormat = dataSource
                 .Preferences

--- a/Toggl.Foundation.MvvmCross/ViewModels/LoginViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/LoginViewModel.cs
@@ -103,40 +103,40 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             var emailObservable = emailSubject.Select(email => email.TrimmedEnd());
 
-            Shake = shakeSubject.AsDriver(this.schedulerProvider);
+            Shake = shakeSubject.AsDriver();
 
             Email = emailObservable
                 .Select(email => email.ToString())
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             Password = passwordSubject
                 .Select(password => password.ToString())
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsLoading = isLoadingSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             ErrorMessage = errorMessageSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsPasswordMasked = isPasswordMaskedSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsShowPasswordButtonVisible = Password
                 .Select(password => password.Length > 1)
                 .CombineLatest(isShowPasswordButtonVisibleSubject.AsObservable(), CommonFunctions.And)
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             HasError = ErrorMessage
                 .Select(string.IsNullOrEmpty)
                 .Select(CommonFunctions.Invert)
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             LoginEnabled = emailObservable
                 .CombineLatest(
@@ -144,7 +144,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                     IsLoading,
                     (email, password, isLoading) => email.IsValid && password.IsValid && !isLoading)
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsPasswordManagerAvailable = passwordManagerService.IsAvailable;
         }

--- a/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
@@ -174,8 +174,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             RatingViewModel = new RatingViewModel(timeService, dataSource, ratingService, analyticsService, onboardingStorage, navigationService, SchedulerProvider);
             TimeEntriesViewModel = new TimeEntriesViewModel(dataSource, interactorFactory, analyticsService, SchedulerProvider);
 
-            LogEmpty = TimeEntriesViewModel.Empty.AsDriver(SchedulerProvider);
-            TimeEntriesCount = TimeEntriesViewModel.Count.AsDriver(SchedulerProvider);
+            LogEmpty = TimeEntriesViewModel.Empty.AsDriver();
+            TimeEntriesCount = TimeEntriesViewModel.Count.AsDriver();
 
             ratingViewExperiment = new RatingViewExperiment(timeService, dataSource, onboardingStorage, remoteConfigService);
 
@@ -221,7 +221,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             SyncProgressState = dataSource
                 .SyncManager
                 .ProgressObservable
-                .AsDriver(SchedulerProvider);
+                .AsDriver();
 
             var isWelcome = onboardingStorage.IsNewUser;
 
@@ -235,7 +235,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                     noTimeEntries
                 )
                 .DistinctUntilChanged()
-                .AsDriver(SchedulerProvider);
+                .AsDriver();
 
             ShouldShowWelcomeBack = ObservableAddons.CombineLatestAll(
                     isWelcome.Select(b => !b),
@@ -243,7 +243,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                 )
                 .StartWith(false)
                 .DistinctUntilChanged()
-                .AsDriver(SchedulerProvider);
+                .AsDriver();
 
             ShouldShowRunningTimeEntryNotification = userPreferences.AreRunningTimerNotificationsEnabledObservable;
             ShouldShowStoppedTimeEntryNotification = userPreferences.AreStoppedTimerNotificationsEnabledObservable;
@@ -251,7 +251,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             CurrentRunningTimeEntry = dataSource
                 .TimeEntries
                 .CurrentlyRunningTimeEntry
-                .AsDriver(SchedulerProvider);
+                .AsDriver();
 
             CurrentTimeEntryHasDescription = CurrentRunningTimeEntry
                 .Select(te => !string.IsNullOrWhiteSpace(te?.Description))
@@ -277,7 +277,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             ShouldReloadTimeEntryLog = Observable.Merge(
                 TimeService.MidnightObservable.SelectUnit(),
                 TimeService.SignificantTimeChangeObservable.SelectUnit())
-                .AsDriver(SchedulerProvider);
+                .AsDriver();
 
             switch (urlNavigationAction)
             {

--- a/Toggl.Foundation.MvvmCross/ViewModels/NoWorkspaceViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/NoWorkspaceViewModel.cs
@@ -52,7 +52,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             CreateWorkspaceWithDefaultName = UIAction.FromAsync(createWorkspaceWithDefaultName);
             TryAgain = UIAction.FromAsync(tryAgain);
-            IsLoading = isLoading.AsDriver(onErrorJustReturn: false, schedulerProvider: schedulerProvider);
+            IsLoading = isLoading.AsDriver(onErrorJustReturn: false);
         }
 
         private async Task tryAgain()

--- a/Toggl.Foundation.MvvmCross/ViewModels/RatingViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/RatingViewModel.cs
@@ -72,21 +72,21 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             this.navigationService = navigationService;
             this.schedulerProvider = schedulerProvider;
 
-            Impression = impressionSubject.AsDriver(this.schedulerProvider);
+            Impression = impressionSubject.AsDriver();
 
             CtaTitle = impressionSubject
                 .Select(ctaTitle)
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             CtaDescription = impressionSubject
                 .Select(ctaDescription)
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             CtaButtonTitle = impressionSubject
                 .Select(ctaButtonTitle)
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
-            IsFeedbackSuccessViewShowing = isFeedbackSuccessViewShowing.AsDriver(this.schedulerProvider);
+            IsFeedbackSuccessViewShowing = isFeedbackSuccessViewShowing.AsDriver();
         }
 
         public void CloseFeedbackSuccessView()

--- a/Toggl.Foundation.MvvmCross/ViewModels/Reports/ReportsBarChartViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Reports/ReportsBarChartViewModel.cs
@@ -39,18 +39,18 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Reports
 
             DateFormat = preferencesDataSource.Current
                 .Select(preferences => preferences.DateFormat)
-                .AsDriver(onErrorJustReturn: defaultDateFormat, schedulerProvider: schedulerProvider);
+                .AsDriver(onErrorJustReturn: defaultDateFormat);
 
             var finalReports = reports.Share();
 
             Bars = finalReports.Select(bars)
-                .AsDriver(onErrorJustReturn: Array.Empty<BarViewModel>(), schedulerProvider: schedulerProvider);
+                .AsDriver(onErrorJustReturn: Array.Empty<BarViewModel>());
 
             MaximumHoursPerBar = finalReports.Select(upperHoursLimit)
-                .AsDriver(onErrorJustReturn: 0, schedulerProvider: schedulerProvider);
+                .AsDriver(onErrorJustReturn: 0);
 
             HorizontalLegend = finalReports.Select(weeklyLegend)
-                .AsDriver(onErrorJustReturn: null, schedulerProvider: schedulerProvider);
+                .AsDriver(onErrorJustReturn: null);
         }
 
         private BarViewModel[] bars(ITimeEntriesTotals report)

--- a/Toggl.Foundation.MvvmCross/ViewModels/Reports/ReportsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Reports/ReportsViewModel.cs
@@ -186,14 +186,14 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Reports
             ToggleCalendarCommand = new MvxCommand(ToggleCalendar);
             ChangeDateRangeCommand = new MvxCommand<ReportsDateRangeParameter>(changeDateRange);
 
-            IsLoadingObservable = isLoading.AsObservable().StartWith(true).AsDriver(schedulerProvider);
-            StartDate = startDateSubject.AsObservable().AsDriver(schedulerProvider);
-            EndDate = endDateSubject.AsObservable().AsDriver(schedulerProvider);
+            IsLoadingObservable = isLoading.AsObservable().StartWith(true).AsDriver();
+            StartDate = startDateSubject.AsObservable().AsDriver();
+            EndDate = endDateSubject.AsObservable().AsDriver();
 
             WorkspaceNameObservable = workspaceSubject
                 .Select(workspace => workspace?.Name ?? string.Empty)
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             WorkspaceHasBillableFeatureEnabled = workspaceSubject
                 .Where(workspace => workspace != null)
@@ -201,11 +201,11 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Reports
                 .Select(workspaceFeatures => workspaceFeatures.IsEnabled(WorkspaceFeatureId.Pro))
                 .StartWith(false)
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             CurrentDateRangeStringObservable = currentDateRangeStringSubject
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             WorkspacesObservable = dataSource.Workspaces
                 .ItemsChanged()
@@ -214,7 +214,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Reports
                 .DistinctUntilChanged()
                 .Select(list => list.Where(w => !w.IsInaccessible))
                 .Select(readOnlyWorkspaceNameTuples)
-                .AsDriver(schedulerProvider);
+                .AsDriver();
         }
 
         public override void Prepare(ReportPeriod parameter)

--- a/Toggl.Foundation.MvvmCross/ViewModels/Settings/SendFeedbackViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Settings/SendFeedbackViewModel.cs
@@ -58,15 +58,15 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             this.interactorFactory = interactorFactory;
             this.navigationService = navigationService;
 
-            IsFeedbackEmpty = isEmptyObservable.DistinctUntilChanged().AsDriver(schedulerProvider);
-            SendEnabled = sendingIsEnabledObservable.DistinctUntilChanged().AsDriver(schedulerProvider);
+            IsFeedbackEmpty = isEmptyObservable.DistinctUntilChanged().AsDriver();
+            SendEnabled = sendingIsEnabledObservable.DistinctUntilChanged().AsDriver();
 
             Close = UIAction.FromObservable(cancel);
             DismissError = UIAction.FromAction(dismissError);
             Send = UIAction.FromObservable(sendFeedback, sendingIsEnabledObservable);
 
-            IsLoading = isLoadingSubject.AsDriver(false, schedulerProvider);
-            Error = currentErrorSubject.AsDriver(default(Exception), schedulerProvider);
+            IsLoading = isLoadingSubject.AsDriver(false);
+            Error = currentErrorSubject.AsDriver(default(Exception));
         }
 
         private void dismissError()

--- a/Toggl.Foundation.MvvmCross/ViewModels/SignupViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/SignupViewModel.cs
@@ -119,48 +119,48 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             var emailObservable = emailSubject.Select(email => email.TrimmedEnd());
 
-            Shake = shakeSubject.AsDriver(this.schedulerProvider);
+            Shake = shakeSubject.AsDriver();
 
             Email = emailObservable
                 .Select(email => email.ToString())
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             Password = passwordSubject
                 .Select(password => password.ToString())
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsLoading = isLoadingSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsCountryErrorVisible = isCountryErrorVisibleSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             ErrorMessage = errorMessageSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             CountryButtonTitle = countryNameSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsPasswordMasked = isPasswordMaskedSubject
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             IsShowPasswordButtonVisible = Password
                 .Select(password => password.Length > 1)
                 .CombineLatest(isShowPasswordButtonVisibleSubject.AsObservable(), CommonFunctions.And)
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             HasError = ErrorMessage
                 .Select(string.IsNullOrEmpty)
                 .Select(CommonFunctions.Invert)
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
 
             SignupEnabled = emailObservable
                 .CombineLatest(
@@ -169,7 +169,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                     countryNameSubject.AsObservable(),
                     (email, password, isLoading, countryName) => email.IsValid && password.IsValid && !isLoading && (countryName != Resources.SelectCountry))
                 .DistinctUntilChanged()
-                .AsDriver(this.schedulerProvider);
+                .AsDriver();
         }
 
         public override void Prepare(CredentialsParameter parameter)
@@ -249,7 +249,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             if (!termsOfServiceAccepted)
                 return;
-            
+
             if (isLoadingSubject.Value) return;
 
             isLoadingSubject.OnNext(true);

--- a/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
@@ -98,8 +98,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                            && shouldSuggestProjectCreation;
 
                 if (IsSuggestingTags)
-                    return Suggestions.None(c => c.Any(s => 
-                               s is TagSuggestion tS 
+                    return Suggestions.None(c => c.Any(s =>
+                               s is TagSuggestion tS
                                && tS.Name.IsSameCaseInsensitiveTrimedTextAs(CurrentQuery)))
                            && CurrentQuery.IsAllowedTagByteSize();
 
@@ -249,7 +249,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             OnboardingStorage = onboardingStorage;
 
-            TextFieldInfoObservable = uiSubject.AsDriver(this.schedulerProvider);
+            TextFieldInfoObservable = uiSubject.AsDriver();
 
             BackCommand = new MvxAsyncCommand(Close);
             DoneCommand = new MvxAsyncCommand(done);
@@ -403,7 +403,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             return true;
         }
 
-        private void onUserChanged(IThreadSafeUser user) 
+        private void onUserChanged(IThreadSafeUser user)
         {
             BeginningOfWeek = user.BeginningOfWeek;
         }

--- a/Toggl.Foundation.MvvmCross/ViewModels/SuggestionsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/SuggestionsViewModel.cs
@@ -57,17 +57,17 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             Suggestions = Observable
                 .CombineLatest(
-                    dataSource.Workspaces.ItemsChanged(), 
+                    dataSource.Workspaces.ItemsChanged(),
                     dataSource.TimeEntries.ItemsChanged())
                 .SelectUnit()
                 .StartWith(Unit.Default)
                 .SelectMany(_ => getSuggestions())
-                .AsDriver(onErrorJustReturn: new Suggestion[0], schedulerProvider: schedulerProvider);
+                .AsDriver(onErrorJustReturn: new Suggestion[0]);
 
             IsEmpty = Suggestions
                 .Select(suggestions => suggestions.Length == 0)
                 .StartWith(true)
-                .AsDriver(onErrorJustReturn: true, schedulerProvider: schedulerProvider);
+                .AsDriver(onErrorJustReturn: true);
         }
 
         private IObservable<Suggestion[]> getSuggestions()

--- a/Toggl.Foundation.MvvmCross/ViewModels/TimeEntriesViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/TimeEntriesViewModel.cs
@@ -66,7 +66,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             DelayDeleteTimeEntry = InputAction<TimeEntryViewModel>.FromAction(delayDeleteTimeEntry);
             CancelDeleteTimeEntry = UIAction.FromAction(cancelDeleteTimeEntry);
 
-            ShouldShowUndo = showUndoSubject.AsObservable().AsDriver(schedulerProvider);
+            ShouldShowUndo = showUndoSubject.AsObservable().AsDriver();
         }
 
         public async Task Initialize()

--- a/Toggl.Foundation.MvvmCross/ViewModels/TokenResetViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/TokenResetViewModel.cs
@@ -82,24 +82,24 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             this.schedulerProvider = schedulerProvider;
 
             Error = errorSubject
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             Email = emailSubject
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             IsPasswordMasked = isPasswordMaskedSubject
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             Password = passwordSubject
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             HasError = Error
                 .Select(error => !string.IsNullOrEmpty(error))
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             TogglePasswordVisibility = UIAction.FromAction(togglePasswordVisibility);
             SetPassword = InputAction<string>.FromAction(setPassword);
@@ -109,12 +109,12 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             IsLoading = Done.Executing
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
 
             NextIsEnabled = Password
                 .CombineLatest(Done.Executing, (password, isExecuting) => password.IsValid && !isExecuting)
                 .DistinctUntilChanged()
-                .AsDriver(schedulerProvider);
+                .AsDriver();
         }
 
         public override async Task Initialize()

--- a/Toggl.Giskard/Startup/Setup.cs
+++ b/Toggl.Giskard/Startup/Setup.cs
@@ -24,6 +24,7 @@ using Toggl.Foundation.Suggestions;
 using Toggl.Giskard.BroadcastReceivers;
 using Toggl.Giskard.Presenters;
 using Toggl.Giskard.Services;
+using Toggl.Multivac;
 using Toggl.Multivac.Extensions;
 using Toggl.PrimeRadiant.Realm;
 using Toggl.PrimeRadiant.Settings;
@@ -89,6 +90,7 @@ namespace Toggl.Giskard
             var settingsStorage = new SettingsStorage(appVersion, keyValueStorage);
             var feedbackService = new FeedbackService(userAgent, mailService, dialogService, platformConstants);
             var schedulerProvider = new AndroidSchedulerProvider();
+            RxApp.MainScheduler = schedulerProvider.MainScheduler;
             var permissionsService = new PermissionsServiceAndroid();
             var calendarService = new CalendarServiceAndroid(permissionsService);
 

--- a/Toggl.Multivac/Extensions/ReactiveExtensions.cs
+++ b/Toggl.Multivac/Extensions/ReactiveExtensions.cs
@@ -58,15 +58,12 @@ namespace Toggl.Multivac.Extensions
         public static IObservable<T> Share<T>(this IObservable<T> observable)
             => observable.Publish().RefCount();
 
-        public static IObservable<T> AsDriver<T>(this IObservable<T> observable, T onErrorJustReturn, ISchedulerProvider schedulerProvider)
+        public static IObservable<T> AsDriver<T>(this IObservable<T> observable, T onErrorJustReturn)
         {
-            if (schedulerProvider.MainScheduler == null)
-                throw new InvalidOperationException("You need to set the MainThreadScheduler property before using the AsDriver extension");
-
             return observable
                 .Replay(1).RefCount()
                 .Catch(Observable.Return(onErrorJustReturn))
-                .ObserveOn(schedulerProvider.MainScheduler);
+                .ObserveOn(RxApp.MainScheduler);
         }
 
         public static IObservable<TValue> NotNullable<TValue>(this IObservable<TValue?> observable)

--- a/Toggl.Multivac/Extensions/RxAction/InputAction.cs
+++ b/Toggl.Multivac/Extensions/RxAction/InputAction.cs
@@ -14,6 +14,9 @@ namespace Toggl.Multivac.Extensions
         {
         }
 
+        public IObservable<Unit> Execute(TInput input)
+            => Execute(input).ObserveOn(RxApp.MainScheduler);
+
         public static InputAction<TInput> FromAction(Action<TInput> action)
         {
             IObservable<Unit> workFactory(TInput input)
@@ -37,6 +40,11 @@ namespace Toggl.Multivac.Extensions
 
         public static InputAction<TInput> FromObservable(Func<TInput, IObservable<Unit>> workFactory, IObservable<bool> enabledIf = null)
             => new InputAction<TInput>(workFactory, enabledIf);
+
+        public new IObservable<Exception> Errors => base.Errors.ObserveOn(RxApp.MainScheduler);
+        public new IObservable<Unit> Elements => base.Elements.ObserveOn(RxApp.MainScheduler);
+        public new IObservable<bool> Executing => base.Executing.ObserveOn(RxApp.MainScheduler);
+        public new IObservable<bool> Enabled => base.Executing.ObserveOn(RxApp.MainScheduler);
     }
 
     public static class CompletableActionExtensions

--- a/Toggl.Multivac/Extensions/RxAction/UIAction.cs
+++ b/Toggl.Multivac/Extensions/RxAction/UIAction.cs
@@ -15,7 +15,7 @@ namespace Toggl.Multivac.Extensions
         }
 
         public IObservable<Unit> Execute()
-            => Execute(Unit.Default);
+            => Execute(Unit.Default).ObserveOn(RxApp.MainScheduler);
 
         public static UIAction FromAction(Action action, IObservable<bool> enabledIf = null)
         {
@@ -40,6 +40,11 @@ namespace Toggl.Multivac.Extensions
 
         public static UIAction FromObservable(Func<IObservable<Unit>> workFactory, IObservable<bool> enabledIf = null)
             => new UIAction(workFactory, enabledIf);
+
+        public new IObservable<Exception> Errors => base.Errors.ObserveOn(RxApp.MainScheduler);
+        public new IObservable<Unit> Elements => base.Elements.ObserveOn(RxApp.MainScheduler);
+        public new IObservable<bool> Executing => base.Executing.ObserveOn(RxApp.MainScheduler);
+        public new IObservable<bool> Enabled => base.Executing.ObserveOn(RxApp.MainScheduler);
     }
 
     public static class RxActionExtensions

--- a/Toggl.Multivac/RxApp.cs
+++ b/Toggl.Multivac/RxApp.cs
@@ -1,0 +1,9 @@
+using System.Reactive.Concurrency;
+
+namespace Toggl.Multivac
+{
+    public class RxApp
+    {
+        public static IScheduler MainScheduler;
+    }
+}


### PR DESCRIPTION
## What's this?
This is a proposal on how to handle `MainThread` and `MainThread` only in an application wide scope. 

I don't have my hopes up on this being merged, I'm just wondering if we can find a way of doing something similar.

The idea is that things like what the UI thread is, are cross-cutting concerns and shouldn't need to be injected all around. Specifically with this there's not much danger being a system property that won't ever change. 

This allows for the scheduler to be switched with a test one for tests as well, I don't think we need that, though. As I said this is only for the UI thread, if something needs another scheduler, it still has to be injected.

This is sort of based on how ReactiveUI [handles the main thread](https://reactiveui.net/docs/guidelines/framework/ui-thread-and-schedulers). You can see the code [here](https://github.com/reactiveui/ReactiveUI/search?utf8=✓&q=RxApp.MainThreadScheduler&type=).

## Why do we want this?
This is mainly motivated by problems with actions not returning in the main thread, when I think they totally should (only `UIAction` and `InputAction`)

## How is it done?
There's a class called `RxApp` which has a static property called `MainScheduler`, that's it.

I'll admit it's a little ugly right now, we may find a better way of doing it. The only objective is easy access to the UI thread. As I said it's a cross-cutting concern and a non-mutable property.

### Why not another way?
The alternative to this is using factories to make actions creation easier. Maybe there's also a better approach for drivers, I can't say right now, though.

## :squid: Permissions
This is mainly for discussion, so don't.