### PR TITLE
♻ Revert to waiting for initialize to complete

### DIFF
--- a/Toggl.Core.UI/Navigation/NavigationService.cs
+++ b/Toggl.Core.UI/Navigation/NavigationService.cs
@@ -31,9 +31,8 @@ namespace Toggl.Core.UI.Navigation
         {
             var viewModel = viewModelLocator.Load<TViewModel>();
 
-            var initialize = viewModel.Initialize(payload);
-            var present = presenter.Present(viewModel, sourceView);
-            await Task.WhenAll(initialize, present).ConfigureAwait(false);
+            await viewModel.Initialize(payload).ConfigureAwait(false);
+            await presenter.Present(viewModel, sourceView).ConfigureAwait(false);
 
             analyticsService.CurrentPage.Track(typeof(TViewModel));
 

--- a/Toggl.Droid/Properties/AndroidManifest.xml
+++ b/Toggl.Droid/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:versionCode="987654321"
-    android:versionName="2.1.3"
+    android:versionName="2.1.4"
     package="com.toggl.giskard.debug"
     android:installLocation="auto">
     


### PR DESCRIPTION
## What's this?
Reverts one change (albeit not the whole PR) in order to eliminate a possible culprit in [CALI](https://appcenter.ms/orgs/Toggl/apps/Toggl-Android/crashes/errors/3390777968u/overview) crashes.

**What is reverted?**
I have reverted one particular part of #5389 that parallelized the initialization of view from the initialization from viewmodel. I'm assuming that in some cases, one depends on another which still isn't properly initialized.

This async code wasn't present in `2.0.1` where it was synchronous. It was introduced between `2.0.1` and `2.1`, so it's possible that it's an issue.

### Relationships
Refs #4230

## Why do we want this?
No 💥 

## How is it done?
By waiting for initialization prior to presentation.

### Side effects
In most cases only a slight performance loss on navigation (and startup).

## :squid: Permissions
Developers with permissions.