### PR TITLE
iPad: Fix bug that caused action dismiss action sheets to break

### DIFF
--- a/Toggl.Daneel/Services/DialogServiceIos.cs
+++ b/Toggl.Daneel/Services/DialogServiceIos.cs
@@ -71,11 +71,7 @@ namespace Toggl.Daneel.Services
                     preferredStyle: UIAlertControllerStyle.ActionSheet
                 );
 
-                var actionStyleForCancel = UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad
-                    ? UIAlertActionStyle.Default
-                    : UIAlertActionStyle.Cancel;
-
-                var cancelAction = UIAlertAction.Create(cancelText, actionStyleForCancel, _ =>
+                var cancelAction = UIAlertAction.Create(cancelText, UIAlertActionStyle.Cancel, _ =>
                 {
                     observer.OnNext(false);
                     observer.OnCompleted();
@@ -89,7 +85,7 @@ namespace Toggl.Daneel.Services
 
                 if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
                 {
-                    var extraCancelAction = UIAlertAction.Create(cancelText, UIAlertActionStyle.Cancel, _ =>
+                    var extraCancelAction = UIAlertAction.Create(cancelText, UIAlertActionStyle.Default, _ =>
                     {
                         observer.OnNext(false);
                         observer.OnCompleted();

--- a/Toggl.Daneel/Services/DialogServiceIos.cs
+++ b/Toggl.Daneel/Services/DialogServiceIos.cs
@@ -87,6 +87,16 @@ namespace Toggl.Daneel.Services
                     observer.OnCompleted();
                 });
 
+                if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+                {
+                    var extraCancelAction = UIAlertAction.Create(cancelText, UIAlertActionStyle.Cancel, _ =>
+                    {
+                        observer.OnNext(false);
+                        observer.OnCompleted();
+                    });
+                    actionSheet.AddAction(extraCancelAction);
+                }
+
                 actionSheet.AddAction(confirmAction);
                 actionSheet.AddAction(cancelAction);
 


### PR DESCRIPTION
## What's this?
A small fix to an action sheet bug

### Relationships
Closes #4906 

## Why do we want this?
We don't want our action sheets broken, do we?

## How is it done?
By adding the properly needed .Cancel action to the action sheet.

### Why not another way?
This is the correct Apple-approved way

## Review hints
Try and replicate the behaviour from the issue

## :squid: Permissions
iPad crew, just you