### PR TITLE
Make sync graph prettier

### DIFF
--- a/Toggl.Foundation/Properties/AssemblyInfo.cs
+++ b/Toggl.Foundation/Properties/AssemblyInfo.cs
@@ -10,5 +10,6 @@ using Toggl.Multivac;
 [assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("Toggl.Foundation.Tests")]
 [assembly: InternalsVisibleTo("Toggl.Foundation.Sync.Tests")]
+[assembly: InternalsVisibleTo("SyncDiagramGenerator")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 [assembly: LinkerSafe]

--- a/Toggl.Tools/SyncDiagramGenerator/DotFileWriter.cs
+++ b/Toggl.Tools/SyncDiagramGenerator/DotFileWriter.cs
@@ -3,11 +3,25 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SyncDiagramGenerator
 {
     internal sealed class DotFileWriter
     {
+        private static readonly string[] subGraphStartNodes =
+        {
+            "PushState", "PushSingleState",
+            "EnsureFetchListSucceededState", "EnsureFetchSingletonSucceededState",
+            "SevereApiExceptionsRethrowingState"
+        };
+
+        private static readonly string[] subGraphTerminationNodes =
+        {
+            "FetchAllSinceState", "DeadEndState", "Loose End"
+        };
+
+
         public void WriteToFile(string outPath, List<Node> nodes, List<Edge> edges)
         {
             Console.WriteLine($"Assigning unique ids to {nodes.Count} nodes");
@@ -19,6 +33,11 @@ namespace SyncDiagramGenerator
             cleanUpLabels(nodes);
             cleanUpLabels(edges);
 
+            Console.WriteLine("Creating sub graphs");
+
+            markSubGraphStartNodes(nodes);
+            floodFillSubGraphs(edges);
+
             Console.WriteLine($"Serialising {nodes.Count} nodes and {edges.Count} edges to DOT format");
 
             var fileContent = serialise(nodes, edges);
@@ -26,6 +45,39 @@ namespace SyncDiagramGenerator
             Console.WriteLine($"Writing DOT file to {outPath}");
 
             File.WriteAllText(outPath, fileContent);
+        }
+
+        private void markSubGraphStartNodes(List<Node> nodes)
+        {
+            foreach (var node in nodes.Where(node => subGraphStartNodes.Any(name => node.Id.Contains(name))))
+            {
+                node.SubGraph = new SubGraph { SourceNode = node };
+                node.SubGraph.Nodes.Add(node);
+            }
+        }
+
+        private void floodFillSubGraphs(List<Edge> edges)
+        {
+            var propagationCandidates = edges.ToList();
+
+            while (propagationCandidates.RemoveAll(tryPropagateSubGraph) > 0)
+            {
+            }
+        }
+
+        private bool tryPropagateSubGraph(Edge edge)
+        {
+            var subGraph = edge.From.SubGraph;
+            if (subGraph == null || edge.To.SubGraph != null)
+                return false;
+
+            if (subGraphTerminationNodes.Any(name => edge.To.Id.Contains(name)))
+                return false;
+
+            edge.To.SubGraph = subGraph;
+            subGraph.Nodes.Add(edge.To);
+            subGraph.Edges.Add(edge);
+            return true;
         }
 
         private void cleanUpLabels(IEnumerable<ILabeled> labeledList)
@@ -80,25 +132,72 @@ namespace SyncDiagramGenerator
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine("digraph SyncGraph {");
+            writeFileStart(builder);
 
-            builder.AppendLine("node [shape=box,style=rounded];");
-
-            foreach (var node in nodes)
+            foreach (var subGraphGroup in nodes.GroupBy(n => n.SubGraph))
             {
-                var nodeAttributes = getAttributes(node);
-                var attributeString = string.Join(",", nodeAttributes.Select(a => $"{a.Key}=\"{a.Value}\""));
-                builder.AppendLine($"{node.Id} [{attributeString}];");
+                writeSubGraphGroup(subGraphGroup, builder);
             }
 
             foreach (var edge in edges)
             {
-                builder.AppendLine($"{edge.From.Id} -> {edge.To.Id} [label=\"{edge.Label}\"];");
+                writeEdge(edge, builder);
             }
 
-            builder.AppendLine("}");
+            writeFileEnd(builder);
 
             return builder.ToString();
+        }
+
+        private void writeSubGraphGroup(IGrouping<SubGraph, Node> subGraphGroup, StringBuilder builder)
+        {
+            var subGraph = subGraphGroup.Key;
+
+            if (subGraph != null)
+                writeSubGraphHeader(subGraph, builder);
+
+            foreach (var node in subGraphGroup)
+            {
+                writeNode(node, builder);
+            }
+
+            if (subGraph != null)
+                writeSubGraphFooter(builder);
+        }
+
+        private void writeSubGraphHeader(SubGraph subGraph, StringBuilder builder)
+        {
+            // "cluster" is a syntactic prefix, do not change!
+            builder.AppendLine($"subgraph \"cluster {subGraph.SourceNode.Id.Trim('"')}\" {{");
+        }
+
+        private void writeSubGraphFooter(StringBuilder builder)
+        {
+            builder.AppendLine("}");
+        }
+
+        private static void writeFileStart(StringBuilder builder)
+        {
+            builder.AppendLine("digraph SyncGraph {");
+            builder.AppendLine("newrank=true;");
+            builder.AppendLine("node [shape=box,style=rounded];");
+        }
+
+        private static void writeFileEnd(StringBuilder builder)
+        {
+            builder.AppendLine("}");
+        }
+
+        private static void writeEdge(Edge edge, StringBuilder builder)
+        {
+            builder.AppendLine($"{edge.From.Id} -> {edge.To.Id} [label=\"{edge.Label}\"];");
+        }
+
+        private void writeNode(Node node, StringBuilder builder)
+        {
+            var nodeAttributes = getAttributes(node);
+            var attributeString = string.Join(",", nodeAttributes.Select(a => $"{a.Key}=\"{a.Value}\""));
+            builder.AppendLine($"{node.Id} [{attributeString}];");
         }
 
         private List<(string Key, string Value)> getAttributes(Node node)

--- a/Toggl.Tools/SyncDiagramGenerator/Node.cs
+++ b/Toggl.Tools/SyncDiagramGenerator/Node.cs
@@ -13,5 +13,6 @@
         public string Id { get; set; }
         public string Label { get; set; }
         public NodeType Type { get; set; }
+        public SubGraph SubGraph { get; set; }
     }
 }

--- a/Toggl.Tools/SyncDiagramGenerator/Node.cs
+++ b/Toggl.Tools/SyncDiagramGenerator/Node.cs
@@ -8,6 +8,8 @@
             EntryPoint = 1,
             DeadEnd = 2,
             InvalidTransitionState = 3,
+            RetryLoop = 4,
+            APIDelayReset = 5,
         }
 
         public string Id { get; set; }

--- a/Toggl.Tools/SyncDiagramGenerator/SubGraph.cs
+++ b/Toggl.Tools/SyncDiagramGenerator/SubGraph.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace SyncDiagramGenerator
+{
+    internal sealed class SubGraph
+    {
+        public Node SourceNode { get; set; }
+
+        public List<Node> Nodes { get; } = new List<Node>();
+        public List<Edge> Edges { get; } = new List<Edge>();
+    }
+}

--- a/Toggl.Tools/SyncDiagramGenerator/SyncDiagramGenerator.cs
+++ b/Toggl.Tools/SyncDiagramGenerator/SyncDiagramGenerator.cs
@@ -11,6 +11,7 @@ using Toggl.Foundation.Analytics;
 using Toggl.Foundation.DataSources;
 using Toggl.Foundation.Sync;
 using Toggl.Foundation.Sync.States;
+using Toggl.Foundation.Sync.States.Push;
 using Toggl.PrimeRadiant;
 using Toggl.Ultrawave;
 
@@ -149,8 +150,23 @@ namespace SyncDiagramGenerator
                 s => new Node
                 {
                     Label = fullGenericTypeName(s.GetType()),
-                    Type = s is InvalidTransitionState ? Node.NodeType.InvalidTransitionState : Node.NodeType.Regular
+                    Type = nodeType(s)
                 });
+        }
+
+        private Node.NodeType nodeType(object state)
+        {
+            switch (state)
+            {
+                case InvalidTransitionState _:
+                    return Node.NodeType.InvalidTransitionState;
+                case CheckServerStatusState _:
+                    return Node.NodeType.RetryLoop;
+                case ResetAPIDelayState _:
+                    return Node.NodeType.APIDelayReset;
+                default:
+                    return Node.NodeType.Regular;
+            }
         }
 
         private string fullGenericTypeName(Type type)


### PR DESCRIPTION
## What's this?
When I say prettier, I mean: easier to use.

I:
- 🔲grouped the subgraphs that deal with specific entities
- 🌈colour coded retry related code
- ↔️trimming of interface prefixes like `IThradSafe`
- [some general Graphviz settings that improve layout](https://github.com/toggl/mobileapp/pull/3721/files#diff-f0e9824227055edb7ab16cb60625ac49R181)

Here is an excerpt of what it looks like now:

<img width="460" alt="screenshot 2018-11-14 at 16 19 16" src="https://user-images.githubusercontent.com/3987892/48496609-50670780-e82a-11e8-92dc-93ec17513d2a.png">

### Relationships
Will look even better once #3717 is merged.

## Why do we want this?
So we can easier see if something is wrong with the graph, use it to teach people about syncing easier, and generally decrease the difficulty of wrapping ones head around it.

## How is it done?
Hardcoding of some special cases, through type and string matching. It'll be easy enough to change if we make significant changes to our syncing algo though.

For the grouping specifically, I added a list of node names that will start a new group, and then use a basic flood fill algorithm to add nodes to graphs by following the arcs. There is also a list of nodes that groupings should not be spread to in such a manner, which prevents things from going funny in the big pull-sync loop.

### Why not another way?
The code could be written nice, no doubt. Using abstractions and fancy matching rules. However, this works and is pretty easy to extend.

### Side effects
I shared the internals of `Foundation` with the diagram renderer project, so I can pattern match by state type easily. Not really a big deal, but worth noting.

## Review hints
Check the generated graph.

## :squid: Permissions
Me.