### PR TITLE
Fixes build errors when analytics are used

### DIFF
--- a/Toggl.Droid/Services/AnalyticsServiceAndroid.cs
+++ b/Toggl.Droid/Services/AnalyticsServiceAndroid.cs
@@ -1,10 +1,12 @@
 ﻿using Android.OS;
+using Android.App;
 using Firebase.Analytics;
 using Microsoft.AppCenter;
 using Microsoft.AppCenter.Crashes;
 using System;
 using System.Collections.Generic;
 using Toggl.Core.Analytics;
+using AppCenterAnalytics = Microsoft.AppCenter.Analytics.Analytics;
 
 namespace Toggl.Droid.Services
 {

--- a/Toggl.Droid/Services/FirebaseStopwatchProviderAndroid.cs
+++ b/Toggl.Droid/Services/FirebaseStopwatchProviderAndroid.cs
@@ -1,4 +1,5 @@
 ﻿using Com.Google.Firebase.Perf.Metrics;
+using Com.Google.Firebase.Perf;
 using Toggl.Core.Diagnostics;
 
 namespace Toggl.Droid.Services


### PR DESCRIPTION
## What's this?
When `USE_ANALYTICS` variable is defined, some code is enabled, but their `using`s are missing. 

↩ This is a result of a code styles changes (#5460). Since the `USE_ANALYTICS` variable is not defined in debug, they were reported as the _"unused"_ usings. 🤷‍♂ 

## Why do we want this?
So that we can build the project.

## How is it done?
By adding missing usings.

## :squid: Permissions
Me and @heytherewill.