### PR TITLE
Fix NullReferenceException in CalendarViewController.ScrollToTop

### DIFF
--- a/Toggl.Daneel/ViewControllers/Calendar/CalendarViewController.cs
+++ b/Toggl.Daneel/ViewControllers/Calendar/CalendarViewController.cs
@@ -144,7 +144,7 @@ namespace Toggl.Daneel.ViewControllers
 
         public void ScrollToTop()
         {
-            CalendarCollectionView.SetContentOffset(CGPoint.Empty, true);
+            CalendarCollectionView?.SetContentOffset(CGPoint.Empty, true);
         }
 
         private void selectGoodScrollPoint(TimeSpan timeOfDay)


### PR DESCRIPTION
## What's this?
This fixes a crash that's been happening on Daneel 1.21. The issue describes the crash a bit more.

### Relationships

Closes #5016

## :squid: Permissions
🦑 