### PR TITLE
Respect duration format preferences in GTE

### DIFF
--- a/Toggl.Foundation.MvvmCross/Transformations/TimeEntriesGroupsFlattening.cs
+++ b/Toggl.Foundation.MvvmCross/Transformations/TimeEntriesGroupsFlattening.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Text.RegularExpressions;
 using Toggl.Foundation.Extensions;
 using Toggl.Foundation.Models.Interfaces;
 using Toggl.Foundation.MvvmCross.Collections;
@@ -34,6 +33,8 @@ namespace Toggl.Foundation.MvvmCross.Transformations
 
         public IEnumerable<MainLogSection> Flatten(IEnumerable<LogGrouping> days, IThreadSafePreferences preferences)
         {
+            durationFormat = preferences.DurationFormat;
+
             return days.Select(preferences.CollapseTimeEntries
                 ? flatten(bySimilarTimeEntries)
                 : flatten(withJustSingleTimeEntries));


### PR DESCRIPTION
## What's this?
Bugfix.

### Relationships
Closes #4788 

## Why do we want this?
Respect user's preferences.

## How is it done?
Actually use duration format when flattening.

### Why not another way?
🤷‍♂️ 

### Side effects
None.

## Review hints
Check the tests.

## :squid: Permissions
🦑 