### PR TITLE
Fix an autocomplete-autocorrect clash

### DIFF
--- a/Toggl.iOS/Extensions/TextViewExtensions.cs
+++ b/Toggl.iOS/Extensions/TextViewExtensions.cs
@@ -1,0 +1,28 @@
+using CoreGraphics;
+using Foundation;
+using UIKit;
+
+namespace Toggl.iOS.Extensions
+{
+    public static class TextViewExtensions
+    {
+        public static void rejectAutocorrect(this UITextView textView)
+        {
+            var originalText = textView.Text;
+            NSRange originalRange = textView.SelectedRange;
+            CGPoint originalOffset = textView.ContentOffset;
+
+            //Force any pending autocorrection to be applied
+            textView.ResignFirstResponder();
+            textView.BecomeFirstResponder();
+
+            string finalText = textView.Text;
+            if (originalText != finalText)
+            {
+                textView.Text = originalText;
+                textView.SelectedRange = originalRange;
+                textView.SetContentOffset(originalOffset, false);
+            }
+        }
+    }
+}

--- a/Toggl.iOS/Extensions/TextViewExtensions.cs
+++ b/Toggl.iOS/Extensions/TextViewExtensions.cs
@@ -6,7 +6,7 @@ namespace Toggl.iOS.Extensions
 {
     public static class TextViewExtensions
     {
-        public static void rejectAutocorrect(this UITextView textView)
+        public static void RejectAutocorrect(this UITextView textView)
         {
             var originalText = textView.Text;
             NSRange originalRange = textView.SelectedRange;

--- a/Toggl.iOS/Toggl.iOS.csproj
+++ b/Toggl.iOS/Toggl.iOS.csproj
@@ -1975,6 +1975,7 @@
     </Compile>
     <Compile Include="ViewSources\Generic\Common\SelectorTableViewSource.cs" />
     <Compile Include="Helper\Handoff.cs" />
+    <Compile Include="Extensions\TextViewExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Toggl.Core.UI\Toggl.Core.UI.csproj">

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -26,7 +26,6 @@ namespace Toggl.iOS.ViewControllers
     public sealed partial class StartTimeEntryViewController : KeyboardAwareViewController<StartTimeEntryViewModel>
     {
         private const double desiredIpadHeight = 360;
-        private const string autocorrectPromptClassName = "UIAutocorrectInlinePrompt";
 
         private bool isUpdatingDescriptionField;
 
@@ -213,16 +212,7 @@ namespace Toggl.iOS.ViewControllers
             DescriptionTextView.InputDelegate = emptyInputDelegate;
             DescriptionTextView.AttributedText = attributedText;
 
-            // This line is needed for when the user selects from suggestion and
-            // the iOS autocorrect is ready to add text at the same time too.
-            // Without this the little selection will persist even after the
-            // suggestion has been selected
-            foreach (var view in DescriptionTextView.Subviews)
-                if (view.Class.Name == autocorrectPromptClassName)
-                {
-                    view.RemoveFromSuperview();
-                    break;
-                }
+            DescriptionTextView.rejectAutocorrect();
 
             updatePlaceholder();
         }

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -26,6 +26,7 @@ namespace Toggl.iOS.ViewControllers
     public sealed partial class StartTimeEntryViewController : KeyboardAwareViewController<StartTimeEntryViewModel>
     {
         private const double desiredIpadHeight = 360;
+        private const string autocorrectPromptClassName = "UIAutocorrectInlinePrompt";
 
         private bool isUpdatingDescriptionField;
 
@@ -217,7 +218,7 @@ namespace Toggl.iOS.ViewControllers
             // Without this the little selection will persist even after the
             // suggestion has been selected
             foreach (var view in DescriptionTextView.Subviews)
-                if (view.Class.Name == "UIAutocorrectInlinePrompt")
+                if (view.Class.Name == autocorrectPromptClassName)
                 {
                     view.RemoveFromSuperview();
                     break;

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -212,7 +212,7 @@ namespace Toggl.iOS.ViewControllers
             DescriptionTextView.InputDelegate = emptyInputDelegate;
             DescriptionTextView.AttributedText = attributedText;
 
-            DescriptionTextView.rejectAutocorrect();
+            DescriptionTextView.RejectAutocorrect();
 
             updatePlaceholder();
         }

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -209,6 +209,10 @@ namespace Toggl.iOS.ViewControllers
             DescriptionTextView.InputDelegate = emptyInputDelegate; //This line is needed for when the user selects from suggestion and the iOS autocorrect is ready to add text at the same time. Without this line both will happen.
             DescriptionTextView.AttributedText = attributedText;
 
+            foreach (UIView view in DescriptionTextView.Subviews) // This line is needed for when the user selects from suggestion and the iOS autocorrect is ready to add text at the same time too. Without this the little selection will persist even after the suggestion has been selected
+                if (view.Class.Name == "UIAutocorrectInlinePrompt")
+                    view.RemoveFromSuperview();
+
             updatePlaceholder();
         }
 

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -206,10 +206,17 @@ namespace Toggl.iOS.ViewControllers
             if (DescriptionTextView.AttributedText.GetHashCode() == attributedText.GetHashCode())
                 return;
 
-            DescriptionTextView.InputDelegate = emptyInputDelegate; //This line is needed for when the user selects from suggestion and the iOS autocorrect is ready to add text at the same time. Without this line both will happen.
+            //This line is needed for when the user selects from suggestion and
+            // the iOS autocorrect is ready to add text at the same time.
+            // Without this line both will happen.
+            DescriptionTextView.InputDelegate = emptyInputDelegate;
             DescriptionTextView.AttributedText = attributedText;
 
-            foreach (UIView view in DescriptionTextView.Subviews) // This line is needed for when the user selects from suggestion and the iOS autocorrect is ready to add text at the same time too. Without this the little selection will persist even after the suggestion has been selected
+            // This line is needed for when the user selects from suggestion and
+            // the iOS autocorrect is ready to add text at the same time too.
+            // Without this the little selection will persist even after the
+            // suggestion has been selected
+            foreach (var view in DescriptionTextView.Subviews)
                 if (view.Class.Name == "UIAutocorrectInlinePrompt")
                 {
                     view.RemoveFromSuperview();

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -211,7 +211,10 @@ namespace Toggl.iOS.ViewControllers
 
             foreach (UIView view in DescriptionTextView.Subviews) // This line is needed for when the user selects from suggestion and the iOS autocorrect is ready to add text at the same time too. Without this the little selection will persist even after the suggestion has been selected
                 if (view.Class.Name == "UIAutocorrectInlinePrompt")
+                {
                     view.RemoveFromSuperview();
+                    break;
+                }
 
             updatePlaceholder();
         }


### PR DESCRIPTION
## What's this?
A slightly unsightly fix to a little clash we had between our suggestions and iOS' autocomplete.

### Relationships
Closes #5662

## Why do we want this?
So things look spotless!

## How is it done?
By walking across all the subviews of `DescriptionTextView`, finding the offending `UIAutocorrectInlinePrompt` (which is defined in a runtime-only header) by classname, and removing it from the `DescriptionTextView`.

### Why not another way?
Looked at other options, but due to the runtime-only nature of `UIAutocorrectInlinePrompt` I can't come up with anything.

## Review hints
Reproduce the error from the source issue on `develop`, then here.

## :squid: Permissions
All yours!