### PR TITLE
Use strategy for equality checks in BaseRecyclerAdapter's Diffing algorithm.

### DIFF
--- a/Toggl.Foundation.MvvmCross/Interfaces/IDiffableByIdentifier.cs
+++ b/Toggl.Foundation.MvvmCross/Interfaces/IDiffableByIdentifier.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Toggl.Foundation.MvvmCross.Interfaces
 {
-    public interface IDiffable<T> : IEquatable<T>
+    public interface IDiffableByIdentifier<T> : IEquatable<T>
     {
         long Identifier { get; }
     }

--- a/Toggl.Foundation.MvvmCross/ViewModels/ReportsCalendar/QuickSelectShortcuts/ReportsCalendarBaseQuickSelectShortcut.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/ReportsCalendar/QuickSelectShortcuts/ReportsCalendarBaseQuickSelectShortcut.cs
@@ -7,7 +7,7 @@ using Toggl.Foundation.Services;
 namespace Toggl.Foundation.MvvmCross.ViewModels.ReportsCalendar.QuickSelectShortcuts
 {
     [Preserve(AllMembers = true)]
-    public abstract class ReportsCalendarBaseQuickSelectShortcut : IDiffable<ReportsCalendarBaseQuickSelectShortcut>
+    public abstract class ReportsCalendarBaseQuickSelectShortcut : IDiffableByIdentifier<ReportsCalendarBaseQuickSelectShortcut>
     {
         protected ITimeService TimeService { get; private set; }
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/ReportsCalendar/ReportsCalendarDayViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/ReportsCalendar/ReportsCalendarDayViewModel.cs
@@ -10,7 +10,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels.ReportsCalendar
 {
     [Preserve(AllMembers = true)]
     [AddINotifyPropertyChangedInterface]
-    public sealed class ReportsCalendarDayViewModel : IDiffable<ReportsCalendarDayViewModel>
+    public sealed class ReportsCalendarDayViewModel : IDiffableByIdentifier<ReportsCalendarDayViewModel>
     {
         private readonly DateTimeOffset dateTime;
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableBeginningOfWeekViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableBeginningOfWeekViewModel.cs
@@ -6,7 +6,7 @@ using Toggl.Multivac;
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
     [Preserve(AllMembers = true)]
-    public sealed class SelectableBeginningOfWeekViewModel : IDiffable<SelectableBeginningOfWeekViewModel>
+    public sealed class SelectableBeginningOfWeekViewModel : IDiffableByIdentifier<SelectableBeginningOfWeekViewModel>
     {
         public BeginningOfWeek BeginningOfWeek { get; }
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableClientViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableClientViewModel.cs
@@ -4,7 +4,7 @@ using Toggl.Multivac;
 
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
-    public abstract class SelectableClientBaseViewModel : IDiffable<SelectableClientBaseViewModel>
+    public abstract class SelectableClientBaseViewModel : IDiffableByIdentifier<SelectableClientBaseViewModel>
     {
         public string Name { get; set; }
         public bool Selected { get; set; }

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableColorViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableColorViewModel.cs
@@ -6,7 +6,7 @@ using Toggl.Multivac;
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
     [Preserve(AllMembers = true)]
-    public sealed class SelectableColorViewModel : IDiffable<SelectableColorViewModel>
+    public sealed class SelectableColorViewModel : IDiffableByIdentifier<SelectableColorViewModel>
     {
         public MvxColor Color { get; }
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableCountryViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableCountryViewModel.cs
@@ -6,7 +6,7 @@ using Toggl.Multivac.Models;
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
     [Preserve(AllMembers = true)]
-    public sealed class SelectableCountryViewModel : IDiffable<SelectableCountryViewModel>
+    public sealed class SelectableCountryViewModel : IDiffableByIdentifier<SelectableCountryViewModel>
     {
         public ICountry Country { get; }
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableDateFormatViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableDateFormatViewModel.cs
@@ -5,7 +5,7 @@ using Toggl.Multivac;
 namespace Toggl.Foundation.MvvmCross.ViewModels.Selectable
 {
     [Preserve]
-    public sealed class SelectableDateFormatViewModel : IDiffable<SelectableDateFormatViewModel>
+    public sealed class SelectableDateFormatViewModel : IDiffableByIdentifier<SelectableDateFormatViewModel>
     {
         public long Identifier => DateFormat.GetHashCode(); 
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableDurationFormatViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableDurationFormatViewModel.cs
@@ -7,7 +7,7 @@ using Toggl.Multivac;
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
     [Preserve(AllMembers = true)]
-    public sealed class SelectableDurationFormatViewModel : IDiffable<SelectableDurationFormatViewModel>
+    public sealed class SelectableDurationFormatViewModel : IDiffableByIdentifier<SelectableDurationFormatViewModel>
     {
         public long Identifier => DurationFormat.GetHashCode();
 

--- a/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableWorkspaceViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/Selectable/SelectableWorkspaceViewModel.cs
@@ -5,7 +5,7 @@ using Toggl.Multivac;
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
     [Preserve(AllMembers = true)]
-    public sealed class SelectableWorkspaceViewModel : IDiffable<SelectableWorkspaceViewModel>
+    public sealed class SelectableWorkspaceViewModel : IDiffableByIdentifier<SelectableWorkspaceViewModel>
     {
         public long WorkspaceId { get; }
 

--- a/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BasePushEntityStateTests.cs
+++ b/Toggl.Foundation.Tests/Sync/States/Push/BaseStates/BasePushEntityStateTests.cs
@@ -9,6 +9,7 @@ using Toggl.Foundation.Analytics;
 using Toggl.Foundation.Sync;
 using Toggl.Foundation.Sync.States.Push;
 using Toggl.Foundation.Tests.Helpers;
+using Toggl.Multivac.Extensions;
 using Toggl.PrimeRadiant;
 using Toggl.Ultrawave.Exceptions;
 using Xunit;
@@ -168,7 +169,7 @@ namespace Toggl.Foundation.Tests.Sync.States.Push.BaseStates
         {
             var testAnalyticsService = (ITestAnalyticsService)analyticsService;
 
-            return typeof(IThreadSafeTestModel).IsAssignableFrom(entityType)
+            return entityType.ImplementsOrDerivesFrom<IThreadSafeTestModel>()
                 ? testAnalyticsService.TestEvent
                 : SyncAnalyticsExtensions.DefaultSyncAnalyticsExtensionsSearchStrategy(entityType, analyticsService);
         }

--- a/Toggl.Foundation.Tests/Sync/TestConfigurator.cs
+++ b/Toggl.Foundation.Tests/Sync/TestConfigurator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Toggl.Foundation.Sync;
+using Toggl.Multivac.Extensions;
 
 namespace Toggl.Foundation.Tests.Sync
 {
@@ -60,9 +61,9 @@ namespace Toggl.Foundation.Tests.Sync
                 .ToList();
         }
 
-        private static bool isStateResultProperty(PropertyInfo p)
+        private static bool isStateResultProperty(PropertyInfo property)
         {
-            return typeof(IStateResult).IsAssignableFrom(p.PropertyType);
+            return property.PropertyType.ImplementsOrDerivesFrom<IStateResult>();
         }
     }
 }

--- a/Toggl.Foundation/Analytics/SyncAnalyticsExtensions.cs
+++ b/Toggl.Foundation/Analytics/SyncAnalyticsExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Toggl.Foundation.Extensions;
 using Toggl.Foundation.Models.Interfaces;
+using Toggl.Multivac.Extensions;
 
 namespace Toggl.Foundation.Analytics
 {
@@ -19,33 +20,33 @@ namespace Toggl.Foundation.Analytics
 
         internal static IAnalyticsEvent<string> DefaultSyncAnalyticsExtensionsSearchStrategy(Type entityType, IAnalyticsService analyticsService)
         {
-            if (typeof(IThreadSafeWorkspace).IsAssignableFrom(entityType))
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeWorkspace>())
                 return analyticsService.WorkspaceSyncError;
-           
-            if (typeof(IThreadSafeUser).IsAssignableFrom(entityType))
+
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeUser>())
                 return analyticsService.UserSyncError;
 
-            if (typeof(IThreadSafeWorkspaceFeature).IsAssignableFrom(entityType))
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeWorkspaceFeature>())
                 return analyticsService.WorkspaceFeaturesSyncError;
-           
-            if (typeof(IThreadSafePreferences).IsAssignableFrom(entityType))
+
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafePreferences>())
                 return analyticsService.PreferencesSyncError;
-           
-            if (typeof(IThreadSafeTag).IsAssignableFrom(entityType))
+
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeTag>())
                 return analyticsService.TagsSyncError;
 
-            if (typeof(IThreadSafeClient).IsAssignableFrom(entityType))
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeClient>())
                 return analyticsService.ClientsSyncError;
 
-            if (typeof(IThreadSafeProject).IsAssignableFrom(entityType))
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeProject>())
                 return analyticsService.ProjectsSyncError;
 
-            if (typeof(IThreadSafeTask).IsAssignableFrom(entityType))
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeTask>())
                 return analyticsService.TasksSyncError;
 
-            if (typeof(IThreadSafeTimeEntry).IsAssignableFrom(entityType))
+            if (entityType.ImplementsOrDerivesFrom<IThreadSafeTimeEntry>())
                 return analyticsService.TimeEntrySyncError;
-               
+
             throw new ArgumentException($"The entity '{entityType.Name}' has no corresponding analytics events and should not be used.");
         }
     }

--- a/Toggl.Giskard/Adapters/BaseRecyclerAdapter.cs
+++ b/Toggl.Giskard/Adapters/BaseRecyclerAdapter.cs
@@ -38,11 +38,11 @@ namespace Toggl.Giskard.Adapters
             set => SetItems(value ?? new List<T>());
         }
 
-        protected BaseRecyclerAdapter(IDiffingStrategy<T> diffingStrategy)
+        protected BaseRecyclerAdapter(IDiffingStrategy<T> diffingStrategy = null)
         {
-            HasStableIds = true;
-
             this.diffingStrategy = normalizeDiffingStrategy(diffingStrategy);
+
+            HasStableIds = this.diffingStrategy.HasStableIds;
         }
 
         private IDiffingStrategy<T> normalizeDiffingStrategy(IDiffingStrategy<T> diffingStrategy)
@@ -82,7 +82,8 @@ namespace Toggl.Giskard.Adapters
 
         public override long GetItemId(int position)
         {
-            return items[position].Identifier;
+            var item = items[position];
+            return diffingStrategy.GetItemId(item);
         }
 
         public virtual T GetItem(int viewPosition)

--- a/Toggl.Giskard/Adapters/BaseRecyclerAdapter.cs
+++ b/Toggl.Giskard/Adapters/BaseRecyclerAdapter.cs
@@ -8,14 +8,18 @@ using Android.Support.V7.Util;
 using Android.Support.V7.Widget;
 using Android.Views;
 using Toggl.Giskard.ViewHolders;
+using Toggl.Multivac.Extensions;
 using Toggl.Foundation.MvvmCross.Interfaces;
 using Handler = Android.OS.Handler;
+using Toggl.Giskard.Adapters.DiffingStrategies;
 
 namespace Toggl.Giskard.Adapters
 {
     public abstract class BaseRecyclerAdapter<T> : RecyclerView.Adapter
-        where T: IDiffable<T>
+        where T : IEquatable<T>
     {
+        private readonly IDiffingStrategy<T> diffingStrategy;
+
         public IObservable<T> ItemTapObservable => itemTapSubject.AsObservable();
 
         private Subject<T> itemTapSubject = new Subject<T>();
@@ -34,9 +38,22 @@ namespace Toggl.Giskard.Adapters
             set => SetItems(value ?? new List<T>());
         }
 
-        protected BaseRecyclerAdapter()
+        protected BaseRecyclerAdapter(IDiffingStrategy<T> diffingStrategy)
         {
             HasStableIds = true;
+
+            this.diffingStrategy = normalizeDiffingStrategy(diffingStrategy);
+        }
+
+        private IDiffingStrategy<T> normalizeDiffingStrategy(IDiffingStrategy<T> diffingStrategy)
+        {
+            if (diffingStrategy != null)
+                return diffingStrategy;
+
+            if (typeof(T).ImplementsOrDerivesFrom<IDiffableByIdentifier<T>>())
+                return new IdentifierEqualityDiffingStrategy<T>();
+
+            return new EquatableDiffingStrategy<T>();
         }
 
         protected BaseRecyclerAdapter(IntPtr javaReference, JniHandleOwnership transfer)
@@ -93,7 +110,7 @@ namespace Toggl.Giskard.Adapters
             var handler = new Handler();
             Task.Run(() =>
             {
-                var diffResult = DiffUtil.CalculateDiff(new BaseDiffCallBack(oldItems, newItems));
+                var diffResult = DiffUtil.CalculateDiff(new BaseDiffCallBack(oldItems, newItems, diffingStrategy));
                 handler.Post(() =>
                 {
                     dispatchUpdates(newItems, diffResult);
@@ -123,23 +140,29 @@ namespace Toggl.Giskard.Adapters
         {
             private IList<T> oldItems;
             private IList<T> newItems;
+            private IDiffingStrategy<T> diffingStrategy;
 
-            public BaseDiffCallBack(IList<T> oldItems, IList<T> newItems)
+            public BaseDiffCallBack(IList<T> oldItems, IList<T> newItems, IDiffingStrategy<T> diffingStrategy)
             {
                 this.oldItems = oldItems;
                 this.newItems = newItems;
+                this.diffingStrategy = diffingStrategy;
             }
 
             public override bool AreContentsTheSame(int oldItemPosition, int newItemPosition)
             {
                 var oldItem = oldItems[oldItemPosition];
                 var newItem = newItems[newItemPosition];
-                return oldItem.Equals(newItem);
+
+                return diffingStrategy.AreContentsTheSame(oldItem, newItem);
             }
 
             public override bool AreItemsTheSame(int oldItemPosition, int newItemPosition)
             {
-                return oldItems[oldItemPosition].Identifier == newItems[newItemPosition].Identifier;
+                var oldItem = oldItems[oldItemPosition];
+                var newItem = newItems[newItemPosition];
+
+                return diffingStrategy.AreItemsTheSame(oldItem, newItem);
             }
 
             public override int NewListSize => newItems.Count;

--- a/Toggl.Giskard/Adapters/DiffingStrategies/EquatableDiffingStrategy.cs
+++ b/Toggl.Giskard/Adapters/DiffingStrategies/EquatableDiffingStrategy.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Android.Support.V7.Widget;
+using System;
 using System.Linq;
 
 namespace Toggl.Giskard.Adapters.DiffingStrategies
@@ -15,5 +16,9 @@ namespace Toggl.Giskard.Adapters.DiffingStrategies
         {
             return item.Equals(other);
         }
+
+        public long GetItemId(T item) => RecyclerView.NoId;
+
+        public bool HasStableIds => false;
     }
 }

--- a/Toggl.Giskard/Adapters/DiffingStrategies/EquatableDiffingStrategy.cs
+++ b/Toggl.Giskard/Adapters/DiffingStrategies/EquatableDiffingStrategy.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+
+namespace Toggl.Giskard.Adapters.DiffingStrategies
+{
+    public sealed class EquatableDiffingStrategy<T> : IDiffingStrategy<T>
+       where T : IEquatable<T>
+    {
+        public bool AreContentsTheSame(T item, T other)
+        {
+            return item.Equals(other);
+        }
+
+        public bool AreItemsTheSame(T item, T other)
+        {
+            return item.Equals(other);
+        }
+    }
+}

--- a/Toggl.Giskard/Adapters/DiffingStrategies/IDiffingStrategy.cs
+++ b/Toggl.Giskard/Adapters/DiffingStrategies/IDiffingStrategy.cs
@@ -13,9 +13,11 @@ using Toggl.Foundation.MvvmCross.Interfaces;
 
 namespace Toggl.Giskard.Adapters.DiffingStrategies
 {
-    public interface IDiffingStrategy<T>
+    public interface IDiffingStrategy<T> where T : IEquatable<T>
     {
         bool AreContentsTheSame(T item, T other);
         bool AreItemsTheSame(T item, T other);
+        bool HasStableIds { get; }
+        long GetItemId(T item);
     }
 }

--- a/Toggl.Giskard/Adapters/DiffingStrategies/IDiffingStrategy.cs
+++ b/Toggl.Giskard/Adapters/DiffingStrategies/IDiffingStrategy.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Toggl.Foundation.MvvmCross.Interfaces;
+
+namespace Toggl.Giskard.Adapters.DiffingStrategies
+{
+    public interface IDiffingStrategy<T>
+    {
+        bool AreContentsTheSame(T item, T other);
+        bool AreItemsTheSame(T item, T other);
+    }
+}

--- a/Toggl.Giskard/Adapters/DiffingStrategies/IdentifierEqualityDiffingStrategy.cs
+++ b/Toggl.Giskard/Adapters/DiffingStrategies/IdentifierEqualityDiffingStrategy.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using Toggl.Foundation.MvvmCross.Interfaces;
+using Toggl.Multivac;
+
+namespace Toggl.Giskard.Adapters.DiffingStrategies
+{
+    public sealed class IdentifierEqualityDiffingStrategy<T> : IDiffingStrategy<T>
+        where T : IEquatable<T>
+    {
+        public IdentifierEqualityDiffingStrategy()
+        {
+            Ensure.Argument.TypeImplementsOrInheritsFromType(
+                derivedType: typeof(T),
+                baseType: typeof(IDiffableByIdentifier<T>));
+        }
+
+        public bool AreContentsTheSame(T item, T other)
+        {
+            return item.Equals(other);
+        }
+
+        public bool AreItemsTheSame(T item, T other)
+        {
+            var itemDiffable = (IDiffableByIdentifier<T>)item;
+            var otherDiffable = (IDiffableByIdentifier<T>)item;
+
+            return itemDiffable.Identifier == otherDiffable.Identifier;
+        }
+    }
+}

--- a/Toggl.Giskard/Adapters/DiffingStrategies/IdentifierEqualityDiffingStrategy.cs
+++ b/Toggl.Giskard/Adapters/DiffingStrategies/IdentifierEqualityDiffingStrategy.cs
@@ -27,5 +27,9 @@ namespace Toggl.Giskard.Adapters.DiffingStrategies
 
             return itemDiffable.Identifier == otherDiffable.Identifier;
         }
+
+        public long GetItemId(T item) => ((IDiffableByIdentifier<T>)item).Identifier;
+
+        public bool HasStableIds => true;
     }
 }

--- a/Toggl.Giskard/Adapters/SimpleAdapter.cs
+++ b/Toggl.Giskard/Adapters/SimpleAdapter.cs
@@ -2,18 +2,20 @@
 using Android.Runtime;
 using Android.Views;
 using Toggl.Foundation.MvvmCross.Interfaces;
+using Toggl.Giskard.Adapters.DiffingStrategies;
 using Toggl.Giskard.ViewHolders;
 using Toggl.Multivac;
 
 namespace Toggl.Giskard.Adapters
 {
     public sealed class SimpleAdapter<T> : BaseRecyclerAdapter<T>
-        where T : IDiffable<T>
+        where T : IEquatable<T>
     {
         private readonly int layoutId;
         private readonly Func<View, BaseRecyclerViewHolder<T>> createViewHolder;
 
-        public SimpleAdapter(int layoutId, Func<View, BaseRecyclerViewHolder<T>> createViewHolder)
+        public SimpleAdapter(int layoutId, Func<View, BaseRecyclerViewHolder<T>> createViewHolder, IDiffingStrategy<T> diffingStrategy = null)
+            : base(diffingStrategy)
         {
             Ensure.Argument.IsNotNull(createViewHolder, nameof(createViewHolder));
 

--- a/Toggl.Giskard/Extensions/Reactive/RecyclerAdapterExtensions.cs
+++ b/Toggl.Giskard/Extensions/Reactive/RecyclerAdapterExtensions.cs
@@ -8,7 +8,7 @@ namespace Toggl.Giskard.Extensions.Reactive
 {
     public static class RecyclerAdapterExtensions
     {
-        public static Action<IList<T>> Items<T>(this IReactive<BaseRecyclerAdapter<T>> reactive) where T : IDiffable<T>
+        public static Action<IList<T>> Items<T>(this IReactive<BaseRecyclerAdapter<T>> reactive) where T : IEquatable<T>
             => collection => reactive.Base.Items = collection;
     }
 }

--- a/Toggl.Giskard/Toggl.Giskard.csproj
+++ b/Toggl.Giskard/Toggl.Giskard.csproj
@@ -296,6 +296,9 @@
     <Compile Include="Activities\SendFeedbackActivity.ViewBinds.cs">
       <DependentUpon>SendFeedbackActivity.cs</DependentUpon>
     </Compile>
+    <Compile Include="Adapters\DiffingStrategies\EquatableDiffingStrategy.cs" />
+    <Compile Include="Adapters\DiffingStrategies\IdentifierEqualityDiffingStrategy.cs" />
+    <Compile Include="Adapters\DiffingStrategies\IDiffingStrategy.cs" />
     <Compile Include="Adapters\ReportsCalendarShortcutAdapter.cs" />
     <Compile Include="Adapters\SelectCreatableEntityRecyclerAdapter.cs" />
     <Compile Include="Adapters\SelectDurationFormatRecyclerAdapter.cs" />

--- a/Toggl.Multivac/Ensure.cs
+++ b/Toggl.Multivac/Ensure.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices.WindowsRuntime;
+using Toggl.Multivac.Extensions;
 
 namespace Toggl.Multivac
 {
@@ -67,6 +68,14 @@ namespace Toggl.Multivac
                 if (value.CompareTo(lowerBound) >= 0 && value.CompareTo(upperBound) <= 0) return;
 
                 throw new ArgumentException("Value is in out of bounds.", argumentName);
+            }
+
+            public static void TypeImplementsOrInheritsFromType(Type derivedType, Type baseType)
+            {
+                if (derivedType.ImplementsOrDerivesFrom(baseType))
+                    return;
+
+                throw new ArgumentException($"Type {derivedType.Name} is not of type {baseType.Name}");
             }
         }
     }

--- a/Toggl.Multivac/Extensions/TypeExtensions.cs
+++ b/Toggl.Multivac/Extensions/TypeExtensions.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Toggl.Multivac.Extensions
 {
-    public static class TypeNameExtensions
+    public static class TypeExtensions
     {
         public static string GetFriendlyName(this Type type)
         {
@@ -18,5 +18,11 @@ namespace Toggl.Multivac.Extensions
                 return type.Name;
             }
         }
+
+        public static bool ImplementsOrDerivesFrom<TBaseType>(this Type type)
+            => typeof(TBaseType).IsAssignableFrom(type);
+
+        public static bool ImplementsOrDerivesFrom(this Type type, Type baseType)
+            => baseType.IsAssignableFrom(type);
     }
 }


### PR DESCRIPTION
## What's this?
This PR deals with three things:

* Relaxes the constraint on a type of SimpleAdapter so it's no longer `IDiffable<T>`, but instead `IEquatable<T>` so that now even primitives can be used.
* Abstracts away the diffing part of things to a strategy.
* Along the way, I have added an extension method to improve readability a bit.

### Relationships
Nothing specific but will help with 🔟.

## Why do we want this?
So that we can use `SimpleAdapter<string>`.

## How is it done?
Most of it is selfexplanatory.

### Why not another way?
I think I have chosen the simplest way possible.

### Side effects
Some renames happened to improve naming. If you have even better naming, please suggest.

## Review hints
Commit by commit.

## :squid: Permissions
🔟 people.