### PR TITLE
Daneel 1.16.1 - Vega hotfix

### DIFF
--- a/Toggl.Daneel.SiriExtension.UI/Info.plist
+++ b/Toggl.Daneel.SiriExtension.UI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16</string>
+	<string>1.16.1</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.Daneel.SiriExtension.UI/Info.plist
+++ b/Toggl.Daneel.SiriExtension.UI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.2</string>
+	<string>1.16</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.Daneel.SiriExtension/Info.plist
+++ b/Toggl.Daneel.SiriExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16</string>
+	<string>1.16.1</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.Daneel.SiriExtension/Info.plist
+++ b/Toggl.Daneel.SiriExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.2</string>
+	<string>1.16</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.Daneel/Info.plist
+++ b/Toggl.Daneel/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.16</string>
+	<string>1.16.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Toggl.Daneel/Info.plist
+++ b/Toggl.Daneel/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.15</string>
+	<string>1.16</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Toggl.Daneel/ViewControllers/SelectColorViewController.cs
+++ b/Toggl.Daneel/ViewControllers/SelectColorViewController.cs
@@ -33,7 +33,7 @@ namespace Toggl.Daneel.ViewControllers
             base.ViewDidLoad();
 
             TitleLabel.Text = Resources.ProjectColor;
-            CloseButton.SetTitle(Resources.Save, UIControlState.Normal);
+            SaveButton.SetTitle(Resources.Save, UIControlState.Normal);
 
             prepareViews();
 

--- a/Toggl.Daneel/ViewControllers/SelectDateTimeViewController.cs
+++ b/Toggl.Daneel/ViewControllers/SelectDateTimeViewController.cs
@@ -22,7 +22,7 @@ namespace Toggl.Daneel.ViewControllers
             base.ViewDidLoad();
 
             TitleLabel.Text = Resources.Startdate;
-            CloseButton.SetTitle(Resources.Save, UIControlState.Normal);
+            SaveButton.SetTitle(Resources.Save, UIControlState.Normal);
 
             prepareDatePicker();
 

--- a/Toggl.Daneel/ViewControllers/SelectTagsViewController.cs
+++ b/Toggl.Daneel/ViewControllers/SelectTagsViewController.cs
@@ -25,7 +25,7 @@ namespace Toggl.Daneel.ViewControllers
 
             TitleLabel.Text = Resources.Tags;
             EmptyStateLabel.Text = Resources.EmptyTagText;
-            CloseButton.SetTitle(Resources.Save, UIControlState.Normal);
+            SaveButton.SetTitle(Resources.Save, UIControlState.Normal);
 
             var source = new SelectTagsTableViewSource(TagsTableView);
             TagsTableView.Source = source;

--- a/Toggl.Daneel/ViewSources/TimeEntriesLogViewSource.cs
+++ b/Toggl.Daneel/ViewSources/TimeEntriesLogViewSource.cs
@@ -35,14 +35,11 @@ namespace Toggl.Daneel.ViewSources
 
         public bool IsEmptyState { get; set; }
 
-        public IObservable<TimeEntryViewModel> ContinueTap
-            => continueTapSubject.AsObservable();
+        public IObservable<TimeEntryViewModel> ContinueTap { get; }
 
-        public IObservable<TimeEntryViewModel> SwipeToContinue
-            => swipeToContinueSubject.AsObservable();
+        public IObservable<TimeEntryViewModel> SwipeToContinue { get; }
 
-        public IObservable<TimeEntryViewModel> SwipeToDelete
-            => swipeToDeleteSubject.AsObservable();
+        public IObservable<TimeEntryViewModel> SwipeToDelete { get; }
 
         public IObservable<TimeEntriesLogViewCell> FirstCell { get; }
 
@@ -68,6 +65,9 @@ namespace Toggl.Daneel.ViewSources
                 deleteTableViewRowAction.BackgroundColor = Foundation.MvvmCross.Helper.Color.TimeEntriesLog.DeleteSwipeActionBackground.ToNativeColor();
             }
 
+            ContinueTap = continueTapSubject.AsDriver(schedulerProvider);
+            SwipeToContinue = swipeToContinueSubject.AsDriver(schedulerProvider);
+            SwipeToDelete = swipeToDeleteSubject.AsDriver(schedulerProvider);
             FirstCell = firstCellSubject.AsDriver(schedulerProvider);
         }
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Reports/ReportsViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Reports/ReportsViewModel.cs
@@ -181,7 +181,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Reports
                 .AsDriver(schedulerProvider);
 
             DurationFormatObservable = dataSource.Preferences.Current
-                .Select(prefs => prefs.DurationFormat);
+                .Select(prefs => prefs.DurationFormat)
+                .AsDriver(schedulerProvider);
 
             SegmentsObservable = segmentsSubject.CombineLatest(DurationFormatObservable, applyDurationFormat);
             GroupedSegmentsObservable = SegmentsObservable.CombineLatest(DurationFormatObservable, groupSegments);

--- a/Toggl.Foundation.Tests/MvvmCross/ViewModels/ReportsViewModelTests.cs
+++ b/Toggl.Foundation.Tests/MvvmCross/ViewModels/ReportsViewModelTests.cs
@@ -379,6 +379,8 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 ViewModel.SegmentsObservable.Subscribe(segmentsObservable);
                 ViewModel.GroupedSegmentsObservable.Subscribe(groupedSegmentsObservable);
 
+                TestScheduler.Start();
+                
                 await Initialize();
 
                 var actualSegments = segmentsObservable.Values().Last();
@@ -415,6 +417,8 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 var groupedSegmentsObservable = TestScheduler.CreateObserver<IReadOnlyList<ChartSegment>>();
                 ViewModel.SegmentsObservable.Subscribe(segmentsObservable);
                 ViewModel.GroupedSegmentsObservable.Subscribe(groupedSegmentsObservable);
+
+                TestScheduler.Start();
 
                 await Initialize();
 
@@ -454,6 +458,8 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 ViewModel.SegmentsObservable.Subscribe(segmentsObservable);
                 ViewModel.GroupedSegmentsObservable.Subscribe(groupedSegmentsObservable);
 
+                TestScheduler.Start();
+
                 await Initialize();
 
                 var actualSegments = segmentsObservable.Values().Last();
@@ -490,6 +496,8 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 var groupedSegmentsObservable = TestScheduler.CreateObserver<IReadOnlyList<ChartSegment>>();
                 ViewModel.SegmentsObservable.Subscribe(segmentsObservable);
                 ViewModel.GroupedSegmentsObservable.Subscribe(groupedSegmentsObservable);
+
+                TestScheduler.Start();
 
                 await Initialize();
 


### PR DESCRIPTION
## What's this?
We have a bug in Adjust initialization (the cake script replaces incorrect value) and so we need to change this and upload it to the AppStore asap so we can make sure that our Marketing team can get some useful data from AppStore ads.

The diff between `vega-hotfix` and `develop` is weird because I accidentally squashed the `vega` release branch into `develop` instead of merging it 😢 Please check this diff to see what changed since the last release: https://github.com/toggl/mobileapp/compare/daneel-1.16-3..vega-hotfix

## 🦑  Permissions
Just me. Merge, not squash, this time.