### PR TITLE
Disable the login button on iOS when needed

### DIFF
--- a/Toggl.Daneel/ViewControllers/LoginViewController.cs
+++ b/Toggl.Daneel/ViewControllers/LoginViewController.cs
@@ -96,6 +96,10 @@ namespace Toggl.Daneel.ViewControllers
                 .Subscribe(ViewModel.SetIsShowPasswordButtonVisible)
                 .DisposedBy(DisposeBag);
 
+            ViewModel.LoginEnabled
+                .Subscribe(LoginButton.Rx().Enabled())
+                .DisposedBy(DisposeBag);
+
             //Commands
             SignupCard.Rx()
                 .BindAction(ViewModel.Signup)


### PR DESCRIPTION
## What's this?
Adding a disable subscription to our login button on iOS, we forgot to add it 🙈 

### Relationships
Closes nothing

## Why do we want this?
Consistency.

## How is it done?
By adding the correct subscription.

### Why not another way?
This is the only way.

### Side effects
None

## Review hints
Try a malformed email input.

## :squid: Permissions
All yours!