### PR TITLE
Grouped Time Entries Test Build (1.20)

### DIFF
--- a/Toggl.Daneel.SiriExtension.UI/Info.plist
+++ b/Toggl.Daneel.SiriExtension.UI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17</string>
+	<string>1.20</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.Daneel.SiriExtension/Info.plist
+++ b/Toggl.Daneel.SiriExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17</string>
+	<string>1.20</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.Daneel/Info.plist
+++ b/Toggl.Daneel/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.17</string>
+	<string>1.20</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This draft PR is just for a discussion about a test build.

The version `1.20` was selected because it's free and because this feature should be part of that release (since we missed the `1.19` deadline).