### PR TITLE
Fix calendar events background colour on Android Api Pre-23

### DIFF
--- a/Toggl.Giskard/ViewHolders/CalendarEntryViewHolder.cs
+++ b/Toggl.Giskard/ViewHolders/CalendarEntryViewHolder.cs
@@ -1,5 +1,6 @@
 using System;
 using Android.Graphics;
+using Android.Graphics.Drawables;
 using Android.Runtime;
 using Android.Util;
 using Android.Views;
@@ -13,6 +14,7 @@ namespace Toggl.Giskard.ViewHolders
     public class CalendarEntryViewHolder : BaseRecyclerViewHolder<CalendarItem>
     {
         private TextView label;
+        private GradientDrawable background;
 
         private readonly int regularEntryTextSize = 12;
         private readonly int shortEntryTextSize = 10;
@@ -36,6 +38,7 @@ namespace Toggl.Giskard.ViewHolders
 
         protected override void InitializeViews()
         {
+            background = ItemView.Background as GradientDrawable;
             label = ItemView.FindViewById<TextView>(Resource.Id.EntryLabel);
             defaultElevation = ItemView.Elevation;
             shortTimeEntryHeight = 18.DpToPixels(ItemView.Context);
@@ -86,7 +89,7 @@ namespace Toggl.Giskard.ViewHolders
             if (Item.Source == CalendarItemSource.Calendar)
                 color.A = (byte) (color.A * 0.25);
 
-            ItemView.Background.SetTint(color);
+            background?.SetColor(color);
         }
 
         private void updateTextColor()


### PR DESCRIPTION
## What's this?
This fixes how we set the events background colour, such that it works on Android api < 23.

### Relationships
Closes #4667 

## Why do we want this?
Because it was all white on android 21 and 22. Apparently setting the background tint on those API levels doesn't work as expected. I've changed to change the background drawable colour directly instead.

## How is it done?
Check the code, I've explained ☝️  as well.

### Why not another way?
Because this works for both api-pre-23 and api-23+.

### Side effects
None.

## Review hints
Give it a try, on an emulator with api level 21 or 22.

## :squid: Permissions
🦑 it