### PR TITLE
Use BehavioRelay for StartTime

### DIFF
--- a/Toggl.Daneel/ViewControllers/EditDurationViewController.cs
+++ b/Toggl.Daneel/ViewControllers/EditDurationViewController.cs
@@ -133,7 +133,7 @@ namespace Toggl.Daneel.ViewControllers
 
             var startTime = ViewModel.IsEditingStartTime
                     .Where(CommonFunctions.Identity)
-                    .SelectMany(_ => ViewModel.StartTime);
+                    .SelectMany(_ => ViewModel.StartTimeRelay);
 
             var stopTime = ViewModel.IsEditingStopTime
                     .Where(CommonFunctions.Identity)
@@ -145,7 +145,7 @@ namespace Toggl.Daneel.ViewControllers
 
             ViewModel.IsEditingStartTime
                 .Where(CommonFunctions.Identity)
-                .SelectMany(_ => ViewModel.StartTime)
+                .SelectMany(_ => ViewModel.StartTimeRelay)
                 .Subscribe(v => DatePicker.SetDate(v.ToNSDate(), false))
                 .DisposedBy(disposeBag);
 
@@ -203,7 +203,7 @@ namespace Toggl.Daneel.ViewControllers
                 .Subscribe(v => WheelView.MaximumEndTime = v)
                 .DisposedBy(disposeBag);
 
-            ViewModel.StartTime
+            ViewModel.StartTimeRelay
                 .Subscribe(v => WheelView.StartTime = v)
                 .DisposedBy(disposeBag);
 
@@ -216,7 +216,7 @@ namespace Toggl.Daneel.ViewControllers
                 .DisposedBy(disposeBag);
 
             WheelView.Rx().StartTime()
-                .Subscribe(ViewModel.ChangeStartTime.Inputs)
+                .Subscribe(ViewModel.StartTimeRelay.Accept)
                 .DisposedBy(disposeBag);
 
             WheelView.Rx().EndTime()


### PR DESCRIPTION
## What's this?
This tries to use a BehaviorRelay for the `StartTime` in `EditDurationViewMode`, but it fails.

### Relationships
Closes #4257 

## Why do we want this?
To follow rx-binding guidelines.

## How is it done?
I've changed the subject+observable+rxaction into a simple `BehaviorRelay` for the `StartTime` property.

### Side effects
As you can see if you execute the app this doesn't work. First the start time in the wheel is set to the wrong time. And then it behaves weirdly when dragged. For me it crashes if I drag counter-clockwise first, but also it adds much more duration than it's supposed to if I go clockwise first.

## Review hints
You can try keeping the `StartTime` observable to see where the problem is. If I do this:

```c#
StartTime = StartTimeRelay.AsDriver(schedulerProvider);
```

it works, but printing the thread before and after `AsDriver` shows the exact same ID, so I don't know what's going on here...

## :squid: Permissions
Don't!