### PR TITLE
Allow users to change dates in the calendar

### DIFF
--- a/Toggl.Core.Tests/UI/ViewModels/CalendarViewModelTests.cs
+++ b/Toggl.Core.Tests/UI/ViewModels/CalendarViewModelTests.cs
@@ -1209,7 +1209,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 var expectedOutput = date.ToLocalTime().ToString(format.Long, CultureInfo.InvariantCulture);
                 var observer = TestScheduler.CreateObserver<string>();
-                ViewModel.CurrentDate.Subscribe(observer);
+                ViewModel.FormattedDate.Subscribe(observer);
 
                 dateFormatSubject.OnNext(format);
                 dateSubject.OnNext(date);

--- a/Toggl.Core.UI/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/Calendar/CalendarViewModel.cs
@@ -56,7 +56,7 @@ namespace Toggl.Core.UI.ViewModels.Calendar
 
         public IObservable<string> TimeTrackedToday { get; }
 
-        public IObservable<string> CurrentDate { get; }
+        public IObservable<string> FormattedDate { get; }
 
         public UIAction GetStarted { get; }
 

--- a/Toggl.Core.UI/ViewModels/Calendar/CalendarViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/Calendar/CalendarViewModel.cs
@@ -24,6 +24,7 @@ using Toggl.Core.UI.Views;
 using Toggl.Shared;
 using Toggl.Shared.Extensions;
 using Toggl.Storage.Settings;
+using static Toggl.Core.Helper.Constants;
 
 namespace Toggl.Core.UI.ViewModels.Calendar
 {
@@ -311,7 +312,7 @@ namespace Toggl.Core.UI.ViewModels.Calendar
         private async Task pickNewCalendarDate()
         {
             var now = timeService.CurrentDateTime;
-            var minDate = now.AddMonths(-2);
+            var minDate = now.AddMonths(-FetchTimeEntriesForMonths);
             var maxDate = now;
             var parameters = DateTimePickerParameters
                 .WithDates(DateTimePickerMode.Date, now, minDate, maxDate);

--- a/Toggl.Droid/Fragments/CalendarFragment.ViewBinds.cs
+++ b/Toggl.Droid/Fragments/CalendarFragment.ViewBinds.cs
@@ -7,6 +7,7 @@ namespace Toggl.Droid.Fragments
 {
     public partial class CalendarFragment
     {
+        private View daySelectionView;
         private View headerCalendarEventsView;
         private View headerTimeEntriesView;
         private TextView headerDayTextView;
@@ -27,9 +28,10 @@ namespace Toggl.Droid.Fragments
 
         protected override void InitializeViews(View view)
         {
-            headerCalendarEventsView = view.FindViewById(Resource.Id.HeaderCalendarEventsView);
-            headerTimeEntriesView = view.FindViewById(Resource.Id.HeaderTimeEntriesView);
+            daySelectionView = view.FindViewById(Resource.Id.DaySelection);
             headerDayTextView = view.FindViewById<TextView>(Resource.Id.Day);
+            headerTimeEntriesView = view.FindViewById(Resource.Id.HeaderTimeEntriesView);
+            headerCalendarEventsView = view.FindViewById(Resource.Id.HeaderCalendarEventsView);
             headerWeekdayTextView = view.FindViewById<TextView>(Resource.Id.Weekday);
             headerCalendarEventsTextView = view.FindViewById<TextView>(Resource.Id.HeaderCalendarEventsTextView);
             headerCalendarEventsLabel = view.FindViewById<TextView>(Resource.Id.HeaderCalendarEventsLabel);

--- a/Toggl.Droid/Fragments/CalendarFragment.cs
+++ b/Toggl.Droid/Fragments/CalendarFragment.cs
@@ -43,10 +43,7 @@ namespace Toggl.Droid.Fragments
             calendarRecyclerView.SetTimeService(timeService);
             calendarRecyclerView.SetAdapter(calendarAdapter);
 
-            timeService
-                .CurrentDateTimeObservable
-                .DistinctUntilChanged(offset => offset.Day)
-                .ObserveOn(schedulerProvider.MainScheduler)
+            ViewModel.SelectedDate
                 .Subscribe(configureHeaderDate)
                 .DisposedBy(DisposeBag);
 
@@ -96,6 +93,10 @@ namespace Toggl.Droid.Fragments
 
             ViewModel.ShouldShowOnboarding
                 .Subscribe(onboardingVisibilityChanged)
+                .DisposedBy(DisposeBag);
+
+            daySelectionView.Rx().Tap()
+                .Subscribe(ViewModel.PickCalendarDay.Inputs)
                 .DisposedBy(DisposeBag);
         }
 
@@ -164,7 +165,7 @@ namespace Toggl.Droid.Fragments
                 .Count();
         }
 
-        private void configureHeaderDate(DateTimeOffset offset)
+        private void configureHeaderDate(DateTime offset)
         {
             var day = offset.Day.ToString();
             headerDayTextView.Text = day;

--- a/Toggl.Droid/Fragments/ReactiveDialogFragment.cs
+++ b/Toggl.Droid/Fragments/ReactiveDialogFragment.cs
@@ -24,6 +24,10 @@ namespace Toggl.Droid.Fragments
 
         protected ReactiveDialogFragment()
         {
+            ViewModel = AndroidDependencyContainer
+                .Instance
+                .ViewModelCache
+                .Get<TViewModel>();
         }
 
         protected ReactiveDialogFragment(IntPtr javaReference, JniHandleOwnership transfer)
@@ -40,10 +44,6 @@ namespace Toggl.Droid.Fragments
         public override void OnViewCreated(View view, Bundle savedInstanceState)
         {
             base.OnViewCreated(view, savedInstanceState);
-            ViewModel = AndroidDependencyContainer
-                .Instance
-                .ViewModelCache
-                .Get<TViewModel>();
 
             ViewModel?.AttachView(this);
         }

--- a/Toggl.Droid/Fragments/SelectDateTimeFragment.cs
+++ b/Toggl.Droid/Fragments/SelectDateTimeFragment.cs
@@ -1,0 +1,86 @@
+﻿using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using System;
+using Toggl.Core.UI.Parameters;
+using Toggl.Core.UI.ViewModels;
+
+namespace Toggl.Droid.Fragments
+{
+    public sealed class SelectDateTimeFragment : ReactiveDialogFragment<SelectDateTimeViewModel>
+    {
+        public SelectDateTimeFragment()
+        {
+        }
+
+        public SelectDateTimeFragment(IntPtr javaReference, JniHandleOwnership transfer)
+            : base(javaReference, transfer)
+        {
+        }
+
+        public override Dialog OnCreateDialog(Bundle savedInstanceState)
+        {
+            switch (ViewModel.Mode)
+            {
+                case DateTimePickerMode.Date:
+                    return showDate();
+                case DateTimePickerMode.Time:
+                    return showTime();
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        private DatePickerDialog showDate()
+        {
+            var localTime = ViewModel.CurrentDateTime.Value.ToLocalTime();
+
+            var dialog = new DatePickerDialog(
+                Activity, Resource.Style.TogglDialog, onDateSet,
+                localTime.Year, localTime.Month - 1, localTime.Day);
+
+            dialog.DatePicker.MinDate = ViewModel.MinDate.ToUnixTimeMilliseconds();
+            dialog.DatePicker.MaxDate = ViewModel.MaxDate.ToUnixTimeMilliseconds();
+
+            return dialog;
+        }
+
+        private TimePickerDialog showTime()
+        {
+            var localTime = ViewModel.CurrentDateTime.Value.ToLocalTime();
+
+            var dialog = new TimePickerDialog(
+                Activity, onTimeSet,
+                localTime.Hour, localTime.Minute, ViewModel.Is24HoursFormat);
+
+            return dialog;
+        }
+
+        private void onDateSet(object sender, DatePickerDialog.DateSetEventArgs e)
+        {
+            var localTime = ViewModel.CurrentDateTime.Value.ToLocalTime();
+
+            ViewModel.CurrentDateTime.Accept(
+                new DateTimeOffset(e.Year, e.Month + 1, e.DayOfMonth,
+                    localTime.Hour, localTime.Minute, localTime.Second,
+                    localTime.Offset));
+
+            ViewModel.Save.Execute();
+        }
+
+        private void onTimeSet(object sender, TimePickerDialog.TimeSetEventArgs e)
+        {
+            var localTime = ViewModel.CurrentDateTime.Value.ToLocalTime();
+
+            ViewModel.CurrentDateTime.Accept(
+                new DateTimeOffset(localTime.Year, localTime.Month, localTime.Day,
+                    e.HourOfDay, e.Minute, localTime.Second,
+                    localTime.Offset));            
+        }
+
+        protected override void InitializeViews(View view)
+        {
+        }
+    }
+}

--- a/Toggl.Droid/Presentation/DialogFragmentPresenter.cs
+++ b/Toggl.Droid/Presentation/DialogFragmentPresenter.cs
@@ -21,6 +21,7 @@ namespace Toggl.Droid.Presentation
             typeof(SelectBeginningOfWeekViewModel),
             typeof(SelectColorViewModel),
             typeof(SelectDateFormatViewModel),
+            typeof(SelectDateTimeViewModel),
             typeof(SelectDefaultWorkspaceViewModel),
             typeof(SelectDurationFormatViewModel),
             typeof(SelectUserCalendarsViewModel),
@@ -35,11 +36,11 @@ namespace Toggl.Droid.Presentation
             if (fragmentManager == null)
                 throw new Exception($"Parent ViewModel's view trying to present {viewModel.GetType().Name} doesn't have a FragmentManager");
 
-            var dialog = createReactiveDialog(viewModel);
-
             AndroidDependencyContainer.Instance
                 .ViewModelCache
                 .Cache(viewModel);
+
+            var dialog = createReactiveDialog(viewModel);
 
             dialog.Show(fragmentManager, dialog.GetType().Name);
         }
@@ -62,6 +63,9 @@ namespace Toggl.Droid.Presentation
 
                 case SelectDateFormatViewModel _:
                     return new SelectDateFormatFragment();
+
+                case SelectDateTimeViewModel _:
+                    return new SelectDateTimeFragment();
 
                 case SelectDefaultWorkspaceViewModel _:
                     return new SelectDefaultWorkspaceFragment { Cancelable = false };

--- a/Toggl.Droid/Resources/layout/CalendarHeaderView.axml
+++ b/Toggl.Droid/Resources/layout/CalendarHeaderView.axml
@@ -13,6 +13,7 @@
         android:orientation="horizontal"
         android:background="@color/defaultBackground">
         <android.support.constraint.ConstraintLayout
+            android:id="@+id/DaySelection"
             android:layout_width="68dp"
             android:layout_height="match_parent">
             <TextView

--- a/Toggl.Droid/Toggl.Droid.csproj
+++ b/Toggl.Droid/Toggl.Droid.csproj
@@ -376,6 +376,7 @@
     <Compile Include="DebugHelpers\ErrorTriggeringFragment.cs" />
     <Compile Include="DebugHelpers\ErrorTriggeringFragmentShortcut.cs" />
     <Compile Include="Fragments\ReportsCalendarFragment.cs" />
+    <Compile Include="Fragments\SelectDateTimeFragment.cs" />
     <Compile Include="Presentation\ActivityTransitions.cs" />
     <Compile Include="Presentation\RunningTimeEntrySheetBehavior.cs" />
     <Compile Include="Services\JobServicesConstants.cs" />

--- a/Toggl.iOS/ViewControllers/Calendar/CalendarViewController.cs
+++ b/Toggl.iOS/ViewControllers/Calendar/CalendarViewController.cs
@@ -69,7 +69,7 @@ namespace Toggl.iOS.ViewControllers
                 .Subscribe(TimeTrackedTodayLabel.Rx().Text())
                 .DisposedBy(DisposeBag);
 
-            ViewModel.CurrentDate
+            ViewModel.FormattedDate
                 .Subscribe(CurrentDateLabel.Rx().Text())
                 .DisposedBy(DisposeBag);
 


### PR DESCRIPTION
## What's this?
This adds the possibility yo change days in the calendar view!!!!!!!!!!1!1!1!!111!!ELEVEN!!!!

## Why do we want this?
Users really want that, and our codebase already supports it, so WHY NOT?!?!?!

## How is it done?
I ressurected a dead fragment to write less code, wired some RxActions and boom! it works
Making it work on iOS shouldn't be hard, BTW, we just need specs

I'm constraining the selected date to be from `now - numberOfMonthsWeFetchData` to `now`

### Side effects
The app is objectively better now

### Review hints

Just tap the current date circle on Android and a picker will appear. Not the most discoverable, I know, but that's just a Go Loco project; we can improve designs later

## :squid: Permissions
Only myself, and only after @maritoggl approves.


⚠️ Tests will be written once Mari approves and we settle implementation details ⚠️ 