### PR TITLE
Prevent null exceptions in DurationFieldTextFormatter.AttributedStringFor

### DIFF
--- a/Toggl.Daneel/Views/EditDuration/DurationFieldTextFormatter.cs
+++ b/Toggl.Daneel/Views/EditDuration/DurationFieldTextFormatter.cs
@@ -12,6 +12,7 @@ namespace Toggl.Daneel.Views.EditDuration
 
         public static NSAttributedString AttributedStringFor(string durationText, UIFont font)
         {
+            durationText = durationText ?? "";
             var prefixLength = DurationHelper.LengthOfDurationPrefix(durationText);
             var result = new NSMutableAttributedString(durationText, font: font.GetMonospacedDigitFont(), foregroundColor: UIColor.Black);
             result.AddAttribute(UIStringAttributeKey.ForegroundColor, placeHolderColor, new NSRange(0, prefixLength));


### PR DESCRIPTION
## What's this?
This fixes a potential null exception in DurationFieldTextFormatter.AttributedStringFor.

### Relationships

Closes #5018

## How is it done?
By assigning empty string to the variable if it is null.

## :squid: Permissions
🦑 