### PR TITLE
Fix cake substitutions for iOS adhoc builds

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -356,6 +356,7 @@ private TemporaryFileTransformation GetIosEntitlementsConfigurationTransformatio
     if (target == "Build.Release.iOS.AdHoc")
     {
         groupId = "group.com.toggl.daneel.adhoc.extensions";
+        apsEnvironment = "<string>production</string>";
     }
     else if (target == "Build.Release.iOS.AppStore")
     {


### PR DESCRIPTION
Without this fix, the iOS ad-hoc build cannot be installed on the device.