### PR TITLE
Fix scrolling issues on iPad

### DIFF
--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogHeaderView.cs
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogHeaderView.cs
@@ -10,6 +10,7 @@ namespace Toggl.iOS.Views
 {
     public partial class TimeEntriesLogHeaderView : BaseTableHeaderFooterView<DaySummaryViewModel>
     {
+        private const double maxWidth = 834;
         public static readonly string Identifier = "timeEntryLogHeaderCell";
 
         public static readonly NSString Key = new NSString(nameof(TimeEntriesLogHeaderView));
@@ -37,6 +38,13 @@ namespace Toggl.iOS.Views
         {
             DateLabel.Text = Item.Title;
             DurationLabel.Text = Item.TotalTrackedTime;
+        }
+
+        public override void LayoutSubviews()
+        {
+            if (Superview != null)
+                ContentWidthConstraint.Constant = (nfloat)Math.Min(Superview.Bounds.Width, maxWidth);
+            base.LayoutSubviews();
         }
     }
 }

--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogHeaderView.designer.cs
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogHeaderView.designer.cs
@@ -9,9 +9,12 @@ using System.CodeDom.Compiler;
 
 namespace Toggl.iOS.Views
 {
-    [Register ("TimeEntriesLogHeaderView")]
+	[Register ("TimeEntriesLogHeaderView")]
 	partial class TimeEntriesLogHeaderView
 	{
+		[Outlet]
+		UIKit.NSLayoutConstraint ContentWidthConstraint { get; set; }
+
 		[Outlet]
 		[GeneratedCode ("iOS Designer", "1.0")]
 		UIKit.UILabel DateLabel { get; set; }
@@ -22,7 +25,7 @@ namespace Toggl.iOS.Views
 
 		[Outlet]
 		UIKit.UIView TopSeparator { get; set; }
-
+		
 		void ReleaseDesignerOutlets ()
 		{
 			if (DateLabel != null) {
@@ -38,6 +41,11 @@ namespace Toggl.iOS.Views
 			if (TopSeparator != null) {
 				TopSeparator.Dispose ();
 				TopSeparator = null;
+			}
+
+			if (ContentWidthConstraint != null) {
+				ContentWidthConstraint.Dispose ();
+				ContentWidthConstraint = null;
 			}
 		}
 	}

--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogHeaderView.xib
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogHeaderView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,28 +18,55 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="47.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Today" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tyu-W1-TKI">
-                        <rect key="frame" x="16" y="22" width="42.5" height="18"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0:00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="owW-pl-RR0">
-                        <rect key="frame" x="250" y="23" width="54" height="17"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pLy-6V-eP2" userLabel="Container View">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="47.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Today" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tyu-W1-TKI">
+                                <rect key="frame" x="16" y="21.5" width="42.5" height="18"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0:00:00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="owW-pl-RR0">
+                                <rect key="frame" x="250" y="22.5" width="54" height="17"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="320" id="KMo-gh-Sav"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="KMo-gh-Sav"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <include reference="KMo-gh-Sav"/>
+                            </mask>
+                        </variation>
+                    </view>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="pLy-6V-eP2" firstAttribute="leading" secondItem="bXr-n9-RqK" secondAttribute="leading" priority="750" id="HOk-Bd-gV2"/>
+                    <constraint firstItem="pLy-6V-eP2" firstAttribute="top" secondItem="bXr-n9-RqK" secondAttribute="top" id="I5Y-2j-Znb"/>
+                    <constraint firstItem="pLy-6V-eP2" firstAttribute="centerX" secondItem="bXr-n9-RqK" secondAttribute="centerX" id="d0T-Vs-lqe"/>
+                    <constraint firstAttribute="bottom" secondItem="pLy-6V-eP2" secondAttribute="bottom" id="e8m-cN-Yqy"/>
+                    <constraint firstAttribute="trailing" secondItem="pLy-6V-eP2" secondAttribute="trailing" priority="750" id="qH4-H7-d3a"/>
+                </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="owW-pl-RR0" secondAttribute="bottom" constant="8" id="aC1-uP-wqt"/>
-                <constraint firstItem="tyu-W1-TKI" firstAttribute="leading" secondItem="cZE-iV-UFb" secondAttribute="leading" constant="16" id="ffF-mt-pUB"/>
-                <constraint firstAttribute="trailing" secondItem="owW-pl-RR0" secondAttribute="trailing" constant="16" id="mBf-HK-IaP"/>
-                <constraint firstAttribute="bottom" secondItem="tyu-W1-TKI" secondAttribute="bottom" constant="8" id="xO5-Cw-oTq"/>
+                <constraint firstItem="pLy-6V-eP2" firstAttribute="bottom" secondItem="owW-pl-RR0" secondAttribute="bottom" constant="8" id="aC1-uP-wqt"/>
+                <constraint firstItem="tyu-W1-TKI" firstAttribute="leading" secondItem="pLy-6V-eP2" secondAttribute="leading" constant="16" id="ffF-mt-pUB"/>
+                <constraint firstItem="pLy-6V-eP2" firstAttribute="trailing" secondItem="owW-pl-RR0" secondAttribute="trailing" constant="16" id="mBf-HK-IaP"/>
+                <constraint firstItem="pLy-6V-eP2" firstAttribute="bottom" secondItem="tyu-W1-TKI" secondAttribute="bottom" constant="8" id="xO5-Cw-oTq"/>
             </constraints>
             <connections>
+                <outlet property="ContentWidthConstraint" destination="KMo-gh-Sav" id="wTm-7W-s8l"/>
                 <outlet property="DateLabel" destination="tyu-W1-TKI" id="name-outlet-tyu-W1-TKI"/>
                 <outlet property="DurationLabel" destination="owW-pl-RR0" id="name-outlet-owW-pl-RR0"/>
             </connections>

--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.cs
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.cs
@@ -16,6 +16,8 @@ namespace Toggl.iOS.Views
 {
     public partial class TimeEntriesLogViewCell : BaseTableViewCell<LogItemViewModel>
     {
+        private const double maxWidth = 834;
+
         public static readonly string Identifier = "timeEntryCell";
 
         private ProjectTaskClientToAttributedString projectTaskClientToAttributedString;
@@ -130,6 +132,13 @@ namespace Toggl.iOS.Views
         {
             DisposeBag.Dispose();
             base.Dispose(disposing);
+        }
+
+        public override void LayoutSubviews()
+        {
+            if (Superview != null)
+                ContentWidthConstraint.Constant = (nfloat) System.Math.Min(Superview.Bounds.Width, maxWidth);
+            base.LayoutSubviews();
         }
 
         private void presentAsCollapsedGroupHeader(int groupSize)

--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.designer.cs
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.designer.cs
@@ -19,6 +19,9 @@ namespace Toggl.iOS.Views
 		UIKit.UIView BillableIcon { get; set; }
 
 		[Outlet]
+		UIKit.NSLayoutConstraint ContentWidthConstraint { get; set; }
+
+		[Outlet]
 		[GeneratedCode ("iOS Designer", "1.0")]
 		UIKit.UIButton ContinueButton { get; set; }
 
@@ -27,7 +30,7 @@ namespace Toggl.iOS.Views
 		UIKit.UIImageView ContinueImageView { get; set; }
 
 		[Outlet]
-		FadeView DescriptionFadeView { get; set; }
+		Toggl.iOS.Views.FadeView DescriptionFadeView { get; set; }
 
 		[Outlet]
 		[GeneratedCode ("iOS Designer", "1.0")]
@@ -43,7 +46,7 @@ namespace Toggl.iOS.Views
 		UIKit.UILabel GroupSizeLabel { get; set; }
 
 		[Outlet]
-		FadeView ProjectTaskClientFadeView { get; set; }
+		Toggl.iOS.Views.FadeView ProjectTaskClientFadeView { get; set; }
 
 		[Outlet]
 		[GeneratedCode ("iOS Designer", "1.0")]
@@ -66,7 +69,7 @@ namespace Toggl.iOS.Views
 		[Outlet]
 		[GeneratedCode ("iOS Designer", "1.0")]
 		UIKit.UIImageView UnsyncedImageView { get; set; }
-
+		
 		void ReleaseDesignerOutlets ()
 		{
 			if (AddDescriptionLabel != null) {
@@ -89,19 +92,14 @@ namespace Toggl.iOS.Views
 				ContinueImageView = null;
 			}
 
-			if (DescriptionLabel != null) {
-				DescriptionLabel.Dispose ();
-				DescriptionLabel = null;
-			}
-
 			if (DescriptionFadeView != null) {
 				DescriptionFadeView.Dispose ();
 				DescriptionFadeView = null;
 			}
 
-			if (ProjectTaskClientFadeView != null) {
-				ProjectTaskClientFadeView.Dispose ();
-				ProjectTaskClientFadeView = null;
+			if (DescriptionLabel != null) {
+				DescriptionLabel.Dispose ();
+				DescriptionLabel = null;
 			}
 
 			if (GroupSizeBackground != null) {
@@ -117,6 +115,11 @@ namespace Toggl.iOS.Views
 			if (GroupSizeLabel != null) {
 				GroupSizeLabel.Dispose ();
 				GroupSizeLabel = null;
+			}
+
+			if (ProjectTaskClientFadeView != null) {
+				ProjectTaskClientFadeView.Dispose ();
+				ProjectTaskClientFadeView = null;
 			}
 
 			if (ProjectTaskClientLabel != null) {
@@ -147,6 +150,11 @@ namespace Toggl.iOS.Views
 			if (UnsyncedImageView != null) {
 				UnsyncedImageView.Dispose ();
 				UnsyncedImageView = null;
+			}
+
+			if (ContentWidthConstraint != null) {
+				ContentWidthConstraint.Dispose ();
+				ContentWidthConstraint = null;
 			}
 		}
 	}

--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.xib
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.xib
@@ -4,6 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,300 +18,324 @@
                 <rect key="frame" x="0.0" y="0.0" width="874" height="63.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="BLU-UX-hjg">
-                        <rect key="frame" x="0.0" y="0.0" width="874" height="64"/>
+                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ldo-6H-LmF" userLabel="Container View">
+                        <rect key="frame" x="20" y="0.0" width="834" height="18"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rq6-Da-FtS">
-                                <rect key="frame" x="0.0" y="0.0" width="60" height="64"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="BLU-UX-hjg">
+                                <rect key="frame" x="0.0" y="0.0" width="834" height="64"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0oF-2g-KKS" userLabel="Number Of Grouped Entries">
-                                        <rect key="frame" x="16" y="18" width="28" height="28"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rq6-Da-FtS">
+                                        <rect key="frame" x="0.0" y="0.0" width="60" height="64"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nbd-Eg-lw9">
-                                                <rect key="frame" x="9.5" y="5" width="9" height="18"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <color key="textColor" red="0.36862745098039218" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0oF-2g-KKS" userLabel="Number Of Grouped Entries">
+                                                <rect key="frame" x="16" y="18" width="28" height="28"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nbd-Eg-lw9">
+                                                        <rect key="frame" x="9.5" y="5" width="9" height="18"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <color key="textColor" red="0.36862745098039218" green="0.35686274509803922" blue="0.35686274509803922" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="28" id="ILV-FD-ca4"/>
+                                                    <constraint firstAttribute="height" constant="28" id="Ill-p0-V1f"/>
+                                                    <constraint firstItem="Nbd-Eg-lw9" firstAttribute="centerX" secondItem="0oF-2g-KKS" secondAttribute="centerX" id="XJH-fN-2r5"/>
+                                                    <constraint firstItem="Nbd-Eg-lw9" firstAttribute="centerY" secondItem="0oF-2g-KKS" secondAttribute="centerY" id="dFG-IE-N7I"/>
+                                                </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="14"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                                        <integer key="value" value="1"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
+                                                        <color key="value" red="0.90980392156862744" green="0.90980392156862744" blue="0.90980392156862744" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </view>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="0oF-2g-KKS" firstAttribute="leading" secondItem="Rq6-Da-FtS" secondAttribute="leading" constant="16" id="n4C-5R-RDA"/>
+                                            <constraint firstAttribute="trailing" secondItem="0oF-2g-KKS" secondAttribute="trailing" constant="16" id="qgL-rq-C6O"/>
+                                            <constraint firstItem="0oF-2g-KKS" firstAttribute="centerY" secondItem="Rq6-Da-FtS" secondAttribute="centerY" id="uHu-2R-wNE"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bCj-8c-iBp">
+                                        <rect key="frame" x="76" y="0.0" width="758" height="64"/>
+                                        <subviews>
+                                            <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" axis="vertical" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="LDs-eG-gAX">
+                                                <rect key="frame" x="0.0" y="12" width="583" height="40"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ohm-7o-dpZ" userLabel="Description Fade View" customClass="FadeView">
+                                                        <rect key="frame" x="0.0" y="0.0" width="308" height="40"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exporting assets" textAlignment="natural" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fIi-Jg-bLZ">
+                                                                <rect key="frame" x="0.0" y="0.0" width="308" height="40"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstItem="fIi-Jg-bLZ" firstAttribute="top" secondItem="ohm-7o-dpZ" secondAttribute="top" id="9SO-U8-XPX"/>
+                                                            <constraint firstAttribute="trailing" secondItem="fIi-Jg-bLZ" secondAttribute="trailing" id="KSf-g5-cl0"/>
+                                                            <constraint firstItem="fIi-Jg-bLZ" firstAttribute="leading" secondItem="ohm-7o-dpZ" secondAttribute="leading" id="eC8-j7-IAa"/>
+                                                            <constraint firstAttribute="bottom" secondItem="fIi-Jg-bLZ" secondAttribute="bottom" id="f4X-jY-XRh"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PNy-Vs-gWI" userLabel="Project Task Client Fade View" customClass="FadeView">
+                                                        <rect key="frame" x="316" y="0.0" width="267" height="40"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Design" textAlignment="natural" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqJ-Ao-2Sj">
+                                                                <rect key="frame" x="0.0" y="0.0" width="267" height="40"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <color key="textColor" red="0.29411764705882354" green="0.78431372549019607" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstItem="pqJ-Ao-2Sj" firstAttribute="top" secondItem="PNy-Vs-gWI" secondAttribute="top" id="311-QQ-ASn"/>
+                                                            <constraint firstAttribute="trailing" secondItem="pqJ-Ao-2Sj" secondAttribute="trailing" id="c6u-C9-Vdf"/>
+                                                            <constraint firstAttribute="bottom" secondItem="pqJ-Ao-2Sj" secondAttribute="bottom" id="e9Z-MP-Ftm"/>
+                                                            <constraint firstItem="pqJ-Ao-2Sj" firstAttribute="leading" secondItem="PNy-Vs-gWI" secondAttribute="leading" id="gAI-Ay-NZv"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <variation key="heightClass=regular-widthClass=regular" axis="horizontal" distribution="fill" spacing="8"/>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="qge-32-nsG">
+                                                <rect key="frame" x="583" y="20" width="48" height="24"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Arb-iG-IM3" userLabel="Billable Container">
+                                                        <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                                        <subviews>
+                                                            <imageView autoresizesSubviews="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icBillable" translatesAutoresizingMaskIntoConstraints="NO" id="oU9-Ch-71f">
+                                                                <rect key="frame" x="9" y="6" width="6" height="12"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="6" id="U5g-9V-02s"/>
+                                                                    <constraint firstAttribute="height" constant="12" id="pbr-CT-eya"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstItem="oU9-Ch-71f" firstAttribute="centerX" secondItem="Arb-iG-IM3" secondAttribute="centerX" id="45c-l8-Lhf"/>
+                                                            <constraint firstItem="oU9-Ch-71f" firstAttribute="centerY" secondItem="Arb-iG-IM3" secondAttribute="centerY" id="C0S-ma-KSW"/>
+                                                            <constraint firstAttribute="width" constant="24" id="nBM-PK-efA"/>
+                                                            <constraint firstAttribute="height" constant="24" id="rWv-Yu-Csv"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a5M-eL-8fp" userLabel="Tag Container">
+                                                        <rect key="frame" x="24" y="0.0" width="24" height="24"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icTags" translatesAutoresizingMaskIntoConstraints="NO" id="9OE-uM-4PM">
+                                                                <rect key="frame" x="6.5" y="6.5" width="11" height="11"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="11" id="qdI-81-aYU"/>
+                                                                    <constraint firstAttribute="width" constant="11" id="z8w-CF-HEo"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="24" id="Ebb-gj-etU"/>
+                                                            <constraint firstItem="9OE-uM-4PM" firstAttribute="centerY" secondItem="a5M-eL-8fp" secondAttribute="centerY" id="TGk-eR-vhi"/>
+                                                            <constraint firstItem="9OE-uM-4PM" firstAttribute="centerX" secondItem="a5M-eL-8fp" secondAttribute="centerX" id="Yae-S7-7hy"/>
+                                                            <constraint firstAttribute="height" constant="24" id="ley-c5-jz0"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="24" id="EL0-K9-4rY"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="48" id="fhS-xb-djI"/>
+                                                </constraints>
+                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="500" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="999:23:10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y3e-98-yuY">
+                                                <rect key="frame" x="635" y="24.5" width="59" height="14.5"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="59" id="VA8-Jq-Vd3"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Re8-uD-vpm">
+                                                <rect key="frame" x="694" y="0.0" width="64" height="64"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="Re8-uD-vpm" secondAttribute="height" multiplier="1:1" id="J0t-Yx-gJE"/>
+                                                </constraints>
+                                            </button>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icContinue" translatesAutoresizingMaskIntoConstraints="NO" id="2Q5-T6-UvK">
+                                                <rect key="frame" x="721" y="26.5" width="10" height="11"/>
+                                                <accessibility key="accessibilityConfiguration" label="TimeEntryRowContinueButton">
+                                                    <bool key="isElement" value="YES"/>
+                                                </accessibility>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="11" id="1wx-Ua-IPz"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="e1m-FH-gEi"/>
+                                                    <constraint firstAttribute="height" constant="11" id="uBL-9K-Hda"/>
+                                                </constraints>
+                                            </imageView>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icSyncerror" translatesAutoresizingMaskIntoConstraints="NO" id="ZL2-U3-2N0">
+                                                <rect key="frame" x="718" y="24" width="16" height="16"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="16" id="2ce-tF-NXu"/>
+                                                    <constraint firstAttribute="width" constant="16" id="zUx-mP-hYa"/>
+                                                </constraints>
+                                            </imageView>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icUnsynced" translatesAutoresizingMaskIntoConstraints="NO" id="xHF-rx-bdW">
+                                                <rect key="frame" x="698" y="25" width="16" height="14"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="14" id="58F-aD-4b2"/>
+                                                    <constraint firstAttribute="width" constant="16" id="LUq-Mp-DSd"/>
+                                                </constraints>
+                                            </imageView>
                                         </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="28" id="ILV-FD-ca4"/>
-                                            <constraint firstAttribute="height" constant="28" id="Ill-p0-V1f"/>
-                                            <constraint firstItem="Nbd-Eg-lw9" firstAttribute="centerX" secondItem="0oF-2g-KKS" secondAttribute="centerX" id="XJH-fN-2r5"/>
-                                            <constraint firstItem="Nbd-Eg-lw9" firstAttribute="centerY" secondItem="0oF-2g-KKS" secondAttribute="centerY" id="dFG-IE-N7I"/>
+                                            <constraint firstItem="ZL2-U3-2N0" firstAttribute="centerX" secondItem="2Q5-T6-UvK" secondAttribute="centerX" id="2CF-p2-PCc"/>
+                                            <constraint firstItem="xHF-rx-bdW" firstAttribute="leading" secondItem="Y3e-98-yuY" secondAttribute="trailing" constant="4" id="3z6-yk-Ihr"/>
+                                            <constraint firstItem="qge-32-nsG" firstAttribute="centerY" secondItem="bCj-8c-iBp" secondAttribute="centerY" id="9vg-L3-tu0"/>
+                                            <constraint firstItem="LDs-eG-gAX" firstAttribute="leading" secondItem="bCj-8c-iBp" secondAttribute="leading" id="Cpd-67-tx6"/>
+                                            <constraint firstItem="Y3e-98-yuY" firstAttribute="centerY" secondItem="bCj-8c-iBp" secondAttribute="centerY" id="DnJ-6h-4c9"/>
+                                            <constraint firstItem="2Q5-T6-UvK" firstAttribute="leading" secondItem="xHF-rx-bdW" secondAttribute="trailing" constant="20" id="KhC-i3-HLd"/>
+                                            <constraint firstAttribute="trailing" secondItem="Y3e-98-yuY" secondAttribute="trailing" constant="16" id="Mki-Am-QR3"/>
+                                            <constraint firstItem="qge-32-nsG" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" constant="8" id="PTJ-Dw-6sH"/>
+                                            <constraint firstItem="Re8-uD-vpm" firstAttribute="leading" secondItem="bCj-8c-iBp" secondAttribute="trailing" constant="-64" id="RN8-nA-iee"/>
+                                            <constraint firstItem="LDs-eG-gAX" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" constant="12" id="Re1-K0-JHh"/>
+                                            <constraint firstItem="Y3e-98-yuY" firstAttribute="leading" secondItem="qge-32-nsG" secondAttribute="trailing" constant="4" id="Uph-ae-fQd"/>
+                                            <constraint firstItem="Re8-uD-vpm" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" id="ViN-uS-E6x"/>
+                                            <constraint firstItem="qge-32-nsG" firstAttribute="leading" secondItem="LDs-eG-gAX" secondAttribute="trailing" priority="999" constant="32" id="WCx-jH-NWK"/>
+                                            <constraint firstItem="Y3e-98-yuY" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" constant="12" id="ZQZ-L0-poc"/>
+                                            <constraint firstAttribute="trailing" secondItem="Re8-uD-vpm" secondAttribute="trailing" id="fOJ-Gd-DRW"/>
+                                            <constraint firstItem="Y3e-98-yuY" firstAttribute="leading" secondItem="LDs-eG-gAX" secondAttribute="trailing" constant="52" id="jRO-CF-xrJ"/>
+                                            <constraint firstAttribute="bottom" secondItem="Re8-uD-vpm" secondAttribute="bottom" id="jS2-sV-yVu"/>
+                                            <constraint firstItem="Y3e-98-yuY" firstAttribute="trailing" secondItem="Re8-uD-vpm" secondAttribute="leading" id="lnb-3R-uk0"/>
+                                            <constraint firstItem="xHF-rx-bdW" firstAttribute="centerY" secondItem="2Q5-T6-UvK" secondAttribute="centerY" id="mgl-u3-Awn"/>
+                                            <constraint firstItem="2Q5-T6-UvK" firstAttribute="top" secondItem="qge-32-nsG" secondAttribute="bottom" constant="6" id="pa2-VH-Tpt"/>
+                                            <constraint firstItem="ZL2-U3-2N0" firstAttribute="centerY" secondItem="2Q5-T6-UvK" secondAttribute="centerY" id="qNz-Px-rs4"/>
+                                            <constraint firstAttribute="bottom" secondItem="LDs-eG-gAX" secondAttribute="bottom" constant="12" id="ybp-8R-hlr"/>
+                                            <constraint firstItem="2Q5-T6-UvK" firstAttribute="centerY" secondItem="Re8-uD-vpm" secondAttribute="centerY" id="zl3-BH-csf"/>
                                         </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                <integer key="value" value="14"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
-                                                <integer key="value" value="1"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
-                                                <color key="value" red="0.90980392156862744" green="0.90980392156862744" blue="0.90980392156862744" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
+                                        <variation key="default">
+                                            <mask key="constraints">
+                                                <exclude reference="9vg-L3-tu0"/>
+                                                <exclude reference="DnJ-6h-4c9"/>
+                                                <exclude reference="lnb-3R-uk0"/>
+                                                <exclude reference="3z6-yk-Ihr"/>
+                                                <exclude reference="zl3-BH-csf"/>
+                                            </mask>
+                                        </variation>
+                                        <variation key="heightClass=regular-widthClass=regular">
+                                            <mask key="constraints">
+                                                <include reference="9vg-L3-tu0"/>
+                                                <exclude reference="PTJ-Dw-6sH"/>
+                                                <exclude reference="WCx-jH-NWK"/>
+                                                <include reference="DnJ-6h-4c9"/>
+                                                <exclude reference="Mki-Am-QR3"/>
+                                                <exclude reference="ZQZ-L0-poc"/>
+                                                <include reference="lnb-3R-uk0"/>
+                                                <include reference="3z6-yk-Ihr"/>
+                                                <exclude reference="KhC-i3-HLd"/>
+                                                <exclude reference="pa2-VH-Tpt"/>
+                                                <include reference="zl3-BH-csf"/>
+                                            </mask>
+                                        </variation>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="0oF-2g-KKS" firstAttribute="leading" secondItem="Rq6-Da-FtS" secondAttribute="leading" constant="16" id="n4C-5R-RDA"/>
-                                    <constraint firstAttribute="trailing" secondItem="0oF-2g-KKS" secondAttribute="trailing" constant="16" id="qgL-rq-C6O"/>
-                                    <constraint firstItem="0oF-2g-KKS" firstAttribute="centerY" secondItem="Rq6-Da-FtS" secondAttribute="centerY" id="uHu-2R-wNE"/>
+                                    <constraint firstItem="Rq6-Da-FtS" firstAttribute="top" secondItem="BLU-UX-hjg" secondAttribute="top" id="0OM-Py-H9o"/>
+                                    <constraint firstAttribute="trailing" secondItem="bCj-8c-iBp" secondAttribute="trailing" id="gPT-3F-OHK"/>
+                                    <constraint firstAttribute="bottom" secondItem="bCj-8c-iBp" secondAttribute="bottom" id="iQ7-bz-Yzt"/>
+                                    <constraint firstAttribute="bottom" secondItem="Rq6-Da-FtS" secondAttribute="bottom" id="l7Z-09-Xz1"/>
+                                    <constraint firstItem="bCj-8c-iBp" firstAttribute="top" secondItem="BLU-UX-hjg" secondAttribute="top" id="pPU-Au-7na"/>
+                                    <constraint firstAttribute="height" constant="64" id="z4C-w8-MQK"/>
                                 </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bCj-8c-iBp">
-                                <rect key="frame" x="76" y="0.0" width="798" height="64"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bpL-7n-pbt" userLabel="Fake delete swipe action">
+                                <rect key="frame" x="834" y="0.0" width="200" height="18"/>
                                 <subviews>
-                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" axis="vertical" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="LDs-eG-gAX">
-                                        <rect key="frame" x="0.0" y="12" width="623" height="40"/>
-                                        <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ohm-7o-dpZ" userLabel="Description Fade View" customClass="FadeView">
-                                                <rect key="frame" x="0.0" y="0.0" width="335.5" height="40"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Exporting assets" textAlignment="natural" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fIi-Jg-bLZ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="335.5" height="40"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstItem="fIi-Jg-bLZ" firstAttribute="top" secondItem="ohm-7o-dpZ" secondAttribute="top" id="9SO-U8-XPX"/>
-                                                    <constraint firstAttribute="trailing" secondItem="fIi-Jg-bLZ" secondAttribute="trailing" id="KSf-g5-cl0"/>
-                                                    <constraint firstItem="fIi-Jg-bLZ" firstAttribute="leading" secondItem="ohm-7o-dpZ" secondAttribute="leading" id="eC8-j7-IAa"/>
-                                                    <constraint firstAttribute="bottom" secondItem="fIi-Jg-bLZ" secondAttribute="bottom" id="f4X-jY-XRh"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PNy-Vs-gWI" userLabel="Project Task Client Fade View" customClass="FadeView">
-                                                <rect key="frame" x="343.5" y="0.0" width="279.5" height="40"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Design" textAlignment="natural" lineBreakMode="clip" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqJ-Ao-2Sj">
-                                                        <rect key="frame" x="0.0" y="0.0" width="279.5" height="40"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                        <color key="textColor" red="0.29411764705882354" green="0.78431372549019607" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstItem="pqJ-Ao-2Sj" firstAttribute="top" secondItem="PNy-Vs-gWI" secondAttribute="top" id="311-QQ-ASn"/>
-                                                    <constraint firstAttribute="trailing" secondItem="pqJ-Ao-2Sj" secondAttribute="trailing" id="c6u-C9-Vdf"/>
-                                                    <constraint firstAttribute="bottom" secondItem="pqJ-Ao-2Sj" secondAttribute="bottom" id="e9Z-MP-Ftm"/>
-                                                    <constraint firstItem="pqJ-Ao-2Sj" firstAttribute="leading" secondItem="PNy-Vs-gWI" secondAttribute="leading" id="gAI-Ay-NZv"/>
-                                                </constraints>
-                                            </view>
-                                        </subviews>
-                                        <color key="backgroundColor" red="0.1215686275" green="0.12941176469999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <variation key="heightClass=regular-widthClass=regular" axis="horizontal" distribution="fill" spacing="8"/>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleAspectFit" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="qge-32-nsG">
-                                        <rect key="frame" x="623" y="20" width="48" height="24"/>
-                                        <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Arb-iG-IM3" userLabel="Billable Container">
-                                                <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                                                <subviews>
-                                                    <imageView autoresizesSubviews="NO" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icBillable" translatesAutoresizingMaskIntoConstraints="NO" id="oU9-Ch-71f">
-                                                        <rect key="frame" x="9" y="6" width="6" height="12"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="6" id="U5g-9V-02s"/>
-                                                            <constraint firstAttribute="height" constant="12" id="pbr-CT-eya"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstItem="oU9-Ch-71f" firstAttribute="centerX" secondItem="Arb-iG-IM3" secondAttribute="centerX" id="45c-l8-Lhf"/>
-                                                    <constraint firstItem="oU9-Ch-71f" firstAttribute="centerY" secondItem="Arb-iG-IM3" secondAttribute="centerY" id="C0S-ma-KSW"/>
-                                                    <constraint firstAttribute="width" constant="24" id="nBM-PK-efA"/>
-                                                    <constraint firstAttribute="height" constant="24" id="rWv-Yu-Csv"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a5M-eL-8fp" userLabel="Tag Container">
-                                                <rect key="frame" x="24" y="0.0" width="24" height="24"/>
-                                                <subviews>
-                                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icTags" translatesAutoresizingMaskIntoConstraints="NO" id="9OE-uM-4PM">
-                                                        <rect key="frame" x="6.5" y="6.5" width="11" height="11"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="11" id="qdI-81-aYU"/>
-                                                            <constraint firstAttribute="width" constant="11" id="z8w-CF-HEo"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="24" id="Ebb-gj-etU"/>
-                                                    <constraint firstItem="9OE-uM-4PM" firstAttribute="centerY" secondItem="a5M-eL-8fp" secondAttribute="centerY" id="TGk-eR-vhi"/>
-                                                    <constraint firstItem="9OE-uM-4PM" firstAttribute="centerX" secondItem="a5M-eL-8fp" secondAttribute="centerX" id="Yae-S7-7hy"/>
-                                                    <constraint firstAttribute="height" constant="24" id="ley-c5-jz0"/>
-                                                </constraints>
-                                            </view>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="EL0-K9-4rY"/>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="48" id="fhS-xb-djI"/>
-                                        </constraints>
-                                    </stackView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="500" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="999:23:10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y3e-98-yuY">
-                                        <rect key="frame" x="675" y="24.5" width="59" height="14.5"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="59" id="VA8-Jq-Vd3"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <nil key="textColor"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Delete" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j3P-PZ-hOZ">
+                                        <rect key="frame" x="11" y="0.0" width="46.5" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Re8-uD-vpm">
-                                        <rect key="frame" x="734" y="0.0" width="64" height="64"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="Re8-uD-vpm" secondAttribute="height" multiplier="1:1" id="J0t-Yx-gJE"/>
-                                        </constraints>
-                                    </button>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icContinue" translatesAutoresizingMaskIntoConstraints="NO" id="2Q5-T6-UvK">
-                                        <rect key="frame" x="755" y="26.5" width="16" height="11"/>
-                                        <accessibility key="accessibilityConfiguration" label="TimeEntryRowContinueButton">
-                                            <bool key="isElement" value="YES"/>
-                                        </accessibility>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="11" id="1wx-Ua-IPz"/>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="e1m-FH-gEi"/>
-                                            <constraint firstAttribute="height" constant="11" id="uBL-9K-Hda"/>
-                                        </constraints>
-                                    </imageView>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icSyncerror" translatesAutoresizingMaskIntoConstraints="NO" id="ZL2-U3-2N0">
-                                        <rect key="frame" x="755" y="24" width="16" height="16"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="16" id="2ce-tF-NXu"/>
-                                            <constraint firstAttribute="width" constant="16" id="zUx-mP-hYa"/>
-                                        </constraints>
-                                    </imageView>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icUnsynced" translatesAutoresizingMaskIntoConstraints="NO" id="xHF-rx-bdW">
-                                        <rect key="frame" x="738" y="25" width="16" height="14"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="14" id="58F-aD-4b2"/>
-                                            <constraint firstAttribute="width" constant="16" id="LUq-Mp-DSd"/>
-                                        </constraints>
-                                    </imageView>
                                 </subviews>
+                                <color key="backgroundColor" red="0.96862745098039216" green="0.25098039215686274" blue="0.28627450980392155" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstItem="ZL2-U3-2N0" firstAttribute="centerX" secondItem="2Q5-T6-UvK" secondAttribute="centerX" id="2CF-p2-PCc"/>
-                                    <constraint firstItem="xHF-rx-bdW" firstAttribute="leading" secondItem="Y3e-98-yuY" secondAttribute="trailing" constant="4" id="3z6-yk-Ihr"/>
-                                    <constraint firstItem="qge-32-nsG" firstAttribute="centerY" secondItem="bCj-8c-iBp" secondAttribute="centerY" id="9vg-L3-tu0"/>
-                                    <constraint firstItem="LDs-eG-gAX" firstAttribute="leading" secondItem="bCj-8c-iBp" secondAttribute="leading" id="Cpd-67-tx6"/>
-                                    <constraint firstItem="Y3e-98-yuY" firstAttribute="centerY" secondItem="bCj-8c-iBp" secondAttribute="centerY" id="DnJ-6h-4c9"/>
-                                    <constraint firstItem="2Q5-T6-UvK" firstAttribute="leading" secondItem="xHF-rx-bdW" secondAttribute="trailing" constant="20" id="KhC-i3-HLd"/>
-                                    <constraint firstAttribute="trailing" secondItem="Y3e-98-yuY" secondAttribute="trailing" constant="16" id="Mki-Am-QR3"/>
-                                    <constraint firstItem="qge-32-nsG" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" constant="8" id="PTJ-Dw-6sH"/>
-                                    <constraint firstItem="Re8-uD-vpm" firstAttribute="leading" secondItem="bCj-8c-iBp" secondAttribute="trailing" constant="-64" id="RN8-nA-iee"/>
-                                    <constraint firstItem="LDs-eG-gAX" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" constant="12" id="Re1-K0-JHh"/>
-                                    <constraint firstItem="Y3e-98-yuY" firstAttribute="leading" secondItem="qge-32-nsG" secondAttribute="trailing" constant="4" id="Uph-ae-fQd"/>
-                                    <constraint firstItem="Re8-uD-vpm" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" id="ViN-uS-E6x"/>
-                                    <constraint firstItem="qge-32-nsG" firstAttribute="leading" secondItem="LDs-eG-gAX" secondAttribute="trailing" priority="999" constant="32" id="WCx-jH-NWK"/>
-                                    <constraint firstItem="Y3e-98-yuY" firstAttribute="top" secondItem="bCj-8c-iBp" secondAttribute="top" constant="12" id="ZQZ-L0-poc"/>
-                                    <constraint firstAttribute="trailing" secondItem="Re8-uD-vpm" secondAttribute="trailing" id="fOJ-Gd-DRW"/>
-                                    <constraint firstItem="Y3e-98-yuY" firstAttribute="leading" secondItem="LDs-eG-gAX" secondAttribute="trailing" constant="52" id="jRO-CF-xrJ"/>
-                                    <constraint firstAttribute="bottom" secondItem="Re8-uD-vpm" secondAttribute="bottom" id="jS2-sV-yVu"/>
-                                    <constraint firstItem="Y3e-98-yuY" firstAttribute="trailing" secondItem="Re8-uD-vpm" secondAttribute="leading" id="lnb-3R-uk0"/>
-                                    <constraint firstItem="xHF-rx-bdW" firstAttribute="centerY" secondItem="2Q5-T6-UvK" secondAttribute="centerY" id="mgl-u3-Awn"/>
-                                    <constraint firstItem="2Q5-T6-UvK" firstAttribute="top" secondItem="qge-32-nsG" secondAttribute="bottom" constant="6" id="pa2-VH-Tpt"/>
-                                    <constraint firstItem="ZL2-U3-2N0" firstAttribute="centerY" secondItem="2Q5-T6-UvK" secondAttribute="centerY" id="qNz-Px-rs4"/>
-                                    <constraint firstAttribute="bottom" secondItem="LDs-eG-gAX" secondAttribute="bottom" constant="12" id="ybp-8R-hlr"/>
-                                    <constraint firstItem="2Q5-T6-UvK" firstAttribute="centerY" secondItem="Re8-uD-vpm" secondAttribute="centerY" id="zl3-BH-csf"/>
+                                    <constraint firstItem="j3P-PZ-hOZ" firstAttribute="leading" secondItem="bpL-7n-pbt" secondAttribute="leading" constant="11" id="4Is-Pm-klI"/>
+                                    <constraint firstItem="j3P-PZ-hOZ" firstAttribute="centerY" secondItem="bpL-7n-pbt" secondAttribute="centerY" id="Jh2-ZA-Q9t"/>
+                                    <constraint firstItem="j3P-PZ-hOZ" firstAttribute="height" secondItem="bpL-7n-pbt" secondAttribute="height" id="KoO-hK-qrT"/>
+                                    <constraint firstAttribute="width" constant="200" id="yIu-aG-5hO"/>
                                 </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="9vg-L3-tu0"/>
-                                        <exclude reference="3z6-yk-Ihr"/>
-                                        <exclude reference="DnJ-6h-4c9"/>
-                                        <exclude reference="lnb-3R-uk0"/>
-                                        <exclude reference="zl3-BH-csf"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="9vg-L3-tu0"/>
-                                        <exclude reference="PTJ-Dw-6sH"/>
-                                        <exclude reference="WCx-jH-NWK"/>
-                                        <include reference="3z6-yk-Ihr"/>
-                                        <include reference="DnJ-6h-4c9"/>
-                                        <exclude reference="Mki-Am-QR3"/>
-                                        <exclude reference="ZQZ-L0-poc"/>
-                                        <include reference="lnb-3R-uk0"/>
-                                        <exclude reference="KhC-i3-HLd"/>
-                                        <exclude reference="pa2-VH-Tpt"/>
-                                        <include reference="zl3-BH-csf"/>
-                                    </mask>
-                                </variation>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NPr-F9-Q37" userLabel="Fake continue swipe action">
+                                <rect key="frame" x="-220" y="0.0" width="200" height="18"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Continue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0z-7Y-c3D">
+                                        <rect key="frame" x="124" y="0.0" width="65" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.29803921568627451" green="0.85098039215686272" blue="0.39215686274509803" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="B0z-7Y-c3D" secondAttribute="trailing" constant="11" id="7eT-qx-J3o"/>
+                                    <constraint firstAttribute="width" constant="200" id="8ID-3z-joo"/>
+                                    <constraint firstItem="B0z-7Y-c3D" firstAttribute="height" secondItem="NPr-F9-Q37" secondAttribute="height" id="Xcq-N1-mEL"/>
+                                    <constraint firstItem="B0z-7Y-c3D" firstAttribute="centerY" secondItem="NPr-F9-Q37" secondAttribute="centerY" id="uD0-IW-BKD"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jec-Z0-lsf" userLabel="Bottom separator">
+                                <rect key="frame" x="0.0" y="63" width="834" height="1"/>
+                                <color key="backgroundColor" red="0.90980392156862744" green="0.90980392156862744" blue="0.90980392156862744" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="izG-Sm-pwo"/>
+                                </constraints>
                             </view>
                         </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Rq6-Da-FtS" firstAttribute="top" secondItem="BLU-UX-hjg" secondAttribute="top" id="0OM-Py-H9o"/>
-                            <constraint firstAttribute="trailing" secondItem="bCj-8c-iBp" secondAttribute="trailing" id="gPT-3F-OHK"/>
-                            <constraint firstAttribute="bottom" secondItem="bCj-8c-iBp" secondAttribute="bottom" id="iQ7-bz-Yzt"/>
-                            <constraint firstAttribute="bottom" secondItem="Rq6-Da-FtS" secondAttribute="bottom" id="l7Z-09-Xz1"/>
-                            <constraint firstItem="bCj-8c-iBp" firstAttribute="top" secondItem="BLU-UX-hjg" secondAttribute="top" id="pPU-Au-7na"/>
-                            <constraint firstAttribute="height" constant="64" id="z4C-w8-MQK"/>
+                            <constraint firstAttribute="width" constant="834" id="6yp-kW-ocn"/>
                         </constraints>
-                    </stackView>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bpL-7n-pbt" userLabel="Fake delete swipe action">
-                        <rect key="frame" x="874" y="0.0" width="200" height="18"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Delete" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j3P-PZ-hOZ">
-                                <rect key="frame" x="11" y="0.0" width="46.5" height="18"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" red="0.96862745098039216" green="0.25098039215686274" blue="0.28627450980392155" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="j3P-PZ-hOZ" firstAttribute="leading" secondItem="bpL-7n-pbt" secondAttribute="leading" constant="11" id="4Is-Pm-klI"/>
-                            <constraint firstItem="j3P-PZ-hOZ" firstAttribute="centerY" secondItem="bpL-7n-pbt" secondAttribute="centerY" id="Jh2-ZA-Q9t"/>
-                            <constraint firstItem="j3P-PZ-hOZ" firstAttribute="height" secondItem="bpL-7n-pbt" secondAttribute="height" id="KoO-hK-qrT"/>
-                            <constraint firstAttribute="width" constant="200" id="yIu-aG-5hO"/>
-                        </constraints>
-                    </view>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NPr-F9-Q37" userLabel="Fake continue swipe action">
-                        <rect key="frame" x="-200" y="0.0" width="200" height="18"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Continue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0z-7Y-c3D">
-                                <rect key="frame" x="124" y="0.0" width="65" height="18"/>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" red="0.29803921568627451" green="0.85098039215686272" blue="0.39215686274509803" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="trailing" secondItem="B0z-7Y-c3D" secondAttribute="trailing" constant="11" id="7eT-qx-J3o"/>
-                            <constraint firstAttribute="width" constant="200" id="8ID-3z-joo"/>
-                            <constraint firstItem="B0z-7Y-c3D" firstAttribute="height" secondItem="NPr-F9-Q37" secondAttribute="height" id="Xcq-N1-mEL"/>
-                            <constraint firstItem="B0z-7Y-c3D" firstAttribute="centerY" secondItem="NPr-F9-Q37" secondAttribute="centerY" id="uD0-IW-BKD"/>
-                        </constraints>
-                    </view>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jec-Z0-lsf" userLabel="Bottom separator">
-                        <rect key="frame" x="0.0" y="63" width="874" height="1"/>
-                        <color key="backgroundColor" red="0.90980392156862744" green="0.90980392156862744" blue="0.90980392156862744" alpha="1" colorSpace="calibratedRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="1" id="izG-Sm-pwo"/>
-                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="6yp-kW-ocn"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <include reference="6yp-kW-ocn"/>
+                            </mask>
+                        </variation>
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="BLU-UX-hjg" secondAttribute="trailing" id="2tm-Rh-hZK"/>
-                    <constraint firstItem="BLU-UX-hjg" firstAttribute="leading" secondItem="FMY-EJ-tyu" secondAttribute="leading" id="Bmc-FS-pCV"/>
-                    <constraint firstItem="NPr-F9-Q37" firstAttribute="top" secondItem="FMY-EJ-tyu" secondAttribute="top" id="J3i-mj-Nqd"/>
-                    <constraint firstItem="BLU-UX-hjg" firstAttribute="top" secondItem="FMY-EJ-tyu" secondAttribute="top" id="Qgs-gh-fKM"/>
-                    <constraint firstItem="bpL-7n-pbt" firstAttribute="height" secondItem="FMY-EJ-tyu" secondAttribute="height" id="R7N-am-Z44"/>
-                    <constraint firstItem="bpL-7n-pbt" firstAttribute="top" secondItem="FMY-EJ-tyu" secondAttribute="top" id="RID-DG-DH2"/>
-                    <constraint firstAttribute="trailing" secondItem="jec-Z0-lsf" secondAttribute="trailing" id="SQ1-Sc-cK5"/>
+                    <constraint firstAttribute="trailing" secondItem="ldo-6H-LmF" secondAttribute="trailing" priority="750" id="1of-qZ-rCw"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="trailing" secondItem="BLU-UX-hjg" secondAttribute="trailing" id="2tm-Rh-hZK"/>
+                    <constraint firstItem="BLU-UX-hjg" firstAttribute="leading" secondItem="ldo-6H-LmF" secondAttribute="leading" id="Bmc-FS-pCV"/>
+                    <constraint firstItem="NPr-F9-Q37" firstAttribute="top" secondItem="ldo-6H-LmF" secondAttribute="top" id="J3i-mj-Nqd"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="centerX" secondItem="FMY-EJ-tyu" secondAttribute="centerX" id="Krx-XZ-R6W"/>
+                    <constraint firstItem="BLU-UX-hjg" firstAttribute="top" secondItem="ldo-6H-LmF" secondAttribute="top" id="Qgs-gh-fKM"/>
+                    <constraint firstItem="bpL-7n-pbt" firstAttribute="height" secondItem="ldo-6H-LmF" secondAttribute="height" id="R7N-am-Z44"/>
+                    <constraint firstItem="bpL-7n-pbt" firstAttribute="top" secondItem="ldo-6H-LmF" secondAttribute="top" id="RID-DG-DH2"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="trailing" secondItem="jec-Z0-lsf" secondAttribute="trailing" id="SQ1-Sc-cK5"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="top" secondItem="FMY-EJ-tyu" secondAttribute="top" id="UkC-L4-Uvu"/>
                     <constraint firstItem="jec-Z0-lsf" firstAttribute="bottom" secondItem="BLU-UX-hjg" secondAttribute="bottom" id="Y9G-zR-vYZ"/>
-                    <constraint firstItem="PNy-Vs-gWI" firstAttribute="width" secondItem="FMY-EJ-tyu" secondAttribute="width" multiplier="0.32" id="cgC-GQ-akG"/>
-                    <constraint firstItem="jec-Z0-lsf" firstAttribute="leading" secondItem="FMY-EJ-tyu" secondAttribute="leading" id="eJ5-sk-3ar"/>
-                    <constraint firstItem="NPr-F9-Q37" firstAttribute="height" secondItem="FMY-EJ-tyu" secondAttribute="height" id="jJW-mE-svC"/>
-                    <constraint firstAttribute="bottom" secondItem="BLU-UX-hjg" secondAttribute="bottom" id="mOk-5y-Jeu"/>
-                    <constraint firstItem="bpL-7n-pbt" firstAttribute="leading" secondItem="FMY-EJ-tyu" secondAttribute="trailing" id="nBc-s9-bhR"/>
-                    <constraint firstAttribute="leading" secondItem="NPr-F9-Q37" secondAttribute="trailing" id="tbJ-49-Twy"/>
-                    <constraint firstAttribute="trailing" secondItem="2Q5-T6-UvK" secondAttribute="trailing" constant="27" id="xx9-4r-fxJ"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="leading" secondItem="FMY-EJ-tyu" secondAttribute="leading" priority="750" id="YGN-GO-iwP"/>
+                    <constraint firstAttribute="bottom" secondItem="ldo-6H-LmF" secondAttribute="bottom" id="ZgJ-lw-M7s"/>
+                    <constraint firstItem="PNy-Vs-gWI" firstAttribute="width" secondItem="ldo-6H-LmF" secondAttribute="width" multiplier="0.32" id="cgC-GQ-akG"/>
+                    <constraint firstItem="jec-Z0-lsf" firstAttribute="leading" secondItem="ldo-6H-LmF" secondAttribute="leading" id="eJ5-sk-3ar"/>
+                    <constraint firstItem="NPr-F9-Q37" firstAttribute="height" secondItem="ldo-6H-LmF" secondAttribute="height" id="jJW-mE-svC"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="bottom" secondItem="BLU-UX-hjg" secondAttribute="bottom" id="mOk-5y-Jeu"/>
+                    <constraint firstItem="bpL-7n-pbt" firstAttribute="leading" secondItem="ldo-6H-LmF" secondAttribute="trailing" id="nBc-s9-bhR"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="leading" secondItem="NPr-F9-Q37" secondAttribute="trailing" constant="20" id="tbJ-49-Twy"/>
+                    <constraint firstItem="ldo-6H-LmF" firstAttribute="trailing" secondItem="2Q5-T6-UvK" secondAttribute="trailing" constant="27" id="xx9-4r-fxJ"/>
                 </constraints>
                 <variation key="default">
                     <mask key="constraints">
@@ -328,6 +353,7 @@
             </accessibility>
             <connections>
                 <outlet property="BillableIcon" destination="Arb-iG-IM3" id="MHp-Pv-hnS"/>
+                <outlet property="ContentWidthConstraint" destination="6yp-kW-ocn" id="cgT-Lk-6wi"/>
                 <outlet property="ContinueButton" destination="Re8-uD-vpm" id="name-outlet-Re8-uD-vpm"/>
                 <outlet property="ContinueImageView" destination="2Q5-T6-UvK" id="name-outlet-2Q5-T6-UvK"/>
                 <outlet property="DescriptionFadeView" destination="ohm-7o-dpZ" id="Sgi-eo-FZ7"/>

--- a/Toggl.iOS/Extensions/ViewExtensions.cs
+++ b/Toggl.iOS/Extensions/ViewExtensions.cs
@@ -33,5 +33,12 @@ namespace Toggl.iOS.Extensions
             self.LeadingAnchor.ConstraintEqualTo(view.LeadingAnchor).Active = true;
             self.TrailingAnchor.ConstraintEqualTo(view.TrailingAnchor).Active = true;
         }
+
+
+        public static void ConstrainToViewHeight(this UIView self, UIView view)
+        {
+            self.TopAnchor.ConstraintEqualTo(view.TopAnchor).Active = true;
+            self.BottomAnchor.ConstraintEqualTo(view.BottomAnchor).Active = true;
+        }
     }
 }

--- a/Toggl.iOS/ViewControllers/MainViewController.cs
+++ b/Toggl.iOS/ViewControllers/MainViewController.cs
@@ -300,7 +300,7 @@ namespace Toggl.iOS.ViewControllers
             ratingViewContainer.BottomAnchor.ConstraintEqualTo(tableHeader.BottomAnchor).Active = true;
 
             suggestionsContaier.AddSubview(suggestionsView);
-            suggestionsView.ConstrainInView(suggestionsContaier);
+            suggestionsView.ConstrainToViewHeight(suggestionsContaier);
         }
 
         private (long[], EditTimeEntryOrigin) editEventInfo(LogItemViewModel item)

--- a/Toggl.iOS/ViewControllers/MainViewController.xib
+++ b/Toggl.iOS/ViewControllers/MainViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="ipad9_7" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -48,14 +48,14 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" contentMode="scaleToFill" id="2">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jhd-oR-xIN" userLabel="Time Entries Log">
-                    <rect key="frame" x="0.0" y="23" width="375" height="595"/>
+                    <rect key="frame" x="0.0" y="20" width="1024" height="698"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xqe-XF-nVb" userLabel="Welcome Back Container">
-                            <rect key="frame" x="70.5" y="239" width="234" height="83.5"/>
+                            <rect key="frame" x="395" y="239" width="234" height="83.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome back!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWl-8H-c8B">
                                     <rect key="frame" x="55" y="0.0" width="124" height="21"/>
@@ -84,14 +84,11 @@ time entries will appear here.</string>
                             </constraints>
                         </view>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="hoP-Tg-vBM" customClass="TimeEntriesLogTableView">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="595"/>
+                            <rect key="frame" x="0.0" y="0.0" width="1024" height="698"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="834" id="Jw8-mK-mKg"/>
-                            </constraints>
                         </tableView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="niU-tX-YTJ" userLabel="TopSeparator">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                            <rect key="frame" x="0.0" y="0.0" width="1024" height="1"/>
                             <color key="backgroundColor" red="0.90980392156862744" green="0.90980392156862744" blue="0.90980392156862744" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="9i2-Mn-2T6"/>
@@ -137,7 +134,7 @@ time entries will appear here.</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w5c-30-czh" userLabel="Swipe left bubble">
-                            <rect key="frame" x="178" y="400" width="189" height="45"/>
+                            <rect key="frame" x="827" y="400" width="189" height="45"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Swipe left to delete" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ew1-f0-nHV">
                                     <rect key="frame" x="32" y="14" width="125" height="17"/>
@@ -176,7 +173,7 @@ time entries will appear here.</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r2K-j0-0fe">
-                            <rect key="frame" x="16" y="200" width="343" height="68"/>
+                            <rect key="frame" x="340.5" y="200" width="343" height="68"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rqr-jp-a3k">
                                     <rect key="frame" x="166.5" y="-4" width="10" height="10"/>
@@ -271,7 +268,7 @@ time entries will appear here.</string>
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Kk-Hz-RBS">
-                    <rect key="frame" x="295" y="538" width="80" height="80"/>
+                    <rect key="frame" x="944" y="638" width="80" height="80"/>
                     <accessibility key="accessibilityConfiguration" label="MainStartTimeEntry"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="80" id="ZPS-gP-0Ab"/>
@@ -280,7 +277,7 @@ time entries will appear here.</string>
                     <state key="normal" image="playIcon"/>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jpn-gJ-vFB">
-                    <rect key="frame" x="113" y="554" width="167" height="48"/>
+                    <rect key="frame" x="762" y="654" width="167" height="48"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap to start timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LCs-H0-PO4">
                             <rect key="frame" x="28" y="15.5" width="111.5" height="17"/>
@@ -318,19 +315,19 @@ time entries will appear here.</string>
                     </userDefinedRuntimeAttributes>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vou-B4-go4">
-                    <rect key="frame" x="0.0" y="546" width="375" height="121"/>
+                    <rect key="frame" x="95" y="646" width="834" height="122"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0:15:25" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0J7-Pj-geT">
-                            <rect key="frame" x="161" y="14" width="53.5" height="18"/>
+                            <rect key="frame" x="390.5" y="14" width="53.5" height="18"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E3W-8n-IfX" userLabel="Fading view" customClass="FadeView">
-                            <rect key="frame" x="48" y="32" width="279" height="89"/>
+                            <rect key="frame" x="48" y="32" width="738" height="90"/>
                             <subviews>
                                 <scrollView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tuf-H4-v8x" customClass="MarqueeView">
-                                    <rect key="frame" x="0.0" y="0.0" width="279" height="89"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="738" height="90"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PtF-34-2BI">
                                             <rect key="frame" x="0.0" y="0.0" width="355.5" height="23"/>
@@ -390,7 +387,7 @@ time entries will appear here.</string>
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ddo-IW-xE3">
-                    <rect key="frame" x="319" y="554" width="56" height="56"/>
+                    <rect key="frame" x="873" y="654" width="56" height="56"/>
                     <accessibility key="accessibilityConfiguration" label="MainStopTimeEntry"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="56" id="cJZ-zk-6qM"/>
@@ -399,7 +396,7 @@ time entries will appear here.</string>
                     <state key="normal" image="stopIcon"/>
                 </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0wI-i0-MgR">
-                    <rect key="frame" x="193.5" y="505" width="173.5" height="45"/>
+                    <rect key="frame" x="747.5" y="605" width="173.5" height="45"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap to stop timer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tFY-U0-EZM">
                             <rect key="frame" x="32" y="14" width="109.5" height="17"/>
@@ -437,12 +434,12 @@ time entries will appear here.</string>
                     </userDefinedRuntimeAttributes>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fge-d2-Ud2">
-                    <rect key="frame" x="8" y="436.5" width="359" height="85.5"/>
+                    <rect key="frame" x="103" y="553" width="818" height="69"/>
                     <subviews>
                         <visualEffectView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dOM-nz-0rF">
-                            <rect key="frame" x="0.0" y="0.0" width="359" height="85.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="818" height="69"/>
                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="HB5-OD-DUF">
-                                <rect key="frame" x="0.0" y="0.0" width="359" height="85.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="818" height="69"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </view>
                             <color key="backgroundColor" red="0.83137254900000002" green="0.94509803920000002" blue="0.99607843139999996" alpha="0.82999999999999996" colorSpace="custom" customColorSpace="sRGB"/>
@@ -463,7 +460,7 @@ time entries will appear here.</string>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Thank you for the feedback. If you had any questions, we’ll get back to you soon." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FOL-Gh-maB">
-                            <rect key="frame" x="42" y="36" width="305" height="33.5"/>
+                            <rect key="frame" x="42" y="36" width="764" height="17"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" red="0.070588235289999995" green="0.53725490200000003" blue="0.74901960779999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>

--- a/Toggl.iOS/Views/Suggestions/SuggestionsView.cs
+++ b/Toggl.iOS/Views/Suggestions/SuggestionsView.cs
@@ -38,7 +38,13 @@ namespace Toggl.iOS.Suggestions
             base.MovedToSuperview();
 
             TopAnchor.ConstraintEqualTo(Superview.TopAnchor).Active = true;
-            WidthAnchor.ConstraintEqualTo(Superview.WidthAnchor).Active = true;
+            WidthAnchor.ConstraintLessThanOrEqualTo(834).Active = true;
+            var leftConstraint = LeadingAnchor.ConstraintEqualTo(Superview.LeadingAnchor);
+            leftConstraint.Priority = 750;
+            leftConstraint.Active = true;
+            var rightConstraint = TrailingAnchor.ConstraintEqualTo(Superview.TrailingAnchor);
+            rightConstraint.Priority = 750;
+            rightConstraint.Active = true;
             CenterXAnchor.ConstraintEqualTo(Superview.CenterXAnchor).Active = true;
             //Actual value is set with bindings a few lines below
             heightConstraint.Active = true;
@@ -69,8 +75,8 @@ namespace Toggl.iOS.Suggestions
                 AddSubview(suggestionView);
                 suggestionView.TranslatesAutoresizingMaskIntoConstraints = false;
                 suggestionView.HeightAnchor.ConstraintEqualTo(suggestionHeight).Active = true;
-                suggestionView.CenterXAnchor.ConstraintEqualTo(Superview.CenterXAnchor).Active = true;
-                suggestionView.WidthAnchor.ConstraintEqualTo(Superview.WidthAnchor, 1, -2 * sideMargin).Active = true;
+                suggestionView.CenterXAnchor.ConstraintEqualTo(CenterXAnchor).Active = true;
+                suggestionView.WidthAnchor.ConstraintEqualTo(WidthAnchor, 1, -2 * sideMargin).Active = true;
                 suggestionView.TopAnchor.ConstraintEqualTo(titleLabel.BottomAnchor, distanceFromTitleLabel(i)).Active = true;
 
                 suggestionView.AddGestureRecognizer(new UITapGestureRecognizer(() =>
@@ -90,8 +96,8 @@ namespace Toggl.iOS.Suggestions
             titleLabel.Text = Resources.SuggestionsHeader;
             titleLabel.Font = UIFont.SystemFontOfSize(titleSize, UIFontWeight.Medium);
             titleLabel.TextColor = Colors.Main.SuggestionsTitle.ToNativeColor();
-            titleLabel.TopAnchor.ConstraintEqualTo(Superview.TopAnchor, distanceAboveTitleLabel).Active = true;
-            titleLabel.LeadingAnchor.ConstraintEqualTo(Superview.LeadingAnchor, sideMargin).Active = true;
+            titleLabel.TopAnchor.ConstraintEqualTo(TopAnchor, distanceAboveTitleLabel).Active = true;
+            titleLabel.LeadingAnchor.ConstraintEqualTo(LeadingAnchor, sideMargin).Active = true;
         }
 
         private float distanceFromTitleLabel(int index)

--- a/Toggl.iOS/Views/Suggestions/SuggestionsView.cs
+++ b/Toggl.iOS/Views/Suggestions/SuggestionsView.cs
@@ -16,6 +16,7 @@ namespace Toggl.iOS.Suggestions
         private const float distanceAboveTitleLabel = 20;
         private const float distanceBelowTitleLabel = 16;
         private const float distanceBetweenSuggestions = 12;
+        private const float maxWidth = 834;
 
         private readonly UILabel titleLabel = new UILabel();
 
@@ -38,7 +39,7 @@ namespace Toggl.iOS.Suggestions
             base.MovedToSuperview();
 
             TopAnchor.ConstraintEqualTo(Superview.TopAnchor).Active = true;
-            WidthAnchor.ConstraintLessThanOrEqualTo(834).Active = true;
+            WidthAnchor.ConstraintLessThanOrEqualTo(maxWidth).Active = true;
             var leftConstraint = LeadingAnchor.ConstraintEqualTo(Superview.LeadingAnchor);
             leftConstraint.Priority = 750;
             leftConstraint.Active = true;


### PR DESCRIPTION
## What's this?
A set of code and AL changes that fix the scrolling behaviour on iPad.

### Relationships
Closes #5005

## Why do we want this?
Better scrolling

## How is it done?
Before this PR we would set a max width to the table view, thus constraining its built-in scroll view, making the "margins" unresponsive. This PR changes that to give a max width to the contents of the cells themselves, thus having the scroll view span full width.

### Why not another way?
The other option is wrapping our whole table view in a separate scroll view, that will handle the scrolling, but that option is quite messy and bug-prone.

### Side effects
Tapping on the "margins" counts as selecting a cell, so it can trigger the Edit TE screen. Also, swipe-to-delete/continue also starts from the edge of the screen, and not from the edge of the table view now.

## Review hints
Run app, scroll the main log, select a TE from the centre, select a TE from the paddings, check swipe-to-delete/continue actions.

## :squid: Permissions
All yours!