### PR TITLE
iOS release 1.22 (Terminus)

### DIFF
--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.21.2</string>
+	<string>1.22</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.21.2</string>
+	<string>1.22</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -43,7 +43,7 @@
 	<key>CFBundleName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.21.2</string>
+	<string>1.22</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Changelog

### App Store
- Added new Siri Shortcuts and Workflows integration
- Fixed date label on Reports calendar
- Fixed iPad Main View layout
- Fixed some glitches in Login and Signup views
- Fixed possible crash in Calendar
- Fixed possible freeze when coming from background

### All changes 
#### User facing
- Adds copy from clipboard Siri shortcut
- Adds custom reports and start entry Siri shorctus
- Adds section to manage Siri shortcuts
- Adds section for Siri workflows
- Fixes reports selected date label
- Fixes reports calendar dates label not showing shortcuts
- Fixes layout issues in iPad split view
- Fixes glitch in scroll indicator in iPad
- Fixes glitch in password reset view
- Trims spaces from email fields
- Makes keyboard dismissable by swiping
- Shows toggl.com passwords in autofill
- Fixes glitch on entry description field with line breaks
- Fixes crash in the calendar
- Fixes freeze when coming from background

#### Internal

- Renames Daneel and Giscard to iOS and Android
- Adds Synclight tests and scaffold
- Adds timezone information to feedback info
- Tracks unrepresentable date times
- Tracks low memory warnings
- Fixes iOS UI tests
- Improves project and tag creation unit tests

## Version comparison
https://github.com/toggl/mobileapp/compare/daneel-1.21.1...ios-1.22