### PR TITLE
💥 Fix crash with armeabi v7

### DIFF
--- a/Toggl.Droid/Toggl.Droid.csproj
+++ b/Toggl.Droid/Toggl.Droid.csproj
@@ -20,6 +20,7 @@
     <EnableProguard>true</EnableProguard>
     <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AndroidAotAdditionalArguments>llvmopts="-data-layout='e-p:32:32-n32-S64' -O2 -disable-tail-calls"</AndroidAotAdditionalArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,6 +31,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidSupportedAbis>arm64-v8a;armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
+    <AndroidAotAdditionalArguments>llvmopts="-data-layout='e-p:32:32-n32-S64' -O2 -disable-tail-calls"</AndroidAotAdditionalArguments>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
   </PropertyGroup>
@@ -37,6 +39,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi-v7a;x86_64;x86;arm64-v8a</AndroidSupportedAbis>
+    <AndroidAotAdditionalArguments>llvmopts="-data-layout='e-p:32:32-n32-S64' -O2 -disable-tail-calls"</AndroidAotAdditionalArguments>
     <DebugType>
     </DebugType>
     <OutputPath>..\bin</OutputPath>
@@ -59,6 +62,7 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi-v7a;x86_64;x86;arm64-v8a</AndroidSupportedAbis>
+    <AndroidAotAdditionalArguments>llvmopts="-data-layout='e-p:32:32-n32-S64' -O2 -disable-tail-calls"</AndroidAotAdditionalArguments>
     <DebugType>
     </DebugType>
     <DefineConstants>USE_ANALYTICS;USE_PRODUCTION_API</DefineConstants>


### PR DESCRIPTION
## What's this?
This will probably fix problems with armeabi v7 builds (debugs and releases)

### Relationships
The problem (and the workaround) is described here:

xamarin/xamarin-android/issues/2966
xamarin/xamarin-android/issues/2920
xamarin/xamarin-android/issues/2960

Refs: #4944 

## Why do we want this?
No 💥

## How is it done?
By preventing 64bit architectures run 32bit version of the app.

### Why not another way?
When `Xamarin.Android` is updated with a fix, this change will no longer be necessary.

### Side effects
Not that we know of.

## Review hints
This applies the fix from the mentioned `xamarin-android` repo links, so feel free to read about it yoursef.

## :squid: Permissions
Me, @heytherewill 