### PR TITLE
Use none as default rating view trigger

### DIFF
--- a/Toggl.Giskard/Resources/xml/RemoteConfigDefaults.xml
+++ b/Toggl.Giskard/Resources/xml/RemoteConfigDefaults.xml
@@ -6,7 +6,7 @@
     </entry> 
     <entry> 
         <key>UserRatingDialogTrigger</key> 
-        <value>stop</value> 
+        <value>none</value> 
     </entry> 
     <entry> 
         <key>day_count</key> 
@@ -14,6 +14,6 @@
     </entry> 
     <entry> 
         <key>criterion</key> 
-        <value>stop</value> 
+        <value>none</value> 
     </entry> 
 </defaultsMap> 


### PR DESCRIPTION
## What's this?
Changes the default trigger for rating dialog to `none`.

### Relationships
Closes #3892 

## Why do we want this?
Because if Firebase fails, the users will see the rating dialog.

## How is it done?
Setting the defaults in xml.

## :squid: Permissions
Whoever.