### PR TITLE
Disable background sync for Android 10

### DIFF
--- a/Toggl.Droid/Services/BackgroundSyncJobSchedulerService.cs
+++ b/Toggl.Droid/Services/BackgroundSyncJobSchedulerService.cs
@@ -2,6 +2,7 @@
 using Android.App.Job;
 using System;
 using System.Reactive.Linq;
+using Toggl.Droid.Helper;
 using static Toggl.Shared.Extensions.CommonFunctions;
 
 namespace Toggl.Droid.Services
@@ -17,6 +18,14 @@ namespace Toggl.Droid.Services
 
         public override bool OnStartJob(JobParameters @params)
         {
+            // Background sync is temporary disabled due to a crash on Android 10 that is hard to reproduce
+            // Calling JobFinished and returning early here stops the background job from running
+            if (QApis.AreAvailable)
+            {
+                JobFinished(@params, false);
+                return true;
+            }
+
             AndroidDependencyContainer.EnsureInitialized(ApplicationContext);
             var dependencyContainer = AndroidDependencyContainer.Instance;
             if (!dependencyContainer.UserAccessManager.CheckIfLoggedIn())

--- a/Toggl.Droid/Services/BackgroundSyncJobSchedulerService.cs
+++ b/Toggl.Droid/Services/BackgroundSyncJobSchedulerService.cs
@@ -23,7 +23,7 @@ namespace Toggl.Droid.Services
             if (QApis.AreAvailable)
             {
                 JobFinished(@params, false);
-                return true;
+                return false;
             }
 
             AndroidDependencyContainer.EnsureInitialized(ApplicationContext);

--- a/Toggl.Droid/Services/BackgroundSyncServiceAndroid.cs
+++ b/Toggl.Droid/Services/BackgroundSyncServiceAndroid.cs
@@ -3,6 +3,7 @@ using Android.App.Job;
 using Android.Content;
 using Toggl.Core.Services;
 using Toggl.Droid.Extensions;
+using Toggl.Droid.Helper;
 
 namespace Toggl.Droid.Services
 {
@@ -10,6 +11,13 @@ namespace Toggl.Droid.Services
     {
         public override void EnableBackgroundSync()
         {
+            // Background sync is temporary disabled for android 10 due to a crash that is hard to reproduce
+            if (QApis.AreAvailable)
+            {
+                DisableBackgroundSync();
+                return;
+            }
+
             var context = Application.Context;
             var jobScheduler = (JobScheduler)context.GetSystemService(Context.JobSchedulerService);
             var periodicity = (long)MinimumBackgroundFetchInterval.TotalMilliseconds;


### PR DESCRIPTION
## What's this?
This disables background sync again, but this time only on Android 10 ( I guess we can call this a progress) 

### Relationships

Closes #6040

## Why do we want this?
We don't want background sync related crashes on Android 10 devices

## How is it done?
I reused the disabling code from the past but only for Android 10+

### Why not another way?
We couldn't find a less drastic solution.

### Side effects
Background sync won't work on all Android 10 devices

## :squid: Permissions
Me