### PR TITLE
GTE: Fix delayed deletion flickering

### DIFF
--- a/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/MainViewModel.cs
@@ -155,7 +155,7 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
             SuggestionsViewModel = new SuggestionsViewModel(dataSource, interactorFactory, onboardingStorage, suggestionProviders, schedulerProvider, rxActionFactory);
             RatingViewModel = new RatingViewModel(timeService, dataSource, ratingService, analyticsService, onboardingStorage, navigationService, schedulerProvider, rxActionFactory);
-            TimeEntriesViewModel = new TimeEntriesViewModel(dataSource, syncManager, interactorFactory, analyticsService, schedulerProvider, rxActionFactory, timeService);
+            TimeEntriesViewModel = new TimeEntriesViewModel(dataSource, interactorFactory, analyticsService, schedulerProvider, rxActionFactory, timeService);
 
             LogEmpty = TimeEntriesViewModel.Empty.AsDriver(schedulerProvider);
             TimeEntriesCount = TimeEntriesViewModel.Count.AsDriver(schedulerProvider);

--- a/Toggl.Foundation.MvvmCross/ViewModels/TimeEntriesViewModel.cs
+++ b/Toggl.Foundation.MvvmCross/ViewModels/TimeEntriesViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
@@ -16,26 +17,24 @@ using Toggl.Foundation.MvvmCross.Transformations;
 using Toggl.Foundation.MvvmCross.ViewModels.TimeEntriesLog;
 using Toggl.Foundation.MvvmCross.ViewModels.TimeEntriesLog.Identity;
 using Toggl.Foundation.Services;
-using Toggl.Foundation.Sync;
 using Toggl.Multivac;
 using Toggl.Multivac.Extensions;
 
 namespace Toggl.Foundation.MvvmCross.ViewModels
 {
-
     [Preserve(AllMembers = true)]
     public sealed class TimeEntriesViewModel
     {
-        private readonly ISyncManager syncManager;
         private readonly IInteractorFactory interactorFactory;
         private readonly IAnalyticsService analyticsService;
         private readonly ISchedulerProvider schedulerProvider;
 
         private readonly TimeEntriesGroupsFlattening groupsFlatteningStrategy;
 
-        private Subject<int?> timeEntriesPendingDeletionSubject = new Subject<int?>();
-        private IDisposable delayedDeletionDisposable;
-        private long[] timeEntriesToDelete;
+        private readonly Subject<int?> timeEntriesPendingDeletionSubject = new Subject<int?>();
+        private readonly HashSet<long> timeEntriesToDelete = new HashSet<long>();
+
+        private DelayedInteractorExecution<IObservable<Unit>> delayedDeletion;
 
         public IObservable<IEnumerable<AnimatableSectionModel<DaySummaryViewModel, LogItemViewModel, IMainLogKey>>> TimeEntries { get; }
         public IObservable<bool> Empty { get; }
@@ -48,7 +47,6 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public TimeEntriesViewModel(
             ITogglDataSource dataSource,
-            ISyncManager syncManager,
             IInteractorFactory interactorFactory,
             IAnalyticsService analyticsService,
             ISchedulerProvider schedulerProvider,
@@ -56,14 +54,12 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
             ITimeService timeService)
         {
             Ensure.Argument.IsNotNull(dataSource, nameof(dataSource));
-            Ensure.Argument.IsNotNull(syncManager, nameof(syncManager));
             Ensure.Argument.IsNotNull(interactorFactory, nameof(interactorFactory));
             Ensure.Argument.IsNotNull(analyticsService, nameof(analyticsService));
             Ensure.Argument.IsNotNull(schedulerProvider, nameof(schedulerProvider));
             Ensure.Argument.IsNotNull(rxActionFactory, nameof(rxActionFactory));
             Ensure.Argument.IsNotNull(timeService, nameof(timeService));
 
-            this.syncManager = syncManager;
             this.interactorFactory = interactorFactory;
             this.analyticsService = analyticsService;
             this.schedulerProvider = schedulerProvider;
@@ -100,15 +96,13 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         public async Task FinalizeDelayDeleteTimeEntryIfNeeded()
         {
-            if (timeEntriesToDelete == null)
+            if (delayedDeletion != null)
             {
-                return;
-            }
+                await delayedDeletion?.ExecuteImmediately();
+                delayedDeletion = null;
 
-            delayedDeletionDisposable.Dispose();
-            await deleteTimeEntries(timeEntriesToDelete);
-            timeEntriesToDelete = null;
-            timeEntriesPendingDeletionSubject.OnNext(null);
+                timeEntriesPendingDeletionSubject.OnNext(null);
+            }
         }
 
         private IEnumerable<IGrouping<DateTime, IThreadSafeTimeEntry>> group(
@@ -124,49 +118,42 @@ namespace Toggl.Foundation.MvvmCross.ViewModels
 
         private void delayDeleteTimeEntries(long[] timeEntries)
         {
-            timeEntriesToDelete = timeEntries;
+            if (delayedDeletion != null)
+            {
+                delayedDeletion.ExecuteImmediately().Subscribe();
+                analyticsService.DeleteTimeEntry.Track();
+            }
 
             timeEntriesPendingDeletionSubject.OnNext(timeEntries.Length);
+            timeEntriesToDelete.AddRange(timeEntries);
 
-            delayedDeletionDisposable = Observable.Merge( // If 5 seconds pass or we try to delete another TE
-                    Observable.Return(timeEntries).Delay(Constants.UndoTime, schedulerProvider.DefaultScheduler),
-                    timeEntriesPendingDeletionSubject
-                        .Where(numberOfDeletedTimeEntries => numberOfDeletedTimeEntries != null)
-                        .SelectValue(timeEntries)
-                )
-                .Take(1)
-                .SelectMany(deleteTimeEntries)
-                .Do(deletedTimeEntries =>
-                {
-                    // Hide bar if there isn't other TE trying to be deleted
-                    if (deletedTimeEntries == timeEntriesToDelete)
-                    {
-                        timeEntriesPendingDeletionSubject.OnNext(null);
-                    }
-                })
+            delayedDeletion = new DelayedInteractorExecution<IObservable<Unit>>(
+                interactorFactory.SoftDeleteMultipleTimeEntries(timeEntries),
+                Constants.UndoTime,
+                schedulerProvider.BackgroundScheduler);
+
+            delayedDeletion.Execute()
+                .Track(analyticsService.DeleteTimeEntry)
+                .Do(dismissUndo)
+                .Do(observable => observable.Subscribe())
                 .Subscribe();
         }
 
         private void cancelDeleteTimeEntry()
         {
-            timeEntriesToDelete = null;
-            delayedDeletionDisposable.Dispose();
+            delayedDeletion?.Cancel();
+            delayedDeletion = null;
+
+            dismissUndo();
+        }
+
+        private void dismissUndo()
+        {
+            timeEntriesToDelete.Clear();
             timeEntriesPendingDeletionSubject.OnNext(null);
         }
 
-        private IObservable<long[]> deleteTimeEntries(long[] timeEntries)
-        {
-            var observables =
-                interactorFactory.SoftDeleteMultipleTimeEntries(timeEntries)
-                    .Execute()
-                    .Track(analyticsService.DeleteTimeEntry);
-
-            return observables.SelectValue(timeEntries);
-        }
-
         private bool isNotRunning(IThreadSafeTimeEntry timeEntry) => !timeEntry.IsRunning();
-
-        private bool isNotDeleted(IThreadSafeTimeEntry timeEntry)
-            => timeEntriesToDelete == null || !timeEntriesToDelete.Contains(timeEntry.Id);
+        private bool isNotDeleted(IThreadSafeTimeEntry timeEntry) => !timeEntriesToDelete.Contains(timeEntry.Id);
     }
 }

--- a/Toggl.Foundation/Interactors/DelayedExecutionInteractor.cs
+++ b/Toggl.Foundation/Interactors/DelayedExecutionInteractor.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace Toggl.Foundation.Interactors
+{
+    public sealed class DelayedInteractorExecution<T>
+        : IInteractor<IObservable<T>>
+    {
+        private readonly IInteractor<T> interactor;
+        private readonly TimeSpan delay;
+        private readonly IScheduler scheduler;
+
+        private IDisposable subscription;
+
+        public DelayedInteractorExecution(
+            IInteractor<T> interactor,
+            TimeSpan delay,
+            IScheduler scheduler)
+        {
+            this.interactor = interactor;
+            this.delay = delay;
+            this.scheduler = scheduler;
+        }
+
+        public IObservable<T> Execute()
+        {
+            var result = new Subject<T>();
+            if (subscription != null)
+            {
+                throw new InvalidOperationException("Interactor can't be executed repeatedly.");
+            }
+
+            subscription = Observable.Return(Unit.Default)
+                .Delay(delay, scheduler)
+                .Select(_ => interactor.Execute())
+                .Subscribe(result);
+
+            return result.AsObservable();
+        }
+
+        public T ExecuteImmediately()
+        {
+            Cancel();
+            return interactor.Execute();
+        }
+
+        public void Cancel()
+        {
+            if (subscription == null)
+            {
+                throw new InvalidOperationException("Interactor hasn't been executed yet and so it can't be cancelled.");
+            }
+
+            subscription.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## What's this?
This PR solves the cause of the problem described in #4758.

### Relationships

Closes #4758

## Why do we want this?

We want nice UI and UX.

## How is it done?
The main idea of this PR is to **remember IDs of all the deleted TEs** until the available time for undoing runs out or user presses the undo button.

The effect of this is that we don't emit time entries which have the already been deleted, but are still cached in the observable chain (combine latest/reemit when) and haven't managed to be propagated from the data source yet.

I also extracted the delayed observable from the VM and put it into an `DelayedInteractorExecution` class. This is the main reason this PR is a draft. I think it makes it much easier to reason about what's going on in the VM and it could be tested much more thoroughly, but maybe it is overengineered. I want to share this PR with you before I spend a lot of time updating and adding tests.

### Side effects
I'm not aware of any.

## Review hints
Try this in simulator/emulator.

## :squid: Permissions
🚫 