### PR TITLE
Change parameters type for EditTimeEntryViewModel

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Calendar/CalendarViewModel.cs
@@ -271,7 +271,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
                     analyticsService.EditViewOpenedFromCalendar.Track();
                     var stopwatch = stopwatchProvider.CreateAndStore(MeasuredOperation.EditTimeEntryFromCalendar);
                     stopwatch.Start();
-                    await navigationService.Navigate<EditTimeEntryViewModel, long>(calendarItem.TimeEntryId.Value);
+                    await navigationService.Navigate<EditTimeEntryViewModel, long[]>(new[] { calendarItem.TimeEntryId.Value });
                     break;
 
                 case CalendarItemSource.Calendar:
@@ -326,7 +326,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.Calendar
             var prototype = duration.AsTimeEntryPrototype(startTime, workspace.Id);
             var timeEntry = await interactorFactory.CreateTimeEntry(prototype).Execute();
             analyticsService.TimeEntryStarted.Track(TimeEntryStartOrigin.CalendarTapAndDrag);
-            await navigationService.Navigate<EditTimeEntryViewModel, long>(timeEntry.Id);
+            await navigationService.Navigate<EditTimeEntryViewModel, long[]>(new[] { timeEntry.Id });
         }
 
         private async Task updateTimeEntry(CalendarItem calendarItem)

--- a/Toggl.Foundation.MvvmCross/ViewModels/EditTimeEntryViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/EditTimeEntryViewModel.cs
@@ -27,7 +27,7 @@ using SelectTimeOrigin = Toggl.Foundation.MvvmCross.Parameters.SelectTimeParamet
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
     [Preserve(AllMembers = true)]
-    public sealed class EditTimeEntryViewModel : MvxViewModel<long>
+    public sealed class EditTimeEntryViewModel : MvxViewModel<long[]>
     {
         private const int maxTagLength = 30;
 
@@ -78,7 +78,8 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public IOnboardingStorage OnboardingStorage => onboardingStorage;
 
-        public long Id { get; set; }
+        public long Id => Ids.First();
+        public long[] Ids { get; set; }
 
         public string Description { get; set; }
 
@@ -267,9 +268,9 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
                 => !IsInaccessible;
         }
 
-        public override void Prepare(long parameter)
+        public override void Prepare(long[] parameter)
         {
-            Id = parameter;
+            Ids = parameter;
         }
 
         public override async Task Initialize()

--- a/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
@@ -437,7 +437,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             var editTimeEntryStopwatch = stopwatchProvider.CreateAndStore(MeasuredOperation.EditTimeEntryFromMainLog);
             editTimeEntryStopwatch.Start();
 
-            await navigate<EditTimeEntryViewModel, long>(timeEntryId);
+            await navigate<EditTimeEntryViewModel, long[]>(new[] { timeEntryId });
 
             lock (isEditViewOpenLock)
             {

--- a/Toggl.Foundation.Tests/MvvmCross/ViewModels/CalendarViewModelTests.cs
+++ b/Toggl.Foundation.Tests/MvvmCross/ViewModels/CalendarViewModelTests.cs
@@ -451,7 +451,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 PermissionsService.RequestCalendarAuthorization().Returns(Observable.Return(true));
                 NavigationService.Navigate<SelectUserCalendarsViewModel, string[]>().Returns(new string[0]);
 
-                 ViewModel.GetStarted.Execute(Unit.Default);
+                ViewModel.GetStarted.Execute(Unit.Default);
 
                 OnboardingStorage.Received().SetCompletedCalendarOnboarding();
             }
@@ -679,7 +679,8 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                     ViewModel.OnItemTapped.Execute(CalendarItem);
                     TestScheduler.Start();
 
-                    await NavigationService.Received().Navigate<EditTimeEntryViewModel, long>(Arg.Is(TimeEntryId));
+                    await NavigationService.Received().Navigate<EditTimeEntryViewModel, long[]>(
+                        Arg.Is<long[]>(array => array[0] == TimeEntryId));
                 }
             }
 
@@ -785,7 +786,8 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 ViewModel.OnDurationSelected.Execute(tuple);
                 TestScheduler.Start();
 
-                await NavigationService.Received().Navigate<EditTimeEntryViewModel, long>(Arg.Is(TimeEntryId));
+                await NavigationService.Received().Navigate<EditTimeEntryViewModel, long[]>(
+                       Arg.Is<long[]>(array => array[0] == TimeEntryId));
             }
 
             [Fact, LogIfTooSlow]


### PR DESCRIPTION
## What's this?
Changes the parameter of the `EditTimeEntryViewModel` so that it supports `long[]`.

### Relationships
Part of #4219 

## Why do we want this?
So that we can send groups as well as TEs to the EditView.

## How is it done?
By arraying.

### Why not another way?
Who knows.

### Side effects
Side effect is that I've fixed some dubbious tests related to the thing along the way.

## Review hints
Careful examination of code transformation. 👅 
 
## :squid: Permissions
🔟 People