### PR TITLE
GTE: Measure diffing performance

### DIFF
--- a/Toggl.Daneel/Binding/AnimatedTableViewReloadingBinder.cs
+++ b/Toggl.Daneel/Binding/AnimatedTableViewReloadingBinder.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using Foundation;
+using Toggl.Daneel.ViewSources;
+using Toggl.Foundation.MvvmCross.Collections;
+using Toggl.Foundation.MvvmCross.Collections.Diffing;
+using Toggl.Foundation.MvvmCross.Reactive;
+using UIKit;
+
+namespace Toggl.Daneel.Binding
+{
+    public sealed class AnimatedTableViewReloadingBinder<TSection, THeader, TModel, TKey>
+        where TKey : IEquatable<TKey>
+        where TSection : IAnimatableSectionModel<THeader, TModel, TKey>, new()
+        where TModel : IDiffable<TKey>, IEquatable<TModel>
+        where THeader : IDiffable<TKey>
+    {
+        public IObserver<IEnumerable<TSection>> CreateAnimatedReloadObserver(
+            IReactive<UITableView> reactive,
+            BaseTableViewSource<TSection, THeader, TModel> dataSource)
+        {
+            return Observer.Create<IEnumerable<TSection>>(finalSections =>
+            {
+                var initialSections = dataSource.Sections;
+                if (initialSections == null || initialSections.Count == 0)
+                {
+                    dataSource.SetSections(finalSections);
+                    reactive.Base.ReloadData();
+                    return;
+                }
+
+                // if view is not in view hierarchy, performing batch updates will crash the app
+                if (reactive.Base.Window == null)
+                {
+                    dataSource.SetSections(finalSections);
+                    reactive.Base.ReloadData();
+                    return;
+                }
+
+                var diff = new Diffing<TSection, THeader, TModel, TKey>(initialSections, finalSections);
+                var changeset = diff.ComputeDifferences();
+
+                // The changesets have to be applied one after another. Not in one transaction.
+                // iOS is picky about the changes which can happen in a single transaction.
+                // Don't put BeginUpdates() ... EndUpdates() around the foreach, it has to stay this way,
+                // otherwise the app might crash from time to time.
+
+                foreach (var difference in changeset)
+                {
+                    reactive.Base.BeginUpdates();
+                    dataSource.SetSections(difference.FinalSections);
+                    performChangesetUpdates(reactive.Base, difference);
+                    reactive.Base.EndUpdates();
+                }
+            });
+        }
+
+        private static void performChangesetUpdates(
+            UITableView tableView,
+            Diffing<TSection, THeader, TModel, TKey>.Changeset changes)
+        {
+            NSIndexSet newIndexSet(List<int> indexes)
+            {
+                var indexSet = new NSMutableIndexSet();
+                foreach (var i in indexes)
+                {
+                    indexSet.Add((nuint)i);
+                }
+
+                return indexSet as NSIndexSet;
+            }
+
+            tableView.DeleteSections(newIndexSet(changes.DeletedSections), UITableViewRowAnimation.Fade);
+            // Updated sections doesn't mean reload entire section, somebody needs to update the section view manually
+            // otherwise all cells will be reloaded for nothing.
+            tableView.InsertSections(newIndexSet(changes.InsertedSections), UITableViewRowAnimation.Fade);
+
+            foreach (var (from, to) in changes.MovedSections)
+            {
+                tableView.MoveSection(from, to);
+            }
+            tableView.DeleteRows(
+                changes.DeletedItems.Select(item => NSIndexPath.FromRowSection(item.itemIndex, item.sectionIndex)).ToArray(),
+                UITableViewRowAnimation.Top
+            );
+
+            tableView.InsertRows(
+                changes.InsertedItems.Select(item =>
+                    NSIndexPath.FromItemSection(item.itemIndex, item.sectionIndex)).ToArray(),
+                UITableViewRowAnimation.Automatic
+            );
+            tableView.ReloadRows(
+                changes.UpdatedItems.Select(item => NSIndexPath.FromRowSection(item.itemIndex, item.sectionIndex))
+                    .ToArray(),
+                // No animation so it doesn't fade showing the cells behind it
+                UITableViewRowAnimation.None
+            );
+
+            foreach (var (from, to) in changes.MovedItems)
+            {
+                tableView.MoveRow(
+                    NSIndexPath.FromRowSection(from.itemIndex, from.sectionIndex),
+                    NSIndexPath.FromRowSection(to.itemIndex, to.sectionIndex)
+                );
+            }
+        }
+    }
+}

--- a/Toggl.Daneel/Extensions/Reactive/UITableViewExtensions.cs
+++ b/Toggl.Daneel/Extensions/Reactive/UITableViewExtensions.cs
@@ -1,15 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reactive;
-using CoreAnimation;
-using CoreImage;
-using CoreText;
-using Foundation;
 using Toggl.Daneel.ViewSources;
-using Toggl.Daneel.ViewSources.Generic;
 using Toggl.Foundation.MvvmCross.Collections;
-using Toggl.Foundation.MvvmCross.Collections.Diffing;
 using Toggl.Foundation.MvvmCross.Reactive;
 using UIKit;
 
@@ -28,50 +21,6 @@ namespace Toggl.Daneel.Extensions.Reactive
             });
         }
 
-        public static IObserver<IEnumerable<TSection>> AnimateSections<TSection, THeader, TModel, TKey>(
-            this IReactive<UITableView> reactive,
-            BaseTableViewSource<TSection, THeader, TModel> dataSource)
-            where TKey : IEquatable<TKey>
-            where TSection : IAnimatableSectionModel<THeader, TModel, TKey>, new()
-            where TModel : IDiffable<TKey>, IEquatable<TModel>
-            where THeader : IDiffable<TKey>
-        {
-            return Observer.Create<IEnumerable<TSection>>(finalSections =>
-            {
-                var initialSections = dataSource.Sections;
-                if (initialSections == null || initialSections.Count == 0)
-                {
-                    dataSource.SetSections(finalSections);
-                    reactive.Base.ReloadData();
-                    return;
-                }
-
-                // if view is not in view hierarchy, performing batch updates will crash the app
-                if (reactive.Base.Window == null)
-                {
-                    dataSource.SetSections(finalSections);
-                    reactive.Base.ReloadData();
-                    return;
-                }
-
-                var diff = new Diffing<TSection, THeader, TModel, TKey>(initialSections, finalSections);
-                var changeset = diff.ComputeDifferences();
-
-                // The changesets have to be applied one after another. Not in one transaction.
-                // iOS is picky about the changes which can happen in a single transaction.
-                // Don't put BeginUpdates() ... EndUpdates() around the foreach, it has to stay this way,
-                // otherwise the app might crash from time to time.
-
-                foreach (var difference in changeset)
-                {
-                    reactive.Base.BeginUpdates();
-                    dataSource.SetSections(difference.FinalSections);
-                    reactive.Base.performChangesetUpdates(difference);
-                    reactive.Base.EndUpdates();
-                }
-            });
-        }
-
         public static IObserver<IEnumerable<TModel>> ReloadItems<TSection, THeader, TModel>(
             this IReactive<UITableView> reactive, BaseTableViewSource<TSection, THeader, TModel> dataSource)
         where TSection : SectionModel<THeader, TModel>, new()
@@ -81,61 +30,6 @@ namespace Toggl.Daneel.Extensions.Reactive
                 dataSource.SetItems(list);
                 reactive.Base.ReloadData();
             });
-        }
-
-        private static void performChangesetUpdates<TSection, THeader, TModel, TKey>(
-            this UITableView tableView,
-            Diffing<TSection, THeader, TModel, TKey>.Changeset changes)
-            where TKey : IEquatable<TKey>
-            where TSection : IAnimatableSectionModel<THeader, TModel, TKey>, new()
-            where TModel : IDiffable<TKey>, IEquatable<TModel>
-            where THeader : IDiffable<TKey>
-
-        {
-            NSIndexSet newIndexSet(List<int> indexes)
-            {
-                var indexSet = new NSMutableIndexSet();
-                foreach (var i in indexes)
-                {
-                    indexSet.Add((nuint) i);
-                }
-
-                return indexSet as NSIndexSet;
-            }
-
-            tableView.DeleteSections(newIndexSet(changes.DeletedSections), UITableViewRowAnimation.Fade);
-            // Updated sections doesn't mean reload entire section, somebody needs to update the section view manually
-            // otherwise all cells will be reloaded for nothing.
-            tableView.InsertSections(newIndexSet(changes.InsertedSections), UITableViewRowAnimation.Fade);
-
-            foreach (var (from, to) in changes.MovedSections)
-            {
-                tableView.MoveSection(from, to);
-            }
-            tableView.DeleteRows(
-                changes.DeletedItems.Select(item => NSIndexPath.FromRowSection(item.itemIndex, item.sectionIndex)).ToArray(),
-                UITableViewRowAnimation.Top
-            );
-
-            tableView.InsertRows(
-                changes.InsertedItems.Select(item =>
-                    NSIndexPath.FromItemSection(item.itemIndex, item.sectionIndex)).ToArray(),
-                UITableViewRowAnimation.Automatic
-            );
-            tableView.ReloadRows(
-                changes.UpdatedItems.Select(item => NSIndexPath.FromRowSection(item.itemIndex, item.sectionIndex))
-                    .ToArray(),
-                // No animation so it doesn't fade showing the cells behind it
-                UITableViewRowAnimation.None
-            );
-
-            foreach (var (from, to) in changes.MovedItems)
-            {
-                tableView.MoveRow(
-                    NSIndexPath.FromRowSection(from.itemIndex, from.sectionIndex),
-                    NSIndexPath.FromRowSection(to.itemIndex, to.sectionIndex)
-                );
-            }
         }
     }
 }

--- a/Toggl.Daneel/Toggl.Daneel.csproj
+++ b/Toggl.Daneel/Toggl.Daneel.csproj
@@ -1178,6 +1178,7 @@
     <Compile Include="Views\EntityCreation\CreateEntityViewCell.designer.cs">
       <DependentUpon>CreateEntityViewCell.cs</DependentUpon>
     </Compile>
+    <Compile Include="Binding\AnimatedTableViewReloadingBinder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Toggl.Foundation.MvvmCross\Toggl.Foundation.MvvmCross.csproj">

--- a/Toggl.Daneel/ViewControllers/MainViewController.cs
+++ b/Toggl.Daneel/ViewControllers/MainViewController.cs
@@ -115,10 +115,10 @@ namespace Toggl.Daneel.ViewControllers
             tableViewSource.ObservedHeaders = ViewModel.TimeEntries.Select(e => e.Select(section => section.Header));
 
             TimeEntriesLogTableView.Source = tableViewSource;
-            var binder = new AnimatedTableViewReloadingBinder<MainLogSection, DaySummaryViewModel, LogItemViewModel, IMainLogKey>();
+            var binder = new AnimatedTableViewReloadingBinder<MainLogSection, DaySummaryViewModel, LogItemViewModel, IMainLogKey>(tableViewSource);
 
             ViewModel.TimeEntries
-                .Subscribe(binder.CreateAnimatedReloadObserver(TimeEntriesLogTableView.Rx(), tableViewSource))
+                .Subscribe(binder.CreateAnimatedReloadObserver(TimeEntriesLogTableView))
                 .DisposedBy(disposeBag);
 
             ViewModel.ShouldReloadTimeEntryLog

--- a/Toggl.Daneel/ViewControllers/MainViewController.cs
+++ b/Toggl.Daneel/ViewControllers/MainViewController.cs
@@ -115,10 +115,10 @@ namespace Toggl.Daneel.ViewControllers
             tableViewSource.ObservedHeaders = ViewModel.TimeEntries.Select(e => e.Select(section => section.Header));
 
             TimeEntriesLogTableView.Source = tableViewSource;
-            var binder = new AnimatedTableViewReloadingBinder<MainLogSection, DaySummaryViewModel, LogItemViewModel, IMainLogKey>(tableViewSource);
+            var timeEntriesViewSourceBinder = new AnimatedTableViewReloadingBinder<MainLogSection, DaySummaryViewModel, LogItemViewModel, IMainLogKey>(tableViewSource);
 
             ViewModel.TimeEntries
-                .Subscribe(binder.CreateAnimatedReloadObserver(TimeEntriesLogTableView))
+                .Subscribe(timeEntriesViewSourceBinder.CreateAnimatedReloadObserver(TimeEntriesLogTableView))
                 .DisposedBy(disposeBag);
 
             ViewModel.ShouldReloadTimeEntryLog

--- a/Toggl.Daneel/ViewControllers/MainViewController.cs
+++ b/Toggl.Daneel/ViewControllers/MainViewController.cs
@@ -29,6 +29,7 @@ using Toggl.PrimeRadiant.Onboarding;
 using Toggl.PrimeRadiant.Settings;
 using UIKit;
 using static Toggl.Foundation.MvvmCross.Helper.Animation;
+using Toggl.Daneel.Binding;
 
 namespace Toggl.Daneel.ViewControllers
 {
@@ -114,9 +115,10 @@ namespace Toggl.Daneel.ViewControllers
             tableViewSource.ObservedHeaders = ViewModel.TimeEntries.Select(e => e.Select(section => section.Header));
 
             TimeEntriesLogTableView.Source = tableViewSource;
+            var binder = new AnimatedTableViewReloadingBinder<MainLogSection, DaySummaryViewModel, LogItemViewModel, IMainLogKey>();
 
             ViewModel.TimeEntries
-                .Subscribe(TimeEntriesLogTableView.Rx().AnimateSections<MainLogSection, DaySummaryViewModel, LogItemViewModel, IMainLogKey>(tableViewSource))
+                .Subscribe(binder.CreateAnimatedReloadObserver(TimeEntriesLogTableView.Rx(), tableViewSource))
                 .DisposedBy(disposeBag);
 
             ViewModel.ShouldReloadTimeEntryLog

--- a/Toggl.Foundation/Diagnostics/MeasuredOperation.cs
+++ b/Toggl.Foundation/Diagnostics/MeasuredOperation.cs
@@ -23,6 +23,7 @@
         CreateMainLogSuggestionsViewHolder,
         MainActivityOnCreate,
         BackgroundSync,
-        Sync
+        Sync,
+        Diffing
     }
 }


### PR DESCRIPTION
## What's this?
Add performance measurement for iOS diffing.

### Relationships
We don't have an issue for this.

## Why do we want this?
We ran into performance issues and this might give us more ideas about where are our bottlenecks. I think the diffing algorithm is actually pretty fast and I hope this will give us a reason to rule out why updating and deleting many things in batch takes so long...

## How is it done?
I moved the extension into a separate class which then grabs the stopwatch provider and measures perf of every diff.

### Why not another way?
I could just grab the stopwatch provider in the extension method from the static container, but I would like to make that easy to update after Mvxit is finished and we have just our custom DI container which is hopefully not static (@heytherewill could chime in and tell us how we're gonna access the services without exposing them as VM properties... hopefully this will be possible).

### Side effects
A bit of (nice?) refactoring.

## Review hints
Run in the iOS simulator.

## :squid: Permissions
🦑 