### PR TITLE
Clear swipe backgrounds when clearing views on MainRecyclerViewTouchCallback clear callback

### DIFF
--- a/Toggl.Giskard/ViewHelpers/MainRecyclerViewTouchCallback.cs
+++ b/Toggl.Giskard/ViewHelpers/MainRecyclerViewTouchCallback.cs
@@ -89,6 +89,7 @@ namespace Toggl.Giskard.ViewHelpers
         {
             if (viewHolder is MainLogCellViewHolder logViewHolder)
             {
+                logViewHolder.HideSwipeBackgrounds();
                 DefaultUIUtil.ClearView(logViewHolder.MainLogContentView);
             }
             else


### PR DESCRIPTION
## What's this?
This fixes the delete and continue backgrounds that get stuck when you go loco in the main log view.

### Relationships
Closes #4433

## Why do we want this?
Because we want our ui to look good and work well no matter how it's used. (Actually, deleting a bunch o time entries very fast doesn't look like a very weird use case to me).

## How is it done?
The view holder callback to clear the swipe backgrounds is called when the `MainRecyclerViewTouchCallback` callback to clear the viewholder when the swiping ends.

### Why not another way?
🤔 I don't know. Please give your suggestion.

### Side effects
None.

## Review hints
Try to replicate the bug on this branch. You can't be sure it works just based on the change.

## :squid: Permissions
🦑 it