### PR TITLE
Droid background wheel: background wheel and inner clock

### DIFF
--- a/Toggl.Giskard/Toggl.Giskard.csproj
+++ b/Toggl.Giskard/Toggl.Giskard.csproj
@@ -369,6 +369,7 @@
     <Compile Include="Views\BarChartView.cs" />
     <Compile Include="Views\EditDuration\Shapes\Arc.cs" />
     <Compile Include="Views\EditDuration\Shapes\Cap.cs" />
+    <Compile Include="Views\EditDuration\Shapes\ClockDial.cs" />
     <Compile Include="Views\EditDuration\Shapes\Dot.cs" />
     <Compile Include="Views\EditDuration\Shapes\Wheel.cs" />
     <Compile Include="Views\EditDuration\WheelBackgroundView.cs" />

--- a/Toggl.Giskard/Toggl.Giskard.csproj
+++ b/Toggl.Giskard/Toggl.Giskard.csproj
@@ -371,6 +371,7 @@
     <Compile Include="Views\EditDuration\Shapes\Cap.cs" />
     <Compile Include="Views\EditDuration\Shapes\Dot.cs" />
     <Compile Include="Views\EditDuration\Shapes\Wheel.cs" />
+    <Compile Include="Views\EditDuration\WheelBackgroundView.cs" />
     <Compile Include="Views\EditDuration\WheelForegroundView.cs" />
     <Compile Include="Views\ReportsCalendarView.cs" />
     <Compile Include="Views\SelectProjectRecyclerView.cs" />

--- a/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
+++ b/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
@@ -6,8 +6,9 @@ namespace Toggl.Giskard.Views.EditDuration.Shapes
 {
     public class ClockDial
     {
-        private const int minuteSegmentsPerHourMark = MinutesInAnHour / HoursOnTheClock;
         private const float angleOffsetCorrection = (float) FullCircle / 4f;
+        private const char numberPaddingChar = '0';
+        private const int digitsCount = 2;
         private readonly PointF dialCenter;
         private readonly float textRadius;
         private Rect textBounds = new Rect();
@@ -28,7 +29,7 @@ namespace Toggl.Giskard.Views.EditDuration.Shapes
 
         public void OnDraw(Canvas canvas)
         {
-            for (var minute = 5; minute <= MinutesInAnHour; minute += 5)
+            for (var minute = 0; minute < MinutesInAnHour; minute += 5)
             {
                 var angle = (float) FullCircle * (minute / (float) MinutesInAnHour) - angleOffsetCorrection;
                 drawMinuteNumber(canvas, minute, angle);
@@ -37,7 +38,7 @@ namespace Toggl.Giskard.Views.EditDuration.Shapes
 
         private void drawMinuteNumber(Canvas canvas, int number, float angle)
         {
-            var minuteText = number.ToString();
+            var minuteText = number.ToString().PadLeft(digitsCount, numberPaddingChar);
             var textCenter = PointOnCircumference(dialCenter.ToPoint(), angle, textRadius).ToPointF();
             paint.GetTextBounds(minuteText, 0, minuteText.Length, textBounds);
             var centeredTextX = textCenter.X - textBounds.Width() / 2f;

--- a/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
+++ b/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
@@ -1,0 +1,52 @@
+using Android.Graphics;
+using Toggl.Giskard.Extensions;
+using static Toggl.Multivac.Math;
+
+namespace Toggl.Giskard.Views.EditDuration.Shapes
+{
+    public class ClockDial
+    {
+        private const int minuteSegmentsPerHourMark = MinutesInAnHour / HoursOnTheClock;
+        private const float angleOffsetCorrection = (float) FullCircle / 4f;
+        private readonly PointF dialCenter;
+        private readonly float textRadius;
+        private Rect textBounds = new Rect();
+
+        private readonly Paint paint = new Paint(PaintFlags.AntiAlias)
+        {
+            TextAlign = Paint.Align.Left
+        };
+
+        public ClockDial(PointF dialCenter, float textSize, Color textColor, float textRadius)
+        {
+            this.dialCenter = dialCenter;
+            this.textRadius = textRadius;
+            paint.TextSize = textSize;
+            paint.Color = textColor;
+            paint.SetTypeface(Typeface.Create("sans-serif", TypefaceStyle.Normal));
+        }
+
+        public void OnDraw(Canvas canvas)
+        {
+            for (var minute = 1; minute <= MinutesInAnHour; ++minute)
+            {
+                var angle = (float) FullCircle * (minute / (float) MinutesInAnHour) - angleOffsetCorrection;
+                var correspondsToHourMark = minute % minuteSegmentsPerHourMark == 0;
+                if (correspondsToHourMark)
+                {
+                    drawMinuteNumber(canvas, minute, angle);
+                }
+            }
+        }
+
+        private void drawMinuteNumber(Canvas canvas, int number, float angle)
+        {
+            var minuteText = number.ToString();
+            var textCenter = PointOnCircumference(dialCenter.ToPoint(), angle, textRadius).ToPointF();
+            paint.GetTextBounds(minuteText, 0, minuteText.Length, textBounds);
+            var centeredTextX = textCenter.X - textBounds.Width() / 2f;
+            var centeredTextY = textCenter.Y + textBounds.Height() / 2f;
+            canvas.DrawText(minuteText, centeredTextX, centeredTextY, paint);
+        }
+    }
+}

--- a/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
+++ b/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
@@ -29,14 +29,14 @@ namespace Toggl.Giskard.Views.EditDuration.Shapes
 
         public void OnDraw(Canvas canvas)
         {
-            for (var minute = 0; minute < MinutesInAnHour; minute += 5)
+            for (var minute = 0f; minute < MinutesInAnHour; minute += 5)
             {
-                var angle = (float) FullCircle * (minute / (float) MinutesInAnHour) - angleOffsetCorrection;
-                drawMinuteNumber(canvas, minute, angle);
+                var angle = FullCircle * (minute / MinutesInAnHour) - angleOffsetCorrection;
+                drawMinuteNumber(canvas, minute, (float)angle);
             }
         }
 
-        private void drawMinuteNumber(Canvas canvas, int number, float angle)
+        private void drawMinuteNumber(Canvas canvas, float number, float angle)
         {
             var minuteText = number.ToString().PadLeft(digitsCount, numberPaddingChar);
             var textCenter = PointOnCircumference(dialCenter.ToPoint(), angle, textRadius).ToPointF();

--- a/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
+++ b/Toggl.Giskard/Views/EditDuration/Shapes/ClockDial.cs
@@ -28,14 +28,10 @@ namespace Toggl.Giskard.Views.EditDuration.Shapes
 
         public void OnDraw(Canvas canvas)
         {
-            for (var minute = 1; minute <= MinutesInAnHour; ++minute)
+            for (var minute = 5; minute <= MinutesInAnHour; minute += 5)
             {
                 var angle = (float) FullCircle * (minute / (float) MinutesInAnHour) - angleOffsetCorrection;
-                var correspondsToHourMark = minute % minuteSegmentsPerHourMark == 0;
-                if (correspondsToHourMark)
-                {
-                    drawMinuteNumber(canvas, minute, angle);
-                }
+                drawMinuteNumber(canvas, minute, angle);
             }
         }
 

--- a/Toggl.Giskard/Views/EditDuration/WheelBackgroundView.cs
+++ b/Toggl.Giskard/Views/EditDuration/WheelBackgroundView.cs
@@ -1,0 +1,82 @@
+using System;
+using Android.Content;
+using Android.Graphics;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Toggl.Giskard.Extensions;
+using Toggl.Giskard.Views.EditDuration.Shapes;
+
+namespace Toggl.Giskard.Views.EditDuration
+{
+    [Register("toggl.giskard.views.WheelBackgroundView")]
+    public class WheelBackgroundView : View
+    {
+        private readonly Color wheelColor = Color.ParseColor("#f3f3f3");
+
+        private PointF center;
+        private RectF bounds;
+
+        private float radius;
+        private float arcWidth;
+        private float margins;
+        private Wheel wheel;
+
+        #region Constructors
+
+        protected WheelBackgroundView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+        {
+        }
+
+        public WheelBackgroundView(Context context) : base(context)
+        {
+            init();
+        }
+
+        public WheelBackgroundView(Context context, IAttributeSet attrs) : base(context, attrs)
+        {
+            init();
+        }
+
+        public WheelBackgroundView(Context context, IAttributeSet attrs, int defStyleAttr) : base(context, attrs, defStyleAttr)
+        {
+            init();
+        }
+
+        public WheelBackgroundView(Context context, IAttributeSet attrs, int defStyleAttr, int defStyleRes) : base(context, attrs, defStyleAttr, defStyleRes)
+        {
+            init();
+        }
+
+        private void init()
+        {
+            arcWidth = 8.DpToPixels(Context);
+            margins = 28.DpToPixels(Context);
+        }
+
+        #endregion
+
+        protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+        {
+            base.OnLayout(changed, left, top, right, bottom);
+            radius = Width * 0.5f;
+            center = new PointF(radius, radius);
+            bounds = new RectF(margins, margins, Width - margins, Width - margins);
+        }
+
+        protected override void OnDraw(Canvas canvas)
+        {
+            base.OnDraw(canvas);
+            setupDrawingDelegates();
+            wheel.OnDraw(canvas);
+        }
+
+        private void setupDrawingDelegates()
+        {
+            if (wheel == null)
+            {
+                wheel = new Wheel(bounds, arcWidth, wheelColor);
+            }
+        }
+    }
+}

--- a/Toggl.Giskard/Views/EditDuration/WheelBackgroundView.cs
+++ b/Toggl.Giskard/Views/EditDuration/WheelBackgroundView.cs
@@ -13,14 +13,18 @@ namespace Toggl.Giskard.Views.EditDuration
     public class WheelBackgroundView : View
     {
         private readonly Color wheelColor = Color.ParseColor("#f3f3f3");
+        private readonly Color textColor = Color.ParseColor("#959595");
 
         private PointF center;
         private RectF bounds;
 
         private float radius;
         private float arcWidth;
-        private float margins;
+        private float capWidth;
+        private float textRadius;
+
         private Wheel wheel;
+        private ClockDial clockDial;
 
         #region Constructors
 
@@ -51,7 +55,7 @@ namespace Toggl.Giskard.Views.EditDuration
         private void init()
         {
             arcWidth = 8.DpToPixels(Context);
-            margins = 28.DpToPixels(Context);
+            capWidth = 28.DpToPixels(Context);
         }
 
         #endregion
@@ -61,7 +65,8 @@ namespace Toggl.Giskard.Views.EditDuration
             base.OnLayout(changed, left, top, right, bottom);
             radius = Width * 0.5f;
             center = new PointF(radius, radius);
-            bounds = new RectF(margins, margins, Width - margins, Width - margins);
+            bounds = new RectF(capWidth, capWidth, Width - capWidth, Width - capWidth);
+            textRadius = radius - capWidth * 2 - 2.DpToPixels(Context);
         }
 
         protected override void OnDraw(Canvas canvas)
@@ -69,14 +74,15 @@ namespace Toggl.Giskard.Views.EditDuration
             base.OnDraw(canvas);
             setupDrawingDelegates();
             wheel.OnDraw(canvas);
+            clockDial.OnDraw(canvas);
         }
 
         private void setupDrawingDelegates()
         {
-            if (wheel == null)
-            {
-                wheel = new Wheel(bounds, arcWidth, wheelColor);
-            }
+            if (wheel != null) return;
+
+            wheel = new Wheel(bounds, arcWidth, wheelColor);
+            clockDial = new ClockDial(center, 15.SpToPixels(Context), textColor, textRadius);
         }
     }
 }


### PR DESCRIPTION
## What's this?
This is PR adds the part of the wheel component that draws the background of the wheel that is basically static. The background is composed of the grey arc and the numbers that represent the dial on the wheel.

### Relationships
Closes #4145
Part of #4147 

## Why do we want this?
It's part of the wheel, it would be weird without it.

## How is it done?
I've added another view for the background wheel that is basically composed of a full wheel and clock dial. That's it, the logic is very similar to the ForegroundWheel, except there's no user interaction with this view.

### Why not another way?
This was very easy to do. Feel free to suggest something else.

### Side effects
None.

## Review hints
You can see the view if you put it in some layout inside the app. You have to specify the width and height of the view. Anything like:
```
<?xml version="1.0" encoding="utf-8"?>
<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
             xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_height="wrap_content"
             android:layout_width="match_parent">

    <toggl.giskard.views.WheelBackgroundView  
            android:layout_marginTop="40dp"
            android:layout_gravity="center_horizontal"
            android:layout_height="296dp"
            android:layout_width="296dp" />

    <toggl.giskard.views.WheelForegroundView
            android:layout_marginTop="40dp"
            android:layout_gravity="center_horizontal"
            android:layout_height="296dp"
            android:layout_width="296dp"/>
</FrameLayout>
```
The view looks like this (the background view draws the grey part of the arc and clock dial (60, 5, 10...):
![image](https://user-images.githubusercontent.com/2173493/51210647-1b426880-18f2-11e9-89e6-79d4a9378c6c.png)

## :squid: Permissions
Merge it please. I'd like to keep the commits' history to make reviewing #4147 easier.