### PR TITLE
😱 temporary fix for signup by removing interactor factory

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/SignupViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/SignupViewModel.cs
@@ -26,6 +26,8 @@ using Toggl.Ultrawave.Exceptions;
 using Toggl.Ultrawave.Network;
 using System.Reactive;
 using System.Reactive.Disposables;
+using Toggl.Foundation.Interactors.Timezones;
+using Toggl.Foundation.Serialization;
 
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
@@ -52,7 +54,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
         private readonly ISchedulerProvider schedulerProvider;
         private readonly IRxActionFactory rxActionFactory;
         private readonly IPlatformInfo platformInfo;
-        private readonly IInteractorFactory interactorFactory;
 
         private IDisposable getCountrySubscription;
         private IDisposable signupDisposable;
@@ -102,8 +103,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             ITimeService timeService,
             ISchedulerProvider schedulerProvider,
             IRxActionFactory rxActionFactory,
-            IPlatformInfo platformInfo,
-            IInteractorFactory interactorFactory)
+            IPlatformInfo platformInfo)
         {
             Ensure.Argument.IsNotNull(apiFactory, nameof(apiFactory));
             Ensure.Argument.IsNotNull(userAccessManager, nameof(userAccessManager));
@@ -116,7 +116,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             Ensure.Argument.IsNotNull(schedulerProvider, nameof(schedulerProvider));
             Ensure.Argument.IsNotNull(rxActionFactory, nameof(rxActionFactory));
             Ensure.Argument.IsNotNull(platformInfo, nameof(platformInfo));
-            Ensure.Argument.IsNotNull(interactorFactory, nameof(interactorFactory));
 
             this.apiFactory = apiFactory;
             this.userAccessManager = userAccessManager;
@@ -129,7 +128,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             this.schedulerProvider = schedulerProvider;
             this.rxActionFactory = rxActionFactory;
             this.platformInfo = platformInfo;
-            this.interactorFactory = interactorFactory;
 
             Login = rxActionFactory.FromAsync(login);
             Signup = rxActionFactory.FromAsync(signup);
@@ -279,7 +277,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             isLoadingSubject.OnNext(true);
             errorMessageSubject.OnNext(string.Empty);
 
-            var supportedTimezonesObs = interactorFactory.GetSupportedTimezones().Execute();
+            var supportedTimezonesObs = new GetSupportedTimezonesInteractor(new JsonSerializer()).Execute();
             signupDisposable = supportedTimezonesObs
                 .Select(supportedTimezones => supportedTimezones.FirstOrDefault(tz => platformInfo.TimezoneIdentifier == tz))
                 .SelectMany(timezone

--- a/Toggl.Foundation.Tests/MvvmCross/ViewModels/SignupViewModelTests.cs
+++ b/Toggl.Foundation.Tests/MvvmCross/ViewModels/SignupViewModelTests.cs
@@ -52,8 +52,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                     TimeService,
                     SchedulerProvider,
                     RxActionFactory,
-                    PlatformInfo,
-                    InteractorFactory);
+                    PlatformInfo);
 
             protected override void AdditionalSetup()
             {
@@ -81,8 +80,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 bool useTimeService,
                 bool useSchedulerProvider,
                 bool useRxActionFactory,
-                bool usePlatformInfo,
-                bool useInteractorFactory)
+                bool usePlatformInfo)
             {
                 var apiFactory = useApiFactory ? ApiFactory : null;
                 var userAccessManager = useUserAccessManager ? UserAccessManager : null;
@@ -95,7 +93,6 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                 var schedulerProvider = useSchedulerProvider ? SchedulerProvider : null;
                 var rxActionFactory = useRxActionFactory ? RxActionFactory : null;
                 var timezoneService = usePlatformInfo ? PlatformInfo : null;
-                var interactorFactory = useInteractorFactory ? InteractorFactory : null;
 
                 Action tryingToConstructWithEmptyParameters =
                     () => new SignupViewModel(
@@ -109,8 +106,7 @@ namespace Toggl.Foundation.Tests.MvvmCross.ViewModels
                         timeService,
                         schedulerProvider,
                         rxActionFactory,
-                        timezoneService,
-                        interactorFactory);
+                        timezoneService);
 
                 tryingToConstructWithEmptyParameters
                     .Should().Throw<ArgumentNullException>();


### PR DESCRIPTION
## What's this?
This fixes the problem where Mvx can't construct SignupViewModel

### Relationships
No created issue

## Why do we want this?
So users can sign up.

## How is it done?
By remove IInteractoryFactory from SignupVM and initializing the interactor directly.

### Why not another way?
Until we sort out the problem with our 🏭 dependency, this is the way.

### Side effects
Nada

## Review hints
Try to sign up I guess

## :squid: Permissions
the release manager aka @dshr 