### PR TITLE
Androidx migration

### DIFF
--- a/Toggl.Droid/Resources/layout/AboutActivity.axml
+++ b/Toggl.Droid/Resources/layout/AboutActivity.axml
@@ -5,10 +5,10 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content">
-      <android.support.v7.widget.Toolbar
+      <androidx.appcompat.widget.Toolbar
           android:id="@+id/Toolbar"
           android:minHeight="?attr/actionBarSize"
           android:background="@color/defaultBackground"
@@ -16,7 +16,7 @@
           android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
           android:layout_width="match_parent"
           android:layout_height="wrap_content" />
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
     <TextView
         android:id="@+id/LicensesButton"
         android:textSize="15sp"

--- a/Toggl.Droid/Resources/layout/CalendarFragment.axml
+++ b/Toggl.Droid/Resources/layout/CalendarFragment.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>    
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -32,4 +32,4 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Toggl.Droid/Resources/layout/CalendarHeaderView.axml
+++ b/Toggl.Droid/Resources/layout/CalendarHeaderView.axml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.AppBarLayout
+<com.google.android.material.appbar.AppBarLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -12,7 +12,7 @@
         android:layout_height="?attr/actionBarSize"
         android:orientation="horizontal"
         android:background="@color/defaultBackground">
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="68dp"
             android:layout_height="match_parent">
             <TextView
@@ -44,14 +44,14 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintTop_toBottomOf="@id/Day"
                 app:layout_constraintBottom_toBottomOf="parent" />
-        </android.support.constraint.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
         <FrameLayout
             android:id="@+id/HeaderCalendarEventsView"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1">
 
-            <android.support.constraint.ConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical">
@@ -91,14 +91,14 @@
                     app:layout_constraintTop_toTopOf="@id/HeaderCalendarEventsLabel"
                     app:layout_constraintBottom_toBottomOf="parent"
                     android:background="@color/separator" />
-            </android.support.constraint.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </FrameLayout>
         <FrameLayout
             android:id="@+id/HeaderTimeEntriesView"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1">
-            <android.support.constraint.ConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
@@ -139,7 +139,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintLeft_toLeftOf="parent"
                     android:background="@color/separator" />
-            </android.support.constraint.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </FrameLayout>
         <Button
             android:id="@+id/HeaderLinkCalendarsButton"
@@ -159,4 +159,4 @@
             tools:text="Link calendars"
             android:visibility="gone"/>
     </LinearLayout>
-</android.support.design.widget.AppBarLayout>
+</com.google.android.material.appbar.AppBarLayout>

--- a/Toggl.Droid/Resources/layout/CalendarPermissionDeniedFragment.axml
+++ b/Toggl.Droid/Resources/layout/CalendarPermissionDeniedFragment.axml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -89,4 +89,4 @@
         android:lineSpacingExtra="2sp"
         android:textAllCaps="false"
         tools:text="Allow access"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Toggl.Droid/Resources/layout/CalendarSettingsActivity.axml
+++ b/Toggl.Droid/Resources/layout/CalendarSettingsActivity.axml
@@ -7,7 +7,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/Toolbar"
         android:elevation="4dp"
         android:background="@color/defaultBackground"

--- a/Toggl.Droid/Resources/layout/EditDurationActivity.axml
+++ b/Toggl.Droid/Resources/layout/EditDurationActivity.axml
@@ -6,10 +6,10 @@
     android:fillViewport="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/Toolbar"
             android:elevation="4dp"
             app:layout_constraintTop_toTopOf="parent"
@@ -18,7 +18,7 @@
             android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
             android:layout_width="match_parent"
             android:layout_height="?android:actionBarSize" />
-        <android.support.constraint.Guideline
+        <androidx.constraintlayout.widget.Guideline
             android:id="@+id/CenterGuideline"
             android:orientation="vertical"
             app:layout_constraintGuide_percent="0.5"
@@ -220,5 +220,5 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content" />
         </FrameLayout>
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/Toggl.Droid/Resources/layout/EditProjectActivity.axml
+++ b/Toggl.Droid/Resources/layout/EditProjectActivity.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
@@ -243,7 +243,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize" />
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/Toolbar"
         android:minHeight="?attr/actionBarSize"
         android:background="@android:color/white"
@@ -267,5 +267,5 @@
             android:layout_gravity="end"
             android:layout_width="wrap_content"
             android:layout_height="?attr/actionBarSize" />
-    </android.support.v7.widget.Toolbar>
-</android.support.design.widget.CoordinatorLayout>
+    </androidx.appcompat.widget.Toolbar>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/EditTimeEntryActivity.axml
+++ b/Toggl.Droid/Resources/layout/EditTimeEntryActivity.axml
@@ -10,7 +10,7 @@
     android:focusableInTouchMode="true"
     android:importantForAutofill="noExcludeDescendants"
     android:orientation="vertical">
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/AppBarLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -66,40 +66,40 @@
                 android:textColor="@android:color/black"
                 android:textSize="14sp" />
       </FrameLayout>
-    </android.support.design.widget.AppBarLayout>
-    <android.support.v4.widget.NestedScrollView
+    </com.google.android.material.appbar.AppBarLayout>
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/ScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:foregroundGravity="top"
         android:orientation="vertical">
 
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <android.support.constraint.Group
+            <androidx.constraintlayout.widget.Group
                 android:id="@+id/SingleTimeEntryModeViews"
                 android:visibility="visible"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:constraint_referenced_ids="GroupCount,GroupDuration,TimeMiddleGuide,TimeIcon,StartTimeButton,StartTime,StartDate,StartTimeLabel,StopTimeButton,StopTime,StopDate,StopTimeButton,EditStopTimeLabel,TimeBottomBorder,DurationButton,Duration,DurationLabel,DurationBottomBorder" />
 			
-            <android.support.constraint.Group
+            <androidx.constraintlayout.widget.Group
                 android:id="@+id/TimeEntriesGroupModeViews"
                 android:visibility="visible"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:constraint_referenced_ids="GroupCount,GroupDuration" />
 
-            <android.support.constraint.Group
+            <androidx.constraintlayout.widget.Group
                 android:id="@+id/BillableRelatedViews"
                 android:visibility="visible"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:constraint_referenced_ids="BillableIcon,ToggleBillableButton,BillableLabel,BillableSwitch,BillableBottomBorder" />
 
-            <android.support.constraint.Group
+            <androidx.constraintlayout.widget.Group
                 android:id="@+id/StoppedTimeEntryStopTimeElements"
                 android:visibility="visible"
                 android:layout_width="match_parent"
@@ -108,7 +108,7 @@
 
             <!-- ERROR MESSAGE -->
 
-            <android.support.v7.widget.CardView
+            <androidx.cardview.widget.CardView
                 android:id="@+id/ErrorContainer"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -121,7 +121,7 @@
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
 
-                <android.support.constraint.ConstraintLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:elevation="4dp">
@@ -167,8 +167,8 @@
                         app:layout_constraintRight_toRightOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/ErrorTitle"
                         tools:text="This time entry cant be saved and is rather large. Definitely multilined at best. This should really be big." />
-                </android.support.constraint.ConstraintLayout>
-            </android.support.v7.widget.CardView>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.cardview.widget.CardView>
 
             <TextView
                 android:id="@+id/GroupCount"
@@ -290,7 +290,7 @@
                 app:layout_constraintTop_toTopOf="@+id/TagsIcon"
                 tools:text="Add tags" />
 
-            <android.support.v7.widget.RecyclerView
+            <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/TagsRecyclerView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -565,6 +565,6 @@
                 android:layout_marginLeft="56dp"
                 android:background="@color/separator"
                 app:layout_constraintTop_toBottomOf="@id/DeleteLabel" />
-        </android.support.constraint.ConstraintLayout>
-    </android.support.v4.widget.NestedScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </LinearLayout>

--- a/Toggl.Droid/Resources/layout/ForgotPasswordActivity.axml
+++ b/Toggl.Droid/Resources/layout/ForgotPasswordActivity.axml
@@ -6,14 +6,14 @@
     android:animateLayoutChanges="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/Toolbar"
         android:elevation="0dp"
         android:minHeight="?attr/actionBarSize"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/AppTheme.TransparentActionBar" />
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/LoginEmail"
         app:helperTextTextAppearance="@style/TextInputLayoutRegularTextAppearance"
         tools:helperText="Please enter your email to reset your password"
@@ -31,7 +31,7 @@
             android:inputType="textEmailAddress"
             android:layout_height="match_parent">
         </EditText>
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
     <FrameLayout
         android:background="@color/buttonBlue"
         android:layout_height="36dp"

--- a/Toggl.Droid/Resources/layout/LicensesActivity.axml
+++ b/Toggl.Droid/Resources/layout/LicensesActivity.axml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/RecyclerView"
         android:clipToPadding="false"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/AppBarLayout"
         android:elevation="0dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/Toolbar"
             android:minHeight="?attr/actionBarSize"
             android:background="@color/defaultBackground"
@@ -26,5 +26,5 @@
             android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
-  </android.support.design.widget.AppBarLayout>
-</android.support.design.widget.CoordinatorLayout>
+  </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/LoginActivity.axml
+++ b/Toggl.Droid/Resources/layout/LoginActivity.axml
@@ -30,7 +30,7 @@
                 android:layout_marginTop="64dp"
                 android:layout_marginBottom="36dp"
                 android:layout_centerHorizontal="true" />
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/LoginEmail"
                 tools:hint="Email"
                 android:layout_marginLeft="24dp"
@@ -45,8 +45,8 @@
                     android:backgroundTint="@color/textEditBackgroundTint"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
-            </android.support.design.widget.TextInputLayout>
-            <android.support.design.widget.TextInputLayout
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/LoginPassword"
                 tools:hint="Password"
                 app:passwordToggleEnabled="true"
@@ -56,14 +56,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/LoginEmail">
-                <android.support.design.widget.TextInputEditText
+                <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/LoginPasswordEditText"
                     android:inputType="textPassword"
                     android:backgroundTint="@color/textEditBackgroundTint"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:imeOptions="actionDone" />
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
             <TextView
                 android:id="@+id/LoginError"
                 android:textSize="12sp"
@@ -166,7 +166,7 @@
             </LinearLayout>
         </RelativeLayout>
     </ScrollView>
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:id="@+id/LoginSignupCardView"
         app:cardCornerRadius="8dp"
         android:layout_height="80dp"
@@ -175,7 +175,7 @@
         android:layout_marginRight="24dp"
         android:layout_marginBottom="-8dp"
         android:layout_width="match_parent">
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:background="@android:color/white"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -223,6 +223,6 @@
                 android:layout_height="72dp"
                 android:layout_marginBottom="4dp"
                 android:layout_marginRight="16dp" />
-        </android.support.constraint.ConstraintLayout>
-    </android.support.v7.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
 </FrameLayout>

--- a/Toggl.Droid/Resources/layout/MainFragment.axml
+++ b/Toggl.Droid/Resources/layout/MainFragment.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/MainCoordinatorLayout"
@@ -19,18 +19,18 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize" />
-    <android.support.v4.widget.SwipeRefreshLayout
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/MainSwipeRefreshLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" >
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/MainRecyclerView"
             android:clipToPadding="false"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
-    </android.support.v4.widget.SwipeRefreshLayout>
-    <android.support.design.circularreveal.CircularRevealFrameLayout
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    <com.google.android.material.circularreveal.CircularRevealFrameLayout
       android:id="@+id/MainRunningTimeEntrySheet"
       android:layout_height="wrap_content"
       android:layout_width="match_parent"
@@ -43,8 +43,8 @@
       android:foreground="?android:attr/selectableItemBackground"
       app:layout_behavior="toggl.droid.presentation.RunningTimeEntrySheetBehavior">
         <include layout="@layout/MainRunningTimeEntry" />
-    </android.support.design.circularreveal.CircularRevealFrameLayout>
-    <android.support.design.widget.FloatingActionButton
+    </com.google.android.material.circularreveal.CircularRevealFrameLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/MainPlayButton"
         app:elevation="4dp"
         android:src="@drawable/play_white"
@@ -54,12 +54,12 @@
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp"
         android:layout_gravity="bottom|right" />
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/AppBarLayout"
         android:elevation="0dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/Toolbar"
             android:background="@color/defaultBackground"
             app:layout_scrollFlags="scroll|enterAlways"
@@ -70,6 +70,6 @@
               android:layout_gravity="start"
               android:layout_height="24dp"
               android:layout_width="80dp"/>
-        </android.support.v7.widget.Toolbar>
-    </android.support.design.widget.AppBarLayout>
-</android.support.design.widget.CoordinatorLayout>
+        </androidx.appcompat.widget.Toolbar>
+    </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/MainLogCell.axml
+++ b/Toggl.Droid/Resources/layout/MainLogCell.axml
@@ -35,13 +35,13 @@
         android:background="@color/playButtonRed"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/MainLogContentView"
         android:elevation="1dp"
         android:background="@android:color/white"
         android:layout_height="72dp"
         android:layout_width="match_parent">
-        <android.support.constraint.Guideline
+        <androidx.constraintlayout.widget.Guideline
             android:id="@+id/TopGuideline"
             android:orientation="horizontal"
             app:layout_constraintGuide_begin="0dp"
@@ -232,5 +232,5 @@
             app:layout_constraintBottom_toBottomOf="parent"
             android:layout_height="0.5dp"
             android:layout_width="match_parent" />
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/Toggl.Droid/Resources/layout/MainRunningTimeEntry.axml
+++ b/Toggl.Droid/Resources/layout/MainRunningTimeEntry.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -106,7 +106,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         android:layout_width="0dp"
         android:layout_height="0.5dp" />
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/MainStopButton"
         app:elevation="4dp"
         android:src="@drawable/stop_white"
@@ -117,4 +117,4 @@
         android:layout_height="56dp"
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Toggl.Droid/Resources/layout/MainSuggestions.axml
+++ b/Toggl.Droid/Resources/layout/MainSuggestions.axml
@@ -29,7 +29,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true" />
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SuggestionsRecyclerView"
         android:layout_marginTop="12dp"
         android:layout_marginLeft="16dp"

--- a/Toggl.Droid/Resources/layout/MainSuggestionsCard.axml
+++ b/Toggl.Droid/Resources/layout/MainSuggestionsCard.axml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:tools="http://schemas.android.com/tools"
+<androidx.cardview.widget.CardView xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     app:cardUseCompatPadding="true"
     android:layout_height="64dp"
     android:layout_width="match_parent"
     android:foreground="?attr/selectableItemBackground">
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/ViewLayout"
         android:layout_height="match_parent"
         android:layout_width="match_parent">
-        <android.support.constraint.Guideline
+        <androidx.constraintlayout.widget.Guideline
             app:layout_constraintGuide_percent="0.5"
             android:orientation="horizontal"
             android:layout_width="match_parent"
@@ -71,5 +71,5 @@
             android:layout_marginRight="12dp"
             android:layout_width="24dp"
             android:layout_height="24dp" />
-    </android.support.constraint.ConstraintLayout>
-</android.support.v7.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/Toggl.Droid/Resources/layout/MainTabBarActivity.axml
+++ b/Toggl.Droid/Resources/layout/MainTabBarActivity.axml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -17,7 +17,7 @@
             app:layout_constraintEnd_toEndOf="parent">
     </FrameLayout>
     
-    <android.support.design.widget.BottomNavigationView
+    <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/MainTabBarBottomNavigationView"
         android:background="@android:color/white"
         android:layout_width="0dp"
@@ -31,4 +31,4 @@
         app:labelVisibilityMode="labeled"
         app:menu="@menu/maintabbarbottommenu"/>
     
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Toggl.Droid/Resources/layout/MainUserFeedbackCard.axml
+++ b/Toggl.Droid/Resources/layout/MainUserFeedbackCard.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<androidx.cardview.widget.CardView
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -9,20 +9,20 @@
     android:layout_marginRight="16dp"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_gravity="center"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:layout_height="wrap_content"
         android:layout_width="match_parent">
 
-        <android.support.constraint.Group
+        <androidx.constraintlayout.widget.Group
             android:id="@+id/QuestionView"
             android:visibility="gone"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="UserFeedbackTitle,UserFeedbackThumbsUp,UserFeedbackThumbsDown,UserFeedbackThumbsUpText,UserFeedbackThumbsDownText" />
-        <android.support.constraint.Group
+        <androidx.constraintlayout.widget.Group
             android:id="@+id/ImpressionView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -173,5 +173,5 @@
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             tools:text="Later" />
-    </android.support.constraint.ConstraintLayout>
-</android.support.v7.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/Toggl.Droid/Resources/layout/NoWorkspaceFragment.axml
+++ b/Toggl.Droid/Resources/layout/NoWorkspaceFragment.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
@@ -98,4 +98,4 @@
         android:layout_marginRight="12dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Toggl.Droid/Resources/layout/OutdatedAppActivity.axml
+++ b/Toggl.Droid/Resources/layout/OutdatedAppActivity.axml
@@ -6,7 +6,7 @@
     android:background="#D2D2D3"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         app:cardUseCompatPadding="true"
         android:background="@android:color/white"
         android:layout_gravity="center"
@@ -72,5 +72,5 @@
                 android:layout_marginRight="8dp"
                 android:layout_gravity="bottom|end" />
         </FrameLayout>
-    </android.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 </FrameLayout>

--- a/Toggl.Droid/Resources/layout/ReportsCalendarView.axml
+++ b/Toggl.Droid/Resources/layout/ReportsCalendarView.axml
@@ -81,12 +81,12 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent" />
     </LinearLayout>
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
             android:id="@+id/ReportsCalendarFragmentViewPager"
             android:minHeight="225dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/ReportsCalendarFragmentShortcuts"
             android:scrollbars="vertical"
             android:layout_marginTop="16dp"

--- a/Toggl.Droid/Resources/layout/ReportsFragment.axml
+++ b/Toggl.Droid/Resources/layout/ReportsFragment.axml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/ReportsFragmentRecyclerView"
         android:scrollbars="none"
         android:paddingBottom="64dp"
@@ -13,12 +13,12 @@
         android:layout_marginTop="?attr/actionBarSize"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/AppBarLayout"
         android:elevation="0dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/Toolbar"
             android:minHeight="?attr/actionBarSize"
             android:background="@color/defaultBackground"
@@ -40,9 +40,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="start|center_vertical" />
-        </android.support.v7.widget.Toolbar>
-    </android.support.design.widget.AppBarLayout>
-    <android.support.design.widget.FloatingActionButton
+        </androidx.appcompat.widget.Toolbar>
+    </com.google.android.material.appbar.AppBarLayout>
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/SelectWorkspaceFAB"
         app:elevation="4dp"
         android:src="@drawable/workspace_white"
@@ -52,4 +52,4 @@
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp"
         android:layout_gravity="bottom|right" />
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/ReportsFragmentHeader.axml
+++ b/Toggl.Droid/Resources/layout/ReportsFragmentHeader.axml
@@ -6,7 +6,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:id="@+id/SummaryCard"
         android:elevation="2dp"
         app:cardBackgroundColor="@android:color/white"
@@ -17,10 +17,10 @@
         android:layout_marginRight="16dp"
         android:layout_marginBottom="24dp"
         android:layout_width="match_parent">
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-            <android.support.constraint.Guideline
+            <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/ReportsSummaryCenterView"
                 android:orientation="vertical"
                 app:layout_constraintGuide_percent="0.5"
@@ -100,13 +100,13 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
             </FrameLayout>
-        </android.support.constraint.ConstraintLayout>
-    </android.support.v7.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.CardView
+        <androidx.cardview.widget.CardView
             android:id="@+id/BarChartCard"
             android:elevation="2dp"
             app:cardBackgroundColor="@android:color/white"
@@ -115,7 +115,7 @@
             android:layout_marginBottom="24dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
-            <android.support.constraint.ConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 tools:context=".MainActivity"
                 android:layout_height="286dp"
                 android:layout_width="match_parent">
@@ -181,7 +181,7 @@
                     android:layout_marginRight="12dp"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />
-                <android.support.constraint.Group
+                <androidx.constraintlayout.widget.Group
                     android:id="@+id/WorkspaceBillableGroup"
                     app:constraint_referenced_ids="BillableDot,BillableText,NonBillableDot,NonBillableText"
                     android:layout_width="wrap_content"
@@ -194,9 +194,9 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     android:layout_height="228dp"
                     android:layout_width="match_parent" />
-            </android.support.constraint.ConstraintLayout>
-        </android.support.v7.widget.CardView>
-        <android.support.v7.widget.CardView
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.cardview.widget.CardView>
+        <androidx.cardview.widget.CardView
             android:id="@+id/PieChartCard"
             android:elevation="2dp"
             android:layout_marginLeft="16dp"
@@ -216,7 +216,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
             </FrameLayout>
-        </android.support.v7.widget.CardView>
+        </androidx.cardview.widget.CardView>
         <LinearLayout
             android:id="@+id/EmptyStateView"
             android:gravity="center"

--- a/Toggl.Droid/Resources/layout/ReportsFragmentItem.axml
+++ b/Toggl.Droid/Resources/layout/ReportsFragmentItem.axml
@@ -5,7 +5,7 @@
     android:layout_height="48dp"
     android:layout_marginTop="-2dp"
     android:layout_width="match_parent">
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:elevation="2dp"
         app:cardCornerRadius="2dp"
         app:cardBackgroundColor="@android:color/white"
@@ -80,5 +80,5 @@
                 android:layout_centerVertical="true"
                 android:layout_toLeftOf="@+id/ReportsFragmentItemDuration" />
         </RelativeLayout>
-    </android.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 </FrameLayout>

--- a/Toggl.Droid/Resources/layout/SelectBeginningOfWeekFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectBeginningOfWeekFragment.axml
@@ -15,7 +15,7 @@
         android:layout_margin="24dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/DaysListRecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"

--- a/Toggl.Droid/Resources/layout/SelectClientActivity.axml
+++ b/Toggl.Droid/Resources/layout/SelectClientActivity.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
@@ -38,10 +38,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical" />
     </LinearLayout>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectClientRecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize" />
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/SelectColorFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectColorFragment.axml
@@ -16,7 +16,7 @@
         android:layout_margin="24dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectColorRecyclerView"
         android:scrollbars="vertical"
         android:layout_height="146dp"

--- a/Toggl.Droid/Resources/layout/SelectCountryActivity.axml
+++ b/Toggl.Droid/Resources/layout/SelectCountryActivity.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:background="@android:color/white"
     android:layout_width="match_parent"
@@ -32,10 +32,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical" />
     </LinearLayout>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/RecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize" />
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/SelectDateFormatFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectDateFormatFragment.axml
@@ -15,7 +15,7 @@
         android:layout_margin="24dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectDateFormatRecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"

--- a/Toggl.Droid/Resources/layout/SelectDefaultWorkspaceFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectDefaultWorkspaceFragment.axml
@@ -29,7 +29,7 @@
         android:layout_marginBottom="12dp"
         android:layout_marginLeft="24dp"
         android:layout_marginRight="24dp"/>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectDefaultWorkspaceRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/Toggl.Droid/Resources/layout/SelectDurationFormatFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectDurationFormatFragment.axml
@@ -16,7 +16,7 @@
         android:layout_height="76dp"
         android:layout_marginLeft="24dp"
         android:layout_width="wrap_content" />
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectDurationFormatRecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"

--- a/Toggl.Droid/Resources/layout/SelectProjectActivity.axml
+++ b/Toggl.Droid/Resources/layout/SelectProjectActivity.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
@@ -38,10 +38,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical" />
     </LinearLayout>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/RecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?attr/actionBarSize" />
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/SelectTagsActivity.axml
+++ b/Toggl.Droid/Resources/layout/SelectTagsActivity.axml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -61,10 +61,10 @@
             android:layout_height="56dp"
             android:layout_alignParentRight="true" />
     </RelativeLayout>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectTagsRecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?android:attr/actionBarSize" />
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/SelectUserCalendarsBase.axml
+++ b/Toggl.Droid/Resources/layout/SelectUserCalendarsBase.axml
@@ -38,7 +38,7 @@
         android:layout_height="0.5dp"
         android:layout_marginTop="16dp"
         android:background="@color/separator"/>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/CalendarsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/Toggl.Droid/Resources/layout/SelectWorkspaceFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectWorkspaceFragment.axml
@@ -15,7 +15,7 @@
         android:layout_margin="24dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SelectWorkspaceRecyclerView"
         android:scrollbars="vertical"
         android:layout_width="match_parent"

--- a/Toggl.Droid/Resources/layout/SendFeedbackActivity.axml
+++ b/Toggl.Droid/Resources/layout/SendFeedbackActivity.axml
@@ -5,18 +5,18 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/Toolbar"
             android:background="@color/defaultBackground"
             app:popupTheme="@style/ThemeOverlay.AppCompat"
             android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize" />
-    </android.support.design.widget.AppBarLayout>
-    <android.support.v7.widget.CardView
+    </com.google.android.material.appbar.AppBarLayout>
+    <androidx.cardview.widget.CardView
         android:id="@+id/ErrorCard"
         android:minHeight="70dp"
         android:visibility="gone"
@@ -27,7 +27,7 @@
         android:layout_marginRight="10dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:minHeight="70dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
@@ -75,8 +75,8 @@
                 android:layout_marginBottom="8dp"
                 android:layout_marginStart="10dp"
                 android:layout_height="wrap_content" />
-        </android.support.constraint.ConstraintLayout>
-    </android.support.v7.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
     <TextView
         android:id="@+id/FeedbackHelperTitle"
         android:textSize="16sp"
@@ -95,13 +95,13 @@
         android:layout_marginTop="20dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:layout_marginTop="20dp"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/FeedbackEditText"
             android:textSize="16sp"
             android:imeOptions="actionSend"
@@ -110,5 +110,5 @@
             tools:text="You are so nice! Thanks for everything guys!"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 </LinearLayout>

--- a/Toggl.Droid/Resources/layout/SettingsFragment.axml
+++ b/Toggl.Droid/Resources/layout/SettingsFragment.axml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v4.widget.NestedScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/ScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -322,7 +322,7 @@
                 android:layout_height="0.5dp"
                 android:layout_marginTop="24dp"
                 android:layout_width="match_parent" />
-            <android.support.constraint.ConstraintLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/SettingsToggleManualModeView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -365,7 +365,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@+id/SettingsToggleManualModeLabel"
                     app:layout_constraintTop_toBottomOf="@+id/SettingsIsManualModeEnabledSwitch" />
-            </android.support.constraint.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
             <View
                 android:background="@color/separator"
                 android:layout_height="0.5dp"
@@ -601,13 +601,13 @@
                 android:layout_marginBottom="24dp"
                 android:layout_width="match_parent" />
         </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
-  <android.support.design.widget.AppBarLayout
+    </androidx.core.widget.NestedScrollView>
+  <com.google.android.material.appbar.AppBarLayout
       android:id="@+id/AppBarLayout"
       android:elevation="0dp"
       android:layout_width="match_parent"
       android:layout_height="wrap_content">
-      <android.support.v7.widget.Toolbar
+      <androidx.appcompat.widget.Toolbar
           android:id="@+id/Toolbar"
           android:minHeight="?attr/actionBarSize"
           android:background="@color/defaultBackground"
@@ -617,5 +617,5 @@
           android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
           android:layout_width="match_parent"
           android:layout_height="wrap_content" />
-  </android.support.design.widget.AppBarLayout>
-</android.support.design.widget.CoordinatorLayout>
+  </com.google.android.material.appbar.AppBarLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/SignUpActivity.axml
+++ b/Toggl.Droid/Resources/layout/SignUpActivity.axml
@@ -60,7 +60,7 @@
                 android:layout_marginBottom="36dp"
                 android:layout_centerHorizontal="true"
                 android:layout_below="@id/SignUpCountrySelection" />
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/SignUpEmail"
                 tools:hint="Email"
                 android:layout_marginLeft="24dp"
@@ -75,8 +75,8 @@
                     android:backgroundTint="@color/textEditBackgroundTint"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
-            </android.support.design.widget.TextInputLayout>
-            <android.support.design.widget.TextInputLayout
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/SignUpPassword"
                 tools:hint="Password"
                 app:passwordToggleEnabled="true"
@@ -86,13 +86,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/SignUpEmail">
-                <android.support.design.widget.TextInputEditText
+                <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/SignUpPasswordEditText"
                     android:inputType="textPassword"
                     android:backgroundTint="@color/textEditBackgroundTint"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
             <TextView
                 android:id="@+id/SignUpError"
                 android:textSize="12sp"
@@ -184,7 +184,7 @@
             </LinearLayout>
         </RelativeLayout>
     </ScrollView>
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
         android:id="@+id/LoginSignupCardView"
         app:cardCornerRadius="8dp"
         android:layout_height="80dp"
@@ -193,7 +193,7 @@
         android:layout_marginRight="24dp"
         android:layout_marginBottom="-8dp"
         android:layout_width="match_parent">
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:background="@android:color/white"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -241,6 +241,6 @@
                 android:layout_height="72dp"
                 android:layout_marginBottom="4dp"
                 android:layout_marginRight="16dp" />
-        </android.support.constraint.ConstraintLayout>
-    </android.support.v7.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
 </FrameLayout>

--- a/Toggl.Droid/Resources/layout/StartTimeEntryActivity.axml
+++ b/Toggl.Droid/Resources/layout/StartTimeEntryActivity.axml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:importantForAutofill="noExcludeDescendants">
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/SuggestionsRecyclerView"
         tools:visibility="gone"
         android:scrollbars="vertical"
@@ -14,7 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="@dimen/expandedToolbarHeight" />
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/DurationCard"
         android:background="@android:color/white"
         android:layout_height="64dp"
@@ -84,7 +84,7 @@
                 android:layout_width="40dp"
                 android:layout_height="match_parent"/>
         </LinearLayout>
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
     <RelativeLayout
         android:id="@+id/Toolbar"
         android:elevation="4dp"
@@ -129,4 +129,4 @@
             android:layout_width="wrap_content"
             android:layout_alignParentEnd="true" />
     </RelativeLayout>
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Toggl.Droid/Resources/layout/TokenResetActivity.axml
+++ b/Toggl.Droid/Resources/layout/TokenResetActivity.axml
@@ -7,14 +7,14 @@
     android:animateLayoutChanges="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/Toolbar"
         android:minHeight="?attr/actionBarSize"
         app:popupTheme="@style/ThemeOverlay.AppCompat"
         android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/TokenResetPasswordLayout"
         tools:hint="Password"
         app:hintEnabled="false"
@@ -24,7 +24,7 @@
         android:layout_marginRight="50dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/TokenResetPassword"
             android:lines="1"
             android:maxLines="1"
@@ -39,7 +39,7 @@
             android:background="@android:color/transparent"
             android:layout_height="30dp"
             android:layout_width="match_parent" />
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
     <ProgressBar
         android:id="@+id/TokenResetProgressBar"
         style="?android:attr/progressBarStyleLarge"
@@ -94,7 +94,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentLeft="true"
         android:layout_alignParentBottom="true" />
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/TokenResetDoneButton"
         app:elevation="4dp"
         app:borderWidth="0dp"

--- a/Toggl.Droid/Resources/layout/UpcomingEventsNotificationSettingsFragment.axml
+++ b/Toggl.Droid/Resources/layout/UpcomingEventsNotificationSettingsFragment.axml
@@ -37,7 +37,7 @@
         android:layout_height="1dp"
         android:layout_marginTop="16dp"
         android:background="@color/placeholderText"/>
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/CalendarsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/Toggl.Droid/Resources/values/Styles.xml
+++ b/Toggl.Droid/Resources/values/Styles.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <resources>
-    <style name="Theme.Splash" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Theme.Splash" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowBackground">@drawable/Splash</item>
     </style>
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <item name="android:actionBarSize">56dp</item>
         <item name="android:colorAccent">#328FFF</item>
         <item name="colorControlActivated">#328FFF</item>

--- a/Toggl.Droid/Toggl.Droid.csproj
+++ b/Toggl.Droid/Toggl.Droid.csproj
@@ -1,4 +1,5 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.props" Condition="Exists('..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.props')" />
   <Import Project="..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.props" Condition="Exists('..\packages\Xamarin.Build.Download.0.4.11\build\Xamarin.Build.Download.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -46,7 +47,6 @@
     <AndroidSigningStorePass>{KEYSTORE_PASSWORD}</AndroidSigningStorePass>
     <AndroidSigningKeyAlias>{KEYSTORE_ALIAS}</AndroidSigningKeyAlias>
     <AndroidSigningKeyPass>{KEYSTORE_ALIAS_PASSWORD}</AndroidSigningKeyPass>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release.PlayStore|AnyCPU' ">
     <Optimize>false</Optimize>
@@ -164,8 +164,176 @@
     <Reference Include="Xamarin.Android.Support.Constraint.Layout.Solver, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Xamarin.Android.Support.Constraint.Layout.Solver.1.1.0\lib\MonoAndroid70\Xamarin.Android.Support.Constraint.Layout.Solver.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.AndroidX.Annotation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Annotation.1.0.2-preview02\lib\monoandroid90\Xamarin.AndroidX.Annotation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.AppCompat, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.AppCompat.1.0.2-preview02\lib\monoandroid90\Xamarin.AndroidX.AppCompat.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Arch.Core.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Arch.Core.Common.2.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.Arch.Core.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Arch.Core.Runtime, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Arch.Core.Runtime.2.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.Arch.Core.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.AsyncLayoutInflater, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.AsyncLayoutInflater.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.AsyncLayoutInflater.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Browser, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Browser.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Browser.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.CardView, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.CardView.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.CardView.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Collection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Collection.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Collection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.ConstraintLayout, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.ConstraintLayout.1.1.3-preview02\lib\monoandroid90\Xamarin.AndroidX.ConstraintLayout.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.ConstraintLayout.Solver, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.ConstraintLayout.Solver.1.1.3-preview02\lib\monoandroid90\Xamarin.AndroidX.ConstraintLayout.Solver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.CoordinatorLayout, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.CoordinatorLayout.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.CoordinatorLayout.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Core.1.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.CursorAdapter, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.CursorAdapter.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.CursorAdapter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.CustomView, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.CustomView.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.CustomView.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.DocumentFile, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.DocumentFile.1.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.DocumentFile.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.DrawerLayout, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.DrawerLayout.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.DrawerLayout.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Fragment, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Fragment.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Fragment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Interpolator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Interpolator.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Interpolator.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Legacy.Support.Core.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Legacy.Support.Core.Utils, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Legacy.Support.Core.Utils.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.Utils.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.Common.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.Common.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.Extensions.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.LiveData, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.LiveData.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.LiveData.Core.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.Process, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.Process.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.Process.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.Runtime, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.Runtime.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.Service, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.Service.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.Service.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Lifecycle.ViewModel, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Lifecycle.ViewModel.2.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Lifecycle.ViewModel.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Loader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Loader.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Loader.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.LocalBroadcastManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.LocalBroadcastManager.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.LocalBroadcastManager.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Media, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Media.1.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.Media.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.MultiDex, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.MultiDex.2.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.MultiDex.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Print, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Print.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.Print.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.RecyclerView, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.RecyclerView.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.RecyclerView.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.SlidingPaneLayout, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.SlidingPaneLayout.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.SlidingPaneLayout.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.SwipeRefreshLayout, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.SwipeRefreshLayout.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.SwipeRefreshLayout.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.Transition, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.Transition.1.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.Transition.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.VectorDrawable, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.VectorDrawable.1.0.1-preview02\lib\monoandroid90\Xamarin.AndroidX.VectorDrawable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.VectorDrawable.Animated, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.VectorDrawable.Animated.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.VectorDrawable.Animated.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.VersionedParcelable, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.VersionedParcelable.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.VersionedParcelable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.AndroidX.ViewPager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.AndroidX.ViewPager.1.0.0-preview02\lib\monoandroid90\Xamarin.AndroidX.ViewPager.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Xamarin.Firebase.Messaging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\Xamarin.Firebase.Messaging.60.1142.1\lib\MonoAndroid80\Xamarin.Firebase.Messaging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Xamarin.Google.Android.Material, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\Xamarin.Google.Android.Material.1.0.0-preview02\lib\monoandroid90\Xamarin.Google.Android.Material.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Basement">
@@ -1248,7 +1416,94 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.MultiDex.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.MultiDex.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Annotation.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.Annotation.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Annotation.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.Annotation.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Arch.Core.Common.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Arch.Core.Common.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Common.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Collection.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Collection.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Collection.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Collection.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.Common.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Common.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.Common.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Common.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.Runtime.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Runtime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.Runtime.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Runtime.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.VersionedParcelable.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VersionedParcelable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.VersionedParcelable.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VersionedParcelable.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Core.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Core.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.CustomView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CustomView.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.CustomView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CustomView.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.CardView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CardView.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.CardView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CardView.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Arch.Core.Runtime.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Runtime.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Arch.Core.Runtime.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Runtime.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.CursorAdapter.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CursorAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.CursorAdapter.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CursorAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.DocumentFile.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.DocumentFile.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.DocumentFile.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.DocumentFile.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Interpolator.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Interpolator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Interpolator.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Interpolator.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.LiveData.Core.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.LiveData.Core.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.LiveData.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.LiveData.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.ViewModel.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.ViewModel.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.ViewModel.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.ViewModel.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.LocalBroadcastManager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.LocalBroadcastManager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.LocalBroadcastManager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.LocalBroadcastManager.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Print.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Print.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Print.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Print.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.AsyncLayoutInflater.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.AsyncLayoutInflater.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.AsyncLayoutInflater.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.AsyncLayoutInflater.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.CoordinatorLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CoordinatorLayout.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.CoordinatorLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CoordinatorLayout.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.DrawerLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.DrawerLayout.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.DrawerLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.DrawerLayout.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Loader.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Loader.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Loader.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Legacy.Support.Core.Utils.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.Utils.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Legacy.Support.Core.Utils.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.Utils.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.SlidingPaneLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SlidingPaneLayout.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.SlidingPaneLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SlidingPaneLayout.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.SwipeRefreshLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SwipeRefreshLayout.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.SwipeRefreshLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SwipeRefreshLayout.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.ViewPager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.ViewPager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.ViewPager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.ViewPager.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Fragment.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Fragment.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Fragment.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Fragment.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.VectorDrawable.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.VectorDrawable.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.VectorDrawable.Animated.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.Animated.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.VectorDrawable.Animated.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.Animated.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.AppCompat.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.AppCompat.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.AppCompat.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.AppCompat.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Browser.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Browser.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Browser.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Browser.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.ConstraintLayout.Solver.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.Solver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.ConstraintLayout.Solver.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.Solver.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.ConstraintLayout.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.ConstraintLayout.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.RecyclerView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.RecyclerView.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.RecyclerView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.RecyclerView.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Transition.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Transition.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Transition.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Transition.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Media.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Media.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Media.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Media.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.Google.Android.Material.1.0.0-preview02\build\monoandroid90\Xamarin.Google.Android.Material.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.Google.Android.Material.1.0.0-preview02\build\monoandroid90\Xamarin.Google.Android.Material.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.Process.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Process.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.Process.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Process.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.Service.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Service.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.Service.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Service.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Lifecycle.Extensions.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Extensions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Lifecycle.Extensions.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Extensions.targets'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.props'))" />
+    <Error Condition="!Exists('..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.targets'))" />
   </Target>
   <Import Project="..\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets" Condition="Exists('..\packages\Xamarin.Firebase.Messaging.60.1142.1\build\MonoAndroid80\Xamarin.Firebase.Messaging.targets')" />
   <Import Project="..\packages\Xamarin.Android.Arch.Lifecycle.Extensions.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Extensions.targets" Condition="Exists('..\packages\Xamarin.Android.Arch.Lifecycle.Extensions.1.1.1.1\build\monoandroid90\Xamarin.Android.Arch.Lifecycle.Extensions.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.MultiDex.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets" Condition="Exists('..\packages\Xamarin.AndroidX.MultiDex.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.MultiDex.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Annotation.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.Annotation.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Annotation.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.Annotation.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Arch.Core.Common.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Common.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Arch.Core.Common.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Common.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Collection.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Collection.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Collection.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Collection.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.Common.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Common.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.Common.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Common.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.Runtime.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Runtime.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.Runtime.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Runtime.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.VersionedParcelable.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VersionedParcelable.targets" Condition="Exists('..\packages\Xamarin.AndroidX.VersionedParcelable.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VersionedParcelable.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Core.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Core.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Core.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Core.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.CustomView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CustomView.targets" Condition="Exists('..\packages\Xamarin.AndroidX.CustomView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CustomView.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.CardView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CardView.targets" Condition="Exists('..\packages\Xamarin.AndroidX.CardView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CardView.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Arch.Core.Runtime.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Runtime.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Arch.Core.Runtime.2.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Arch.Core.Runtime.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.CursorAdapter.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CursorAdapter.targets" Condition="Exists('..\packages\Xamarin.AndroidX.CursorAdapter.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CursorAdapter.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.DocumentFile.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.DocumentFile.targets" Condition="Exists('..\packages\Xamarin.AndroidX.DocumentFile.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.DocumentFile.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Interpolator.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Interpolator.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Interpolator.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Interpolator.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.LiveData.Core.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.Core.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.LiveData.Core.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.Core.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.LiveData.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.LiveData.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.LiveData.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.ViewModel.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.ViewModel.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.ViewModel.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.ViewModel.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.LocalBroadcastManager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.LocalBroadcastManager.targets" Condition="Exists('..\packages\Xamarin.AndroidX.LocalBroadcastManager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.LocalBroadcastManager.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Print.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Print.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Print.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Print.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.AsyncLayoutInflater.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.AsyncLayoutInflater.targets" Condition="Exists('..\packages\Xamarin.AndroidX.AsyncLayoutInflater.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.AsyncLayoutInflater.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.CoordinatorLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CoordinatorLayout.targets" Condition="Exists('..\packages\Xamarin.AndroidX.CoordinatorLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.CoordinatorLayout.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.DrawerLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.DrawerLayout.targets" Condition="Exists('..\packages\Xamarin.AndroidX.DrawerLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.DrawerLayout.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Loader.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Loader.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Loader.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Loader.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Legacy.Support.Core.Utils.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.Utils.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Legacy.Support.Core.Utils.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.Utils.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.SlidingPaneLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SlidingPaneLayout.targets" Condition="Exists('..\packages\Xamarin.AndroidX.SlidingPaneLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SlidingPaneLayout.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.SwipeRefreshLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SwipeRefreshLayout.targets" Condition="Exists('..\packages\Xamarin.AndroidX.SwipeRefreshLayout.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.SwipeRefreshLayout.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.ViewPager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.ViewPager.targets" Condition="Exists('..\packages\Xamarin.AndroidX.ViewPager.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.ViewPager.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Legacy.Support.Core.UI.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Legacy.Support.Core.UI.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Fragment.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Fragment.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Fragment.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Fragment.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.VectorDrawable.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.targets" Condition="Exists('..\packages\Xamarin.AndroidX.VectorDrawable.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.VectorDrawable.Animated.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.Animated.targets" Condition="Exists('..\packages\Xamarin.AndroidX.VectorDrawable.Animated.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.VectorDrawable.Animated.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.AppCompat.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.AppCompat.targets" Condition="Exists('..\packages\Xamarin.AndroidX.AppCompat.1.0.2-preview02\build\monoandroid90\Xamarin.AndroidX.AppCompat.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Browser.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Browser.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Browser.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Browser.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.ConstraintLayout.Solver.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.Solver.targets" Condition="Exists('..\packages\Xamarin.AndroidX.ConstraintLayout.Solver.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.Solver.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.ConstraintLayout.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.targets" Condition="Exists('..\packages\Xamarin.AndroidX.ConstraintLayout.1.1.3-preview02\build\monoandroid90\Xamarin.AndroidX.ConstraintLayout.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.RecyclerView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.RecyclerView.targets" Condition="Exists('..\packages\Xamarin.AndroidX.RecyclerView.1.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.RecyclerView.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Transition.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Transition.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Transition.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Transition.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Media.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Media.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Media.1.0.1-preview02\build\monoandroid90\Xamarin.AndroidX.Media.targets')" />
+  <Import Project="..\packages\Xamarin.Google.Android.Material.1.0.0-preview02\build\monoandroid90\Xamarin.Google.Android.Material.targets" Condition="Exists('..\packages\Xamarin.Google.Android.Material.1.0.0-preview02\build\monoandroid90\Xamarin.Google.Android.Material.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.Process.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Process.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.Process.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Process.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.Service.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Service.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.Service.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Service.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Lifecycle.Extensions.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Extensions.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Lifecycle.Extensions.2.0.0-preview02\build\monoandroid90\Xamarin.AndroidX.Lifecycle.Extensions.targets')" />
+  <Import Project="..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.targets" Condition="Exists('..\packages\Xamarin.AndroidX.Migration.1.0.0-preview03\build\Xamarin.AndroidX.Migration.targets')" />
 </Project>

--- a/Toggl.Droid/packages.config
+++ b/Toggl.Droid/packages.config
@@ -116,6 +116,48 @@
   <package id="Xamarin.Android.Support.Vector.Drawable" version="28.0.0.1" targetFramework="monoandroid90" />
   <package id="Xamarin.Android.Support.VersionedParcelable" version="28.0.0.1" targetFramework="monoandroid90" />
   <package id="Xamarin.Android.Support.ViewPager" version="28.0.0.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Annotation" version="1.0.2-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.AppCompat" version="1.0.2-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Arch.Core.Common" version="2.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Arch.Core.Runtime" version="2.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.AsyncLayoutInflater" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Browser" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.CardView" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Collection" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.ConstraintLayout" version="1.1.3-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.ConstraintLayout.Solver" version="1.1.3-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.CoordinatorLayout" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Core" version="1.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.CursorAdapter" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.CustomView" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.DocumentFile" version="1.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.DrawerLayout" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Fragment" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Interpolator" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Legacy.Support.Core.UI" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Legacy.Support.Core.Utils" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.Common" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.Extensions" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.LiveData" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.LiveData.Core" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.Process" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.Runtime" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.Service" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Lifecycle.ViewModel" version="2.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Loader" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.LocalBroadcastManager" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Media" version="1.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Migration" version="1.0.0-preview03" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.MultiDex" version="2.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Print" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.RecyclerView" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.SlidingPaneLayout" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.SwipeRefreshLayout" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.Transition" version="1.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.VectorDrawable" version="1.0.1-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.VectorDrawable.Animated" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.VersionedParcelable" version="1.0.0-preview02" targetFramework="monoandroid90" />
+  <package id="Xamarin.AndroidX.ViewPager" version="1.0.0-preview02" targetFramework="monoandroid90" />
   <package id="Xamarin.Build.Download" version="0.4.11" targetFramework="monoandroid81" />
   <package id="Xamarin.Essentials" version="1.0.0" targetFramework="monoandroid90" />
   <package id="Xamarin.Firebase.Analytics" version="60.1142.1" targetFramework="monoandroid81" />
@@ -124,6 +166,7 @@
   <package id="Xamarin.Firebase.Config" version="60.1142.1" targetFramework="monoandroid90" />
   <package id="Xamarin.Firebase.Iid" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.Firebase.Messaging" version="60.1142.1" targetFramework="monoandroid90" />
+  <package id="Xamarin.Google.Android.Material" version="1.0.0-preview02" targetFramework="monoandroid90" />
   <package id="Xamarin.GooglePlayServices.Auth" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.GooglePlayServices.Auth.Api.Phone" version="60.1142.1" targetFramework="monoandroid81" />
   <package id="Xamarin.GooglePlayServices.Auth.Base" version="60.1142.1" targetFramework="monoandroid81" />


### PR DESCRIPTION
<!-- This template is a guideline, use your own judgement to write a description that is easy to read and will help get the PR reviewed quickly and accurately -->

## What's this?
<!-- Describe clearly and concisely what this PR changes -->
First attempt to migrate to Androidx and material design components under Xamarin's rule. 
Result: Tt won't build anymore - see these errors for yourself. 

### Relationships
<!-- Mention any issues or PRs that are connected to this -->

Closes #5700
Closes #5829

## Why do we want this?
<!-- Describe the reason for making this change -->
We want to use the latest and greatest from google in the future. 

## How is it done?
<!-- Describe how the changes are implemented, list the different parts the changes consist of if it's more than one -->
- basically I followed these steps https://devblogs.microsoft.com/xamarin/androidx-for-xamarin/
- refactored all of our layouts to use material design component or androidx 
- updated our theme to Material.Bridge theme

### Why not another way?
<!-- Are there other possible solutions that might seem more obvious? Tell us why you didn't go with those -->
Feel free to suggest any

### Side effects
<!-- If there are (possible) side effects, something left unfinished or otherwise affected -->
I'm not able to build the project anymore.

## :squid: Permissions
<!-- Is anybody else allowed to merge this? If so, who? -->
Whoever can fix this