### PR TITLE
iOS: use native HTTP handler

### DIFF
--- a/Toggl.Core.Tests.Sync/Helpers/Server.cs
+++ b/Toggl.Core.Tests.Sync/Helpers/Server.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Toggl.Core.Exceptions;
@@ -15,6 +16,7 @@ using Toggl.Networking.Exceptions;
 using Toggl.Networking.Helpers;
 using Toggl.Networking.Network;
 using Toggl.Networking.Tests.Integration.Helper;
+using static System.Net.DecompressionMethods;
 
 namespace Toggl.Core.Tests.Sync.Helpers
 {
@@ -259,7 +261,8 @@ namespace Toggl.Core.Tests.Sync.Helpers
 
             private static IApiClient createApiClient()
             {
-                var realApiClient = Networking.TogglApiFactory.CreateDefaultApiClient(userAgent);
+                var managedHandler = new HttpClientHandler { AutomaticDecompression = GZip | Deflate };
+                var realApiClient = Networking.TogglApiFactory.CreateDefaultApiClient(userAgent, managedHandler);
 
                 return new SlowApiClient(new RetryingApiClient(realApiClient));
             }

--- a/Toggl.Core/UserAccessManager/ApiFactory.cs
+++ b/Toggl.Core/UserAccessManager/ApiFactory.cs
@@ -7,25 +7,26 @@ namespace Toggl.Core.Login
 {
     public sealed class ApiFactory : IApiFactory
     {
-        private readonly HttpMessageHandler httpClientHandler;
+        private readonly HttpMessageHandler httpHandler;
 
         public UserAgent UserAgent { get; }
         public ApiEnvironment Environment { get; }
 
-        public ApiFactory(ApiEnvironment apiEnvironment, UserAgent userAgent, HttpMessageHandler httpClientHandler)
+        public ApiFactory(ApiEnvironment apiEnvironment, UserAgent userAgent, HttpMessageHandler httpHandler)
         {
             Ensure.Argument.IsNotNull(userAgent, nameof(userAgent));
+            Ensure.Argument.IsNotNull(httpHandler, nameof(httpHandler));
 
             UserAgent = userAgent;
             Environment = apiEnvironment;
 
-            this.httpClientHandler = httpClientHandler;
+            this.httpHandler = httpHandler;
         }
 
         public ITogglApi CreateApiWith(Credentials credentials)
         {
             var configuration = new ApiConfiguration(Environment, credentials, UserAgent);
-            return TogglApiFactory.WithConfiguration(configuration, httpClientHandler);
+            return TogglApiFactory.WithConfiguration(configuration, httpHandler);
         }
     }
 }

--- a/Toggl.Core/UserAccessManager/ApiFactory.cs
+++ b/Toggl.Core/UserAccessManager/ApiFactory.cs
@@ -1,4 +1,5 @@
-﻿using Toggl.Shared;
+﻿using System.Net.Http;
+using Toggl.Shared;
 using Toggl.Networking;
 using Toggl.Networking.Network;
 
@@ -6,22 +7,25 @@ namespace Toggl.Core.Login
 {
     public sealed class ApiFactory : IApiFactory
     {
-        public UserAgent UserAgent { get; }
+        private readonly HttpMessageHandler httpClientHandler;
 
+        public UserAgent UserAgent { get; }
         public ApiEnvironment Environment { get; }
 
-        public ApiFactory(ApiEnvironment apiEnvironment, UserAgent userAgent)
+        public ApiFactory(ApiEnvironment apiEnvironment, UserAgent userAgent, HttpMessageHandler httpClientHandler)
         {
             Ensure.Argument.IsNotNull(userAgent, nameof(userAgent));
 
             UserAgent = userAgent;
             Environment = apiEnvironment;
+
+            this.httpClientHandler = httpClientHandler;
         }
 
         public ITogglApi CreateApiWith(Credentials credentials)
         {
             var configuration = new ApiConfiguration(Environment, credentials, UserAgent);
-            return TogglApiFactory.WithConfiguration(configuration);
+            return TogglApiFactory.WithConfiguration(configuration, httpClientHandler);
         }
     }
 }

--- a/Toggl.Networking.Tests.Integration/Helper/TogglApiFactory.cs
+++ b/Toggl.Networking.Tests.Integration/Helper/TogglApiFactory.cs
@@ -1,4 +1,6 @@
+using System.Net.Http;
 using Toggl.Networking.Network;
+using static System.Net.DecompressionMethods;
 
 namespace Toggl.Networking.Tests.Integration.Helper
 {
@@ -7,7 +9,8 @@ namespace Toggl.Networking.Tests.Integration.Helper
         public static ITogglApi TogglApiWith(Credentials credentials)
         {
             var apiConfiguration = configurationFor(credentials);
-            var apiClient = Networking.TogglApiFactory.CreateDefaultApiClient(apiConfiguration.UserAgent);
+            var managedHandler = new HttpClientHandler { AutomaticDecompression = GZip | Deflate };
+            var apiClient = Networking.TogglApiFactory.CreateDefaultApiClient(apiConfiguration.UserAgent, managedHandler);
             var retryingApiClient = new RetryingApiClient(apiClient);
 
             return new TogglApi(apiConfiguration, retryingApiClient);

--- a/Toggl.Networking/TogglApi.cs
+++ b/Toggl.Networking/TogglApi.cs
@@ -1,11 +1,9 @@
-﻿using System.Net;
-using System.Net.Http;
-using Toggl.Shared;
+﻿using System.Net.Http;
 using Toggl.Networking.ApiClients;
 using Toggl.Networking.ApiClients.Interfaces;
 using Toggl.Networking.Network;
 using Toggl.Networking.Serialization;
-using static System.Net.DecompressionMethods;
+using Toggl.Shared;
 
 namespace Toggl.Networking
 {
@@ -58,16 +56,15 @@ namespace Toggl.Networking
 
     public static class TogglApiFactory
     {
-        internal static IApiClient CreateDefaultApiClient(UserAgent userAgent)
+        internal static IApiClient CreateDefaultApiClient(UserAgent userAgent, HttpMessageHandler httpHandler)
         {
-            var httpHandler = new HttpClientHandler { AutomaticDecompression = GZip | Deflate };
             var httpClient = new HttpClient(httpHandler);
             return new ApiClient(httpClient, userAgent);
         }
 
-        public static ITogglApi WithConfiguration(ApiConfiguration configuration)
+        public static ITogglApi WithConfiguration(ApiConfiguration configuration, HttpMessageHandler httpHandler)
         {
-            var apiClient = CreateDefaultApiClient(configuration.UserAgent);
+            var apiClient = CreateDefaultApiClient(configuration.UserAgent, httpHandler);
             return new TogglApi(configuration, apiClient);
         }
     }

--- a/Toggl.iOS.SiriExtension.UI/Toggl.iOS.SiriExtension.UI.csproj
+++ b/Toggl.iOS.SiriExtension.UI/Toggl.iOS.SiriExtension.UI.csproj
@@ -25,7 +25,7 @@
     <IOSDebuggerPort>29367</IOSDebuggerPort>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
     <MtouchVerbosity>
     </MtouchVerbosity>
@@ -48,7 +48,7 @@
     <IOSDebuggerPort>55465</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
     </MtouchVerbosity>
   </PropertyGroup>
@@ -65,7 +65,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
     </MtouchVerbosity>
     <CodesignProvision>Toggl Mobile Siri UI Extension</CodesignProvision>
@@ -87,7 +87,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
     </MtouchVerbosity>
     <CodesignProvision>Daneel AdHoc SiriUIExtension</CodesignProvision>

--- a/Toggl.iOS.SiriExtension/Helper/APIHelper.cs
+++ b/Toggl.iOS.SiriExtension/Helper/APIHelper.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Foundation;
 using Toggl.iOS.ExtensionKit;
 using Toggl.Networking;
@@ -24,7 +25,8 @@ namespace SiriExtension
             var version = NSBundle.MainBundle.InfoDictionary["CFBundleShortVersionString"].ToString();
             var userAgent = new UserAgent("Daneel", $"{version} SiriExtension");
             var apiConfiguration = new ApiConfiguration(environment, Credentials.WithApiToken(apiToken), userAgent);
-            return TogglApiFactory.WithConfiguration(apiConfiguration);
+            var httpClientHandler = new NSUrlSessionHandler(NSUrlSessionConfiguration.DefaultSessionConfiguration);
+            return TogglApiFactory.WithConfiguration(apiConfiguration, httpClientHandler);
         }
     }
 }

--- a/Toggl.iOS.SiriExtension/Toggl.iOS.SiriExtension.csproj
+++ b/Toggl.iOS.SiriExtension/Toggl.iOS.SiriExtension.csproj
@@ -25,7 +25,7 @@
     <IOSDebuggerPort>29481</IOSDebuggerPort>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <DeviceSpecificBuild>false</DeviceSpecificBuild>
     <MtouchVerbosity>
     </MtouchVerbosity>
@@ -49,7 +49,7 @@
     <IOSDebuggerPort>17594</IOSDebuggerPort>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
     </MtouchVerbosity>
   </PropertyGroup>
@@ -64,7 +64,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
     </MtouchVerbosity>
     <CodesignProvision>Daneel AdHoc SiriExtension</CodesignProvision>
@@ -80,7 +80,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
     </MtouchVerbosity>
     <CodesignProvision>Toggl Mobile Siri Extension</CodesignProvision>

--- a/Toggl.iOS/Startup/IosDependencyContainer.cs
+++ b/Toggl.iOS/Startup/IosDependencyContainer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net.Http;
+using Foundation;
 using Toggl.Core;
 using Toggl.Core.Analytics;
 using Toggl.Core.Diagnostics;
@@ -130,5 +132,11 @@ namespace Toggl.iOS
 
         protected override IAccessRestrictionStorage CreateAccessRestrictionStorage()
             => settingsStorage.Value;
+
+        protected override IApiFactory CreateApiFactory()
+        {
+            var managedClientHandler = new NSUrlSessionHandler(NSUrlSessionConfiguration.DefaultSessionConfiguration);
+            return new ApiFactory(ApiEnvironment, UserAgent, managedClientHandler);
+        }
     }
 }

--- a/Toggl.iOS/Toggl.iOS.csproj
+++ b/Toggl.iOS/Toggl.iOS.csproj
@@ -50,7 +50,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release.AppStore|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -98,7 +98,7 @@
     </MtouchVerbosity>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
-    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
## What's this?
This PR adds native `NSUrlSessionHandler` for handling HTTP requests.

### Relationships
Ref #3588 (does not close it, because this PR affects only iOS and the user reported the problem on Android). It was originally implemented in #3602 in November, but the PR was reverted because of problems on Android. It might be also related to #4955 and some other syncing issues related to VPNs.

## Why do we want this?
We want our HTTP requests to be reliable. Let the OS handle it.

This will also allow us to debug HTTP communication on iOS - we will be able to intercept all of the communication between the API server and the app and check all of the HTTP request. This 

## How is it done?
Explicit dependency injection.

The changes in the iOS csproj files do not have any effect - they are overwritten with the explicit specification of the `HttpMessageHandler`. I changed them to avoid any confusion.

### Why not another way?
I could have leave the default implementation in `TogglApiFactory` and let the integration and syncing tests use it. I decided that it would be weird, because it would mean that there is code which is necessary only for tests in the production code. I also didn't want to make it optional in the constructor of `TogglApi`, because passing `null`s around is confusing and error prone.

### Side effects
None.

## Review hints
Try logging and and try creating a TE in the app and check that it syncs to the server.

## Tests
Integration tests: https://app.bitrise.io/build/d7253bd053794c33 - do not merge this branch unless these tests are passing.

Syncing tests: https://app.bitrise.io/build/f4a8c833bea571b2 - do not merge this branch unless these tests are passing.

## :squid: Permissions
I'll merge this if we can verify that it doesn't break Android, iOS, and Siri.