### PR TITLE
Add modal card presenter for iOS

### DIFF
--- a/Toggl.iOS/Presentation/ModalCardPresenter.cs
+++ b/Toggl.iOS/Presentation/ModalCardPresenter.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using Toggl.Core.UI.ViewModels;
+using Toggl.Core.UI.ViewModels.Settings;
+using Toggl.Core.UI.Views;
+using Toggl.iOS.Presentation.Transition;
+using Toggl.iOS.ViewControllers;
+using Toggl.iOS.ViewControllers.Settings;
+using UIKit;
+
+namespace Toggl.iOS.Presentation
+{
+    public class ModalCardPresenter : IosPresenter
+    {
+        private readonly FromBottomTransitionDelegate fromBottomTransitionDelegate = new FromBottomTransitionDelegate();
+
+        protected override HashSet<Type> AcceptedViewModels { get; } = new HashSet<Type>
+        {
+            typeof(EditDurationViewModel),
+            typeof(EditProjectViewModel),
+            typeof(EditTimeEntryViewModel),
+            typeof(SelectBeginningOfWeekViewModel),
+            typeof(SelectClientViewModel),
+            typeof(SelectCountryViewModel),
+            typeof(SelectDateFormatViewModel),
+            typeof(SelectDurationFormatViewModel),
+            typeof(SelectProjectViewModel),
+            typeof(SelectTagsViewModel),
+            typeof(SelectWorkspaceViewModel),
+            typeof(SendFeedbackViewModel),
+            typeof(StartTimeEntryViewModel),
+            typeof(UpcomingEventsNotificationSettingsViewModel),
+        };
+
+        public ModalCardPresenter(UIWindow window, AppDelegate appDelegate) : base(window, appDelegate)
+        {
+        }
+
+        protected override void PresentOnMainThread<TInput, TOutput>(ViewModel<TInput, TOutput> viewModel, IView sourceView)
+        {
+            UIViewController viewController = null;
+
+            switch (viewModel)
+            {
+                case EditDurationViewModel editDurationViewModel:
+                    var editDurationViewController = new EditDurationViewController();
+                    editDurationViewController.ViewModel = editDurationViewModel;
+                    viewController = editDurationViewController;
+                    break;
+                case EditProjectViewModel editProjectViewModel:
+                    var editProjectViewController = new EditProjectViewController();
+                    editProjectViewController.ViewModel = editProjectViewModel;
+                    viewController = editProjectViewController;
+                    break;
+                case EditTimeEntryViewModel editTimeEntryViewModel:
+                    var editTimeEntryViewController = new EditTimeEntryViewController();
+                    editTimeEntryViewController.ViewModel = editTimeEntryViewModel;
+                    viewController = editTimeEntryViewController;
+                    break;
+                case SelectBeginningOfWeekViewModel selectBeginningOfWeekViewModel:
+                    var selectBeginningOfWeekViewController = new SelectBeginningOfWeekViewController();
+                    selectBeginningOfWeekViewController.ViewModel = selectBeginningOfWeekViewModel;
+                    viewController = selectBeginningOfWeekViewController;
+                    break;
+                case SelectClientViewModel selectClientViewModel:
+                    var selectClientViewController = new SelectClientViewController();
+                    selectClientViewController.ViewModel = selectClientViewModel;
+                    viewController = selectClientViewController;
+                    break;
+                case SelectCountryViewModel selectCountryViewModel:
+                    var selectCountryViewController = new SelectCountryViewController();
+                    selectCountryViewController.ViewModel = selectCountryViewModel;
+                    viewController = selectCountryViewController;
+                    break;
+                case SelectDateFormatViewModel selectDateFormatViewModel:
+                    var selectDateFormatViewController = new SelectDateFormatViewController();
+                    selectDateFormatViewController.ViewModel = selectDateFormatViewModel;
+                    viewController = selectDateFormatViewController;
+                    break;
+                case SelectDurationFormatViewModel selectDurationFormatViewModel:
+                    var selectDurationViewController = new SelectDurationFormatViewController();
+                    selectDurationViewController.ViewModel = selectDurationFormatViewModel;
+                    viewController = selectDurationViewController;
+                    break;
+                case SelectProjectViewModel selectProjectViewModel:
+                    var selectProjectViewController = new SelectProjectViewController();
+                    selectProjectViewController.ViewModel = selectProjectViewModel;
+                    viewController = selectProjectViewController;
+                    break;
+                case SelectTagsViewModel selectTagsViewModel:
+                    var selectTagsViewController = new SelectTagsViewController();
+                    selectTagsViewController.ViewModel = selectTagsViewModel;
+                    viewController = selectTagsViewController;
+                    break;
+                case SelectWorkspaceViewModel selectWorkspaceViewModel:
+                    var selectWorkspaceViewController = new SelectWorkspaceViewController();
+                    selectWorkspaceViewController.ViewModel = selectWorkspaceViewModel;
+                    viewController = selectWorkspaceViewController;
+                    break;
+                case SendFeedbackViewModel sendFeedbackViewModel:
+                    var sendFeedbackViewController = new SendFeedbackViewController();
+                    sendFeedbackViewController.ViewModel = sendFeedbackViewModel;
+                    viewController = sendFeedbackViewController;
+                    break;
+                case StartTimeEntryViewModel startTimeEntryViewModel:
+                    var startTimeEntryViewController = new StartTimeEntryViewController();
+                    startTimeEntryViewController.ViewModel = startTimeEntryViewModel;
+                    viewController = startTimeEntryViewController;
+                    break;
+                case UpcomingEventsNotificationSettingsViewModel upcomingEventsNotificationSettingsViewModel:
+                    var upcomingEventsNotificationSettingsViewController = new UpcomingEventsNotificationSettingsViewController();
+                    upcomingEventsNotificationSettingsViewController.ViewModel = upcomingEventsNotificationSettingsViewModel;
+                    viewController = upcomingEventsNotificationSettingsViewController;
+                    break;
+            }
+
+            if (viewController == null)
+                throw new Exception($"Failed to create ViewController for ViewModel of type {viewModel.GetType().Name}");
+
+            presentViewController(viewController);
+        }
+
+        private void presentViewController(UIViewController viewController)
+        {
+            viewController.ModalPresentationStyle = UIModalPresentationStyle.Custom;
+            viewController.TransitioningDelegate = fromBottomTransitionDelegate;
+
+            UIViewController topmostViewController = FindPresentedViewController();
+            topmostViewController.PresentViewController(viewController, true, null);
+        }
+    }
+}

--- a/Toggl.iOS/Presentation/Transition/FromBottomTransitionDelegate.cs
+++ b/Toggl.iOS/Presentation/Transition/FromBottomTransitionDelegate.cs
@@ -7,15 +7,6 @@ namespace Toggl.iOS.Presentation.Transition
 {
     public sealed class FromBottomTransitionDelegate : NSObject, IUIViewControllerTransitioningDelegate
     {
-        private readonly Action onDismissedCallback;
-
-        public FromBottomTransitionDelegate(Action onDismissedCallback)
-        {
-            Ensure.Argument.IsNotNull(onDismissedCallback, nameof(onDismissedCallback));
-
-            this.onDismissedCallback = onDismissedCallback;
-        }
-
         [Export("animationControllerForPresentedController:presentingController:sourceController:")]
         public IUIViewControllerAnimatedTransitioning GetAnimationControllerForDismissedController(
             UIViewController presented, UIViewController presenting, UIViewController source
@@ -28,6 +19,6 @@ namespace Toggl.iOS.Presentation.Transition
         [Export("presentationControllerForPresentedViewController:presentingViewController:sourceViewController:")]
         public UIPresentationController GetPresentationControllerForPresentedViewController(
             UIViewController presented, UIViewController presenting, UIViewController source
-        ) => new ModalPresentationController(presented, presenting, onDismissedCallback);
+        ) => new ModalPresentationController(presented, presenting);
     }
 }

--- a/Toggl.iOS/Presentation/Transition/ModalPresentationController.cs
+++ b/Toggl.iOS/Presentation/Transition/ModalPresentationController.cs
@@ -14,7 +14,6 @@ namespace Toggl.iOS.Presentation.Transition
 {
     public sealed class ModalPresentationController : UIPresentationController
     {
-        private readonly Action onDismissedCallback;
         private readonly UIImpactFeedbackGenerator feedbackGenerator;
 
         private readonly nfloat backgroundAlpha = 0.8f;
@@ -66,14 +65,9 @@ namespace Toggl.iOS.Presentation.Transition
         public UIView AdditionalContentView { get; }
             = new UIView();
 
-        public ModalPresentationController(UIViewController presentedViewController,
-            UIViewController presentingViewController, Action onDismissedCallback)
-          : base(presentedViewController, presentingViewController)
+        public ModalPresentationController(UIViewController presentedViewController, UIViewController presentingViewController)
+            : base(presentedViewController, presentingViewController)
         {
-            Ensure.Argument.IsNotNull(onDismissedCallback, nameof(onDismissedCallback));
-
-            this.onDismissedCallback = onDismissedCallback;
-
             var recognizer = new UITapGestureRecognizer(() => dismiss());
             AdditionalContentView.AddGestureRecognizer(recognizer);
 
@@ -269,7 +263,7 @@ namespace Toggl.iOS.Presentation.Transition
             }
 
             PresentedViewController.DismissViewController(true, null);
-            onDismissedCallback();
+
             return true;
         }
 

--- a/Toggl.iOS/Startup/AppDelegate.cs
+++ b/Toggl.iOS/Startup/AppDelegate.cs
@@ -43,7 +43,8 @@ namespace Toggl.iOS
             var compositePresenter = new CompositePresenter(
                 new RootPresenter(Window, this),
                 new NavigationPresenter(Window, this),
-                new ModalDialogPresenter(Window, this)
+                new ModalDialogPresenter(Window, this),
+                new ModalCardPresenter(Window, this)
             );
 
             IosDependencyContainer.EnsureInitialized(compositePresenter, environment, Platform.Daneel, version);

--- a/Toggl.iOS/Toggl.iOS.csproj
+++ b/Toggl.iOS/Toggl.iOS.csproj
@@ -1328,6 +1328,7 @@
     <Compile Include="Presentation\IosPresenter.cs" />
     <Compile Include="Presentation\NavigationPresenter.cs" />
     <Compile Include="Presentation\ModalDialogPresenter.cs" />
+    <Compile Include="Presentation\ModalCardPresenter.cs" />
     <Compile Include="Presentation\RootPresenter.cs" />
     <Compile Include="Services\PermissionsCheckerIos.cs" />
     <Compile Include="Services\CalendarServiceIos.cs" />

--- a/Toggl.iOS/ViewControllers/Reactive/ReactiveTableViewController.cs
+++ b/Toggl.iOS/ViewControllers/Reactive/ReactiveTableViewController.cs
@@ -71,7 +71,7 @@ namespace Toggl.iOS.ViewControllers
         {
             if (!isDismissing)
             {
-                this.Dismiss();
+                UIApplication.SharedApplication.InvokeOnMainThread(this.Dismiss);
             }
             return Task.CompletedTask;
         }

--- a/Toggl.iOS/ViewControllers/Reactive/ReactiveViewController.cs
+++ b/Toggl.iOS/ViewControllers/Reactive/ReactiveViewController.cs
@@ -71,7 +71,7 @@ namespace Toggl.iOS.ViewControllers
         {
             if (!isDismissing)
             {
-                this.Dismiss();
+                UIApplication.SharedApplication.InvokeOnMainThread(this.Dismiss);
             }
             return Task.CompletedTask;
         }


### PR DESCRIPTION
## What's this?
This is the last presenter we need for iOS! The entire app can be navigated again.

### Relationships

Closes #4859 

## Why do we want this?
🇬🇧 ➡️ 🚪 

## How is it done?
It's another presenter, very similar to the modal dialogs.

### Why not another way?
This is the only way.

### Side effects
I found at least one ViewModel calling Finish on a different thread (missing ObserveOn maybe?), that caused a crash in ReactiveViewController.Dismiss` so that's why I did the thread marshalling.

## :squid: Permissions
🦑 