### PR TITLE
Do not add reportsCalendar repeatedly

### DIFF
--- a/Toggl.Droid/Fragments/ReportsFragment.cs
+++ b/Toggl.Droid/Fragments/ReportsFragment.cs
@@ -125,7 +125,10 @@ namespace Toggl.Droid.Fragments
 
         private void showCalendar()
         {
-            if (reportsCalendarFragment.Value.IsAdded) return;
+            if (reportsCalendarFragment.Value.IsAdded)
+            {
+                return;
+            }
 
             AndroidDependencyContainer
                 .Instance

--- a/Toggl.Droid/Fragments/ReportsFragment.cs
+++ b/Toggl.Droid/Fragments/ReportsFragment.cs
@@ -19,6 +19,7 @@ namespace Toggl.Droid.Fragments
     {
         private static readonly TimeSpan toggleCalendarThrottleDuration = TimeSpan.FromMilliseconds(300);
         private ReportsRecyclerAdapter reportsRecyclerAdapter;
+        private Lazy<ReportsCalendarFragment> reportsCalendarFragment = new Lazy<ReportsCalendarFragment>();
 
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
@@ -124,12 +125,15 @@ namespace Toggl.Droid.Fragments
 
         private void showCalendar()
         {
+            if (reportsCalendarFragment.Value.IsAdded) return;
+
             AndroidDependencyContainer
                 .Instance
                 .ViewModelCache
                 .Cache(ViewModel.CalendarViewModel);
 
-            new ReportsCalendarFragment()
+            reportsCalendarFragment
+                .Value
                 .Show(ChildFragmentManager, nameof(ReportsCalendarFragment));
         }
     }


### PR DESCRIPTION
## What's this?
Wild guess to fix #6044 

### Relationships
Maybe?
Closes #6044

## Why do we want this?
We don't want to add DialogFragments twice by accident.

## How is it done?
I check if the dialog is already added before proceed to show it. 

### Why not another way?
I'm open to suggestions

## :squid: Permissions
Me