### PR TITLE
🚧 Order suggestions by project name in start TE view

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/StartTimeEntryViewModel.cs
@@ -741,6 +741,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             var firstSuggestion = suggestions.FirstOrDefault();
             if (firstSuggestion is ProjectSuggestion)
                 return suggestions
+                    .OrderBy(ps => ((ProjectSuggestion)ps).ProjectName)
                     .GroupByWorkspaceAddingNoProject()
                     .OrderByDefaultWorkspaceAndName(defaultWorkspace?.Id ?? 0);
 


### PR DESCRIPTION
## What's this?
The title says it all

### Relationships
Closes #4225

## Why do we want this?
We like when stuff are ordered alphabetically because it makes it easer and consistent to find find them in lists

## How is it done?
literally 1 line of code

### Why not another way?
can't think of any

### Side effects
Only what it advertises

## Review hints
run it

## :squid: Permissions
:squid: