### PR TITLE
Fix invalid order of labels

### DIFF
--- a/Toggl.Giskard/ViewHolders/MainLogSectionViewHolder.cs
+++ b/Toggl.Giskard/ViewHolders/MainLogSectionViewHolder.cs
@@ -35,8 +35,8 @@ namespace Toggl.Giskard.ViewHolders
 
         protected override void UpdateView()
         {
-            mainLogHeaderTitle.Text = Item.DurationText;
-            mainLogHeaderDuration.Text = Item.HeaderDate(Now);
+            mainLogHeaderTitle.Text = Item.HeaderDate(Now);
+            mainLogHeaderDuration.Text = Item.DurationText;
         }
     }
 }


### PR DESCRIPTION
## What's this?
This is correct natural order.
The date label should be on the left, the duration on the right.

### Relationships
Closes #4789 

## Why do we want this?
Because it just makes more sense.

## How is it done?
By undoing an error somebody has done 😄 

### Why not another way?
This is the only way that makes sense.

### Side effects
It will now work correctly.

## Review hints
By careful examination of the code.

## :squid: Permissions
@daividssilverio 