### PR TITLE
Fix Reports flicker

### DIFF
--- a/Toggl.Core.UI/ViewModels/Reports/ReportsViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/Reports/ReportsViewModel.cs
@@ -214,11 +214,8 @@ namespace Toggl.Core.UI.ViewModels.Reports
 
             viewAppearedSubject
                 .AsObservable()
-                .Throttle(new TimeSpan(0, 5, 0))
-                .Subscribe((_ =>
-                {
-                    reportSubject.OnNext(Unit.Default);
-                }))
+                .Throttle(TimeSpan.FromMinutes(5))
+                .Subscribe(_ => reloadReportsWhenViewAppears())
                 .DisposedBy(disposeBag);
 
             reportSubject
@@ -309,6 +306,11 @@ namespace Toggl.Core.UI.ViewModels.Reports
             isLoading.OnNext(false);
 
             trackReportsEvent(true);
+        }
+
+        private void reloadReportsWhenViewAppears()
+        {
+            reportSubject.OnNext(Unit.Default);
         }
 
         private void onError(Exception ex)

--- a/Toggl.Core.UI/ViewModels/Reports/ReportsViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/Reports/ReportsViewModel.cs
@@ -53,6 +53,7 @@ namespace Toggl.Core.UI.ViewModels.Reports
         private readonly ReportsCalendarViewModel calendarViewModel;
 
         private readonly Subject<Unit> reportSubject = new Subject<Unit>();
+        private readonly Subject<Unit> viewAppearedSubject = new Subject<Unit>();
         private readonly BehaviorSubject<bool> isLoading = new BehaviorSubject<bool>(true);
         private readonly BehaviorSubject<IThreadSafeWorkspace> workspaceSubject = new BehaviorSubject<IThreadSafeWorkspace>(null);
         private readonly BehaviorSubject<string> currentDateRangeStringSubject = new BehaviorSubject<string>(string.Empty);
@@ -211,6 +212,15 @@ namespace Toggl.Core.UI.ViewModels.Reports
                 .Subscribe(changeDateRange)
                 .DisposedBy(disposeBag);
 
+            viewAppearedSubject
+                .AsObservable()
+                .Throttle(new TimeSpan(0, 5, 0))
+                .Subscribe((_ =>
+                {
+                    reportSubject.OnNext(Unit.Default);
+                }))
+                .DisposedBy(disposeBag);
+
             reportSubject
                 .AsObservable()
                 .Do(setLoadingState)
@@ -247,7 +257,7 @@ namespace Toggl.Core.UI.ViewModels.Reports
                 return;
             }
 
-            reportSubject.OnNext(Unit.Default);
+            viewAppearedSubject.OnNext(Unit.Default);
         }
 
         public void StopNavigationFromMainLogStopwatch()


### PR DESCRIPTION
## What's this?
A tiny refactor to prevent the reports view from flickering every time we open it.

### Relationships
Closes #4879 

## Why do we want this?
Better experience

## How is it done?
By creating a new subject for `ViewAppeared`, which is then throttled and used to trigger the reload action.

### Why not another way?
Seems simple enough, and rx-ey too.

### Side effects
No obvious way to manually refresh the reports page (can add a pull-to-refresh if needed)

## Review hints
Just test if the flickers.

## :squid: Permissions
Go fer it