### PR TITLE
Subscribe async

### DIFF
--- a/Toggl.Daneel/ViewControllers/LoginViewController.cs
+++ b/Toggl.Daneel/ViewControllers/LoginViewController.cs
@@ -98,7 +98,7 @@ namespace Toggl.Daneel.ViewControllers
 
             //Commands
             SignupCard.Rx().Tap()
-                .Subscribe(ViewModel.Signup)
+                .SubscribeAsync(ViewModel.Signup)
                 .DisposedBy(DisposeBag);
 
             LoginButton.Rx().Tap()
@@ -110,11 +110,11 @@ namespace Toggl.Daneel.ViewControllers
                 .DisposedBy(DisposeBag);
 
             ForgotPasswordButton.Rx().Tap()
-                .Subscribe(ViewModel.ForgotPassword)
+                .SubscribeAsync(ViewModel.ForgotPassword)
                 .DisposedBy(DisposeBag);
 
             PasswordManagerButton.Rx().Tap()
-                .Subscribe(ViewModel.StartPasswordManager)
+                .SubscribeAsync(ViewModel.StartPasswordManager)
                 .DisposedBy(DisposeBag);
 
             ShowPasswordButton.Rx().Tap()

--- a/Toggl.Daneel/ViewControllers/ReportsViewController.cs
+++ b/Toggl.Daneel/ViewControllers/ReportsViewController.cs
@@ -93,7 +93,7 @@ namespace Toggl.Daneel.ViewControllers
                 .DisposedBy(DisposeBag);
 
             WorkspaceButton.Rx().Tap()
-                .Subscribe(ViewModel.SelectWorkspace)
+                .SubscribeAsync(ViewModel.SelectWorkspace)
                 .DisposedBy(DisposeBag);
 
             var bindingSet = this.CreateBindingSet<ReportsViewController, ReportsViewModel>();

--- a/Toggl.Daneel/ViewControllers/Settings/SettingsViewController.cs
+++ b/Toggl.Daneel/ViewControllers/Settings/SettingsViewController.cs
@@ -77,31 +77,31 @@ namespace Toggl.Daneel.ViewControllers
                 .DisposedBy(DisposeBag);
 
             HelpView.Rx().Tap()
-                .Subscribe(ViewModel.OpenHelpView)
+                .SubscribeAsync(ViewModel.OpenHelpView)
                 .DisposedBy(DisposeBag);
 
             LogoutButton.Rx().Tap()
-                .Subscribe(ViewModel.TryLogout)
+                .SubscribeAsync(ViewModel.TryLogout)
                 .DisposedBy(DisposeBag);
 
             AboutView.Rx().Tap()
-                .Subscribe(ViewModel.OpenAboutView)
+                .SubscribeAsync(ViewModel.OpenAboutView)
                 .DisposedBy(DisposeBag);
 
             FeedbackView.Rx().Tap()
-                .Subscribe(ViewModel.SubmitFeedback)
+                .SubscribeAsync(ViewModel.SubmitFeedback)
                 .DisposedBy(DisposeBag);
 
             DateFormatView.Rx().Tap()
-                .Subscribe(ViewModel.SelectDateFormat)
+                .SubscribeAsync(ViewModel.SelectDateFormat)
                 .DisposedBy(DisposeBag);
 
             WorkspaceView.Rx().Tap()
-                .Subscribe(ViewModel.PickDefaultWorkspace)
+                .SubscribeAsync(ViewModel.PickDefaultWorkspace)
                 .DisposedBy(DisposeBag);
 
             DurationFormatView.Rx().Tap()
-                .Subscribe(ViewModel.SelectDurationFormat)
+                .SubscribeAsync(ViewModel.SelectDurationFormat)
                 .DisposedBy(DisposeBag);
 
             ManualModeSwitch.Rx().Changed()
@@ -109,7 +109,7 @@ namespace Toggl.Daneel.ViewControllers
                 .DisposedBy(DisposeBag);
 
             BeginningOfWeekView.Rx().Tap()
-                .Subscribe(ViewModel.SelectBeginningOfWeek)
+                .SubscribeAsync(ViewModel.SelectBeginningOfWeek)
                 .DisposedBy(DisposeBag);
 
             CalendarSettingsView.Rx()

--- a/Toggl.Daneel/ViewControllers/SignupViewController.cs
+++ b/Toggl.Daneel/ViewControllers/SignupViewController.cs
@@ -104,11 +104,11 @@ namespace Toggl.Daneel.ViewControllers
 
             //Commands
             LoginCard.Rx().Tap()
-                .Subscribe(ViewModel.Login)
+                .SubscribeAsync(ViewModel.Login)
                 .DisposedBy(DisposeBag);
 
             SignupButton.Rx().Tap()
-                .Subscribe(ViewModel.Signup)
+                .SubscribeAsync(ViewModel.Signup)
                 .DisposedBy(DisposeBag);
 
             GoogleSignupButton.Rx().Tap()
@@ -120,7 +120,7 @@ namespace Toggl.Daneel.ViewControllers
                 .DisposedBy(DisposeBag);
 
             SelectCountryButton.Rx().Tap()
-                .Subscribe(ViewModel.PickCountry)
+                .SubscribeAsync(ViewModel.PickCountry)
                 .DisposedBy(DisposeBag);
 
             //Color

--- a/Toggl.Daneel/Views/Rating/RatingView.cs
+++ b/Toggl.Daneel/Views/Rating/RatingView.cs
@@ -101,7 +101,7 @@ namespace Toggl.Daneel
                 .DisposedBy(DisposeBag);
 
             CtaButton.Rx().Tap()
-                .Subscribe(DataContext.PerformMainAction)
+                .SubscribeAsync(DataContext.PerformMainAction)
                 .DisposedBy(DisposeBag);
 
             DismissButton.Rx().Tap()

--- a/Toggl.Foundation.MvvmCross/Extensions/ObservableExtensions.cs
+++ b/Toggl.Foundation.MvvmCross/Extensions/ObservableExtensions.cs
@@ -16,8 +16,11 @@ namespace Toggl.Foundation.MvvmCross.Extensions
         public static IDisposable VoidSubscribe<T>(this IObservable<T> observable, Action onNext)
             => observable.Subscribe((T _) => onNext());
 
-        public static IDisposable Subscribe(this IObservable<Unit> observable, Func<Task> onNext)
-            => observable.Subscribe(async (Unit _) => await onNext());
+        public static IDisposable SubscribeAsync(this IObservable<Unit> observable, Func<Task> onNextAsync)
+            => observable
+                .Select(_ => Observable.FromAsync(onNextAsync))
+                .Concat()
+                .Subscribe();
 
         public static IObservable<T> DeferAndThrowIfPermissionNotGranted<T>(this IObservable<bool> permissionGrantedObservable, Func<IObservable<T>> implementation)
             => Observable.DeferAsync(async cancellationToken =>

--- a/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
@@ -174,7 +174,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
                 .Merge(dayChangedObservable)
                 .Merge(selectedCalendarsChangedObservable)
                 .Merge(appResumedFromBackgroundObservable)
-                .Subscribe(reloadData)
+                .SubscribeAsync(reloadData)
                 .DisposedBy(disposeBag);
 
             selectedCalendarsChangedObservable

--- a/Toggl.Foundation.MvvmCross/ViewModels/Settings/NotificationSettingsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Settings/NotificationSettingsViewModel.cs
@@ -56,7 +56,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Settings
             backgroundService
                 .AppResumedFromBackground
                 .SelectUnit()
-                .Subscribe(refreshPermissionGranted)
+                .SubscribeAsync(refreshPermissionGranted)
                 .DisposedBy(disposeBag);
 
             RequestAccess = UIAction.FromAction(requestAccess);

--- a/Toggl.Giskard/Activities/LoginActivity.cs
+++ b/Toggl.Giskard/Activities/LoginActivity.cs
@@ -67,7 +67,7 @@ namespace Toggl.Giskard.Activities
 
             //Commands
             signupCard.Rx().Tap()
-                .Subscribe(ViewModel.Signup)
+                .SubscribeAsync(ViewModel.Signup)
                 .DisposedBy(DisposeBag);
 
             loginButton.Rx().Tap()
@@ -83,7 +83,7 @@ namespace Toggl.Giskard.Activities
                 .DisposedBy(DisposeBag);
 
             forgotPasswordView.Rx().Tap()
-                .Subscribe(ViewModel.ForgotPassword)
+                .SubscribeAsync(ViewModel.ForgotPassword)
                 .DisposedBy(DisposeBag);
 
             string loginButtonTitle(bool isLoading)

--- a/Toggl.Giskard/Activities/ReportsActivity.cs
+++ b/Toggl.Giskard/Activities/ReportsActivity.cs
@@ -39,7 +39,7 @@ namespace Toggl.Giskard.Activities
             initializeViews();
 
             selectWorkspaceFAB.Rx().Tap()
-                .Subscribe(ViewModel.SelectWorkspace)
+                .SubscribeAsync(ViewModel.SelectWorkspace)
                 .DisposedBy(DisposeBag);
 
             ViewModel.WorkspaceNameObservable

--- a/Toggl.Giskard/Activities/SettingsActivity.cs
+++ b/Toggl.Giskard/Activities/SettingsActivity.cs
@@ -98,15 +98,15 @@ namespace Toggl.Giskard.Activities
                 .DisposedBy(DisposeBag);
 
             helpView.Rx().Tap()
-                .Subscribe(ViewModel.OpenHelpView)
+                .SubscribeAsync(ViewModel.OpenHelpView)
                 .DisposedBy(DisposeBag);
 
             aboutView.Rx().Tap()
-                .Subscribe(ViewModel.OpenAboutView)
+                .SubscribeAsync(ViewModel.OpenAboutView)
                 .DisposedBy(DisposeBag);
 
             feedbackView.Rx().Tap()
-                .Subscribe(ViewModel.SubmitFeedback)
+                .SubscribeAsync(ViewModel.SubmitFeedback)
                 .DisposedBy(DisposeBag);
 
             manualModeView.Rx().Tap()
@@ -126,7 +126,7 @@ namespace Toggl.Giskard.Activities
                 .DisposedBy(DisposeBag);
 
             beginningOfWeekView.Rx().Tap()
-                .Subscribe(ViewModel.SelectBeginningOfWeek)
+                .SubscribeAsync(ViewModel.SelectBeginningOfWeek)
                 .DisposedBy(DisposeBag);
 
             setupToolbar();

--- a/Toggl.Giskard/Activities/SignUpActivity.cs
+++ b/Toggl.Giskard/Activities/SignUpActivity.cs
@@ -78,15 +78,15 @@ namespace Toggl.Giskard.Activities
 
             //Commands
             loginCard.Rx().Tap()
-                .Subscribe(ViewModel.Login)
+                .SubscribeAsync(ViewModel.Login)
                 .DisposedBy(DisposeBag);
 
             signupButton.Rx().Tap()
-                .Subscribe(ViewModel.Signup)
+                .SubscribeAsync(ViewModel.Signup)
                 .DisposedBy(DisposeBag);
 
             passwordEditText.Rx().EditorActionSent()
-                .Subscribe(ViewModel.Signup)
+                .SubscribeAsync(ViewModel.Signup)
                 .DisposedBy(DisposeBag);
 
             googleSignupButton.Rx().Tap()
@@ -94,7 +94,7 @@ namespace Toggl.Giskard.Activities
                 .DisposedBy(DisposeBag);
 
             countrySelection.Rx().Tap()
-                .Subscribe(ViewModel.PickCountry)
+                .SubscribeAsync(ViewModel.PickCountry)
                 .DisposedBy(DisposeBag);
 
             string signupButtonTitle(bool isLoading)


### PR DESCRIPTION
## What's this?
Renames a specific override of `Subscribe` to `SubscribeAsync` and changes its implementation.

## Why do we want this?
If we check the old implementation of this override, we can see that the `Subscribe` method it's using internally takes an `Action<Unit>`, this, apparently can cause some problems if an exception occurs in the `onNext` Action. I've tested that and you can't catch that exception.

Also, `Subscribe` will not await for that lambda, so new values may come through (there'll be no back pressure) and that may result in uncontrolled concurrency.

To me it just seemed strange to mix Rx and async/await in that way, given that Rx is mainly synchronous. After some search, it seems like my suspicion was right. I tried to write some tests to prove this, but I've only been able to prove the unhandled exception thing. Any ideas about the rest are welcome.

There's more info in [this article](https://github.com/dotnet/reactive/issues/459).

## How is it done?
Instead one the funky use of async/await inside `Subscribe`, we'll first `Select` transforming our `Task` into an `Observable` and then `Concat` so it flattens back all events, in the same order, before subscribing.

There's another possibility described in the article, which is to use `Merge` instead of `Concat`, but that's for concurrency and in case we need that it can be done some other way, this is just about simplifying this operator.

## Also
Some of the usages of this operator could (and should) be replaced with `UIAction`, but that'll be another PR.

## :squid: Permissions
If @willsb approves.