### PR TITLE
Reposition scrolling indicator in iPad landscape mode

### DIFF
--- a/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.xib
+++ b/Toggl.iOS/Cells/TimeEntriesLog/TimeEntriesLogViewCell.xib
@@ -4,13 +4,14 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" selectionStyle="blue" indentationWidth="10" rowHeight="64" id="cZE-iV-UFb" customClass="TimeEntriesLogViewCell">
+        <tableViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" selectionStyle="blue" indentationWidth="10" rowHeight="64" id="cZE-iV-UFb" customClass="TimeEntriesLogViewCell">
             <rect key="frame" x="0.0" y="0.0" width="874" height="64"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cZE-iV-UFb" id="FMY-EJ-tyu">
@@ -166,7 +167,7 @@
                                         </constraints>
                                     </button>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icContinue" translatesAutoresizingMaskIntoConstraints="NO" id="2Q5-T6-UvK">
-                                        <rect key="frame" x="755" y="26.5" width="16" height="11"/>
+                                        <rect key="frame" x="761" y="26.5" width="10" height="11"/>
                                         <accessibility key="accessibilityConfiguration" label="TimeEntryRowContinueButton">
                                             <bool key="isElement" value="YES"/>
                                         </accessibility>
@@ -177,7 +178,7 @@
                                         </constraints>
                                     </imageView>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icSyncerror" translatesAutoresizingMaskIntoConstraints="NO" id="ZL2-U3-2N0">
-                                        <rect key="frame" x="755" y="24" width="16" height="16"/>
+                                        <rect key="frame" x="758" y="24" width="16" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="2ce-tF-NXu"/>
                                             <constraint firstAttribute="width" constant="16" id="zUx-mP-hYa"/>
@@ -219,9 +220,9 @@
                                 <variation key="default">
                                     <mask key="constraints">
                                         <exclude reference="9vg-L3-tu0"/>
-                                        <exclude reference="3z6-yk-Ihr"/>
                                         <exclude reference="DnJ-6h-4c9"/>
                                         <exclude reference="lnb-3R-uk0"/>
+                                        <exclude reference="3z6-yk-Ihr"/>
                                         <exclude reference="zl3-BH-csf"/>
                                     </mask>
                                 </variation>
@@ -230,11 +231,11 @@
                                         <include reference="9vg-L3-tu0"/>
                                         <exclude reference="PTJ-Dw-6sH"/>
                                         <exclude reference="WCx-jH-NWK"/>
-                                        <include reference="3z6-yk-Ihr"/>
                                         <include reference="DnJ-6h-4c9"/>
                                         <exclude reference="Mki-Am-QR3"/>
                                         <exclude reference="ZQZ-L0-poc"/>
                                         <include reference="lnb-3R-uk0"/>
+                                        <include reference="3z6-yk-Ihr"/>
                                         <exclude reference="KhC-i3-HLd"/>
                                         <exclude reference="pa2-VH-Tpt"/>
                                         <include reference="zl3-BH-csf"/>

--- a/Toggl.iOS/ViewControllers/MainViewController.cs
+++ b/Toggl.iOS/ViewControllers/MainViewController.cs
@@ -345,6 +345,8 @@ namespace Toggl.iOS.ViewControllers
                 new UIBarButtonItem(settingsButton)
             };
 
+            updateTableViewScrollbarPosition();
+
 #if DEBUG
             NavigationItem.LeftBarButtonItems = new[]
             {
@@ -358,6 +360,12 @@ namespace Toggl.iOS.ViewControllers
             base.TraitCollectionDidChange(previousTraitCollection);
             traitCollectionSubject.OnNext(Unit.Default);
             TimeEntriesLogTableView.ReloadData();
+        }
+
+        public override void DidRotate(UIInterfaceOrientation fromInterfaceOrientation)
+        {
+            base.DidRotate(fromInterfaceOrientation);
+            updateTableViewScrollbarPosition();
         }
 
         private void trackSiriEvents()
@@ -762,6 +770,20 @@ namespace Toggl.iOS.ViewControllers
             swipeRightAnimationDisposable = swipeRightStep.ManageSwipeActionAnimationOf(nextFirstTimeEntry, Direction.Right);
 
             swipeLeftGestureRecognizer = swipeLeftStep.DismissBySwiping(nextFirstTimeEntry, Direction.Left);
+        }
+
+        private void updateTableViewScrollbarPosition()
+        {
+            if (TraitCollection.HorizontalSizeClass == UIUserInterfaceSizeClass.Regular
+                && (UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.LandscapeLeft ||
+                    UIDevice.CurrentDevice.Orientation == UIDeviceOrientation.LandscapeRight))
+            {
+                TimeEntriesLogTableView.ScrollIndicatorInsets = new UIEdgeInsets(0, 0, 0, -8);
+            }
+            else
+            {
+                TimeEntriesLogTableView.ScrollIndicatorInsets = UIEdgeInsets.Zero;
+            }
         }
     }
 }

--- a/Toggl.iOS/ViewControllers/MainViewController.xib
+++ b/Toggl.iOS/ViewControllers/MainViewController.xib
@@ -51,7 +51,7 @@
             <rect key="frame" x="0.0" y="0.0" width="1112" height="834"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jhd-oR-xIN" userLabel="Time Entries Log">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jhd-oR-xIN" userLabel="Time Entries Log">
                     <rect key="frame" x="139" y="20" width="834" height="764"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xqe-XF-nVb" userLabel="Welcome Back Container">
@@ -83,7 +83,7 @@ time entries will appear here.</string>
                                 <constraint firstAttribute="trailing" secondItem="o5G-e2-nYj" secondAttribute="trailing" id="jfQ-UO-KJe"/>
                             </constraints>
                         </view>
-                        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="hoP-Tg-vBM" customClass="TimeEntriesLogTableView">
+                        <tableView contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="64" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="hoP-Tg-vBM" customClass="TimeEntriesLogTableView">
                             <rect key="frame" x="0.0" y="0.0" width="834" height="764"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </tableView>


### PR DESCRIPTION
## What's this?
A small set of AL and code changes that fix scrolling issues on iPad

### Relationships
Closes #5005 

## Why do we want this?
Better looks

## How is it done?
By repositioning the scrolling indicator a bit to the right when in iPad landscape mode.

### Why not another way?
Seems simple enough, and was what we agreed with @maritoggl on.

### Side effects
None.

## Review hints
Scroll around!

## :squid: Permissions
All yours!