### PR TITLE
Fix calendar view not observing timezone

### DIFF
--- a/Toggl.Daneel/ViewControllers/Calendar/CalendarViewController.cs
+++ b/Toggl.Daneel/ViewControllers/Calendar/CalendarViewController.cs
@@ -9,7 +9,6 @@ using Toggl.Daneel.Views.Calendar;
 using Toggl.Daneel.ViewSources;
 using Toggl.Foundation;
 using Toggl.Foundation.MvvmCross.Extensions;
-using Toggl.Foundation.MvvmCross.ViewModels;
 using Toggl.Foundation.MvvmCross.ViewModels.Calendar;
 using Toggl.Multivac.Extensions;
 using UIKit;
@@ -57,8 +56,8 @@ namespace Toggl.Daneel.ViewControllers
             var timeService = Mvx.Resolve<ITimeService>();
 
             dataSource = new CalendarCollectionViewSource(
+                timeService,
                 CalendarCollectionView,
-                ViewModel.Date,
                 ViewModel.TimeOfDayFormat,
                 ViewModel.CalendarItems);
 

--- a/Toggl.Daneel/Views/Calendar/CalendarCollectionViewLayout.cs
+++ b/Toggl.Daneel/Views/Calendar/CalendarCollectionViewLayout.cs
@@ -62,12 +62,11 @@ namespace Toggl.Daneel.Views.Calendar
             this.timeService = timeService;
             this.dataSource = dataSource;
 
-            date = timeService.CurrentDateTime.Date;
+            date = timeService.CurrentDateTime.ToLocalTime().Date;
 
             timeService
                 .MidnightObservable
-                .Do(dateTimeOffset => date = dateTimeOffset.Date)
-                .VoidSubscribe(InvalidateLayout)
+                .Subscribe(dateChanged)
                 .DisposedBy(disposeBag);
 
             timeService
@@ -272,6 +271,12 @@ namespace Toggl.Daneel.Views.Calendar
             var y = yHour + yMins - height / 2;
 
             return new CGRect(x, y, width, height);
+        }
+
+        private void dateChanged(DateTimeOffset dateTimeOffset)
+        {
+            date = dateTimeOffset.ToLocalTime().Date;
+            InvalidateLayout();
         }
     }
 }

--- a/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
@@ -301,7 +301,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
 
         private async Task reloadData()
             => await interactorFactory
-                .GetCalendarItemsForDate(timeService.CurrentDateTime.Date)
+                .GetCalendarItemsForDate(timeService.CurrentDateTime.ToLocalTime().Date)
                 .Execute()
                 .Do(CalendarItems.ReplaceWith);
     }

--- a/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
@@ -51,8 +51,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
 
         public IObservable<TimeFormat> TimeOfDayFormat { get; }
 
-        public IObservable<DateTime> Date { get; }
-
         public UIAction GetStarted { get; }
 
         public UIAction SelectCalendars { get; }
@@ -117,8 +115,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
                 .Preferences
                 .Current
                 .Select(preferences => preferences.TimeOfDayFormat);
-
-            Date = Observable.Return(timeService.CurrentDateTime.Date);
 
             GetStarted = UIAction.FromAsync(getStarted);
 


### PR DESCRIPTION
## What's this?
The calendar view wasn't observing the timezone correctly. This introduces a fix for that and removes an unneeded observable.

### Relationships

Closes #3722 

## Why do we want this?
🚫 🐛 

## How is it done?
`.ToLocalTime()` was needed to observe the timezone correctly. I took the opportunity to 🔥 a confusing (and unneeded) observable and make everything depend on `ITimeService`.

### Side effects
None.

## Review hints
Please give it a try in different timezones and make sure what you see in the calendar view is what you expect 😄 

## :squid: Permissions
⛔️ Only me.