### PR TITLE
Version code generation based on tag name

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -125,9 +125,9 @@ private string GetVersionNumberFromTag()
     {
         throw new InvalidOperationException($"Unsupported release tag format: {tagName}");
     } 
-    var major = Int32.Parse(p.Groups["major"].Value) * 10000000;
-    var minor = Int32.Parse(p.Groups["minor"].Value) * 100000;
-    var build = Int32.Parse(p.Groups["build"].Value) * 1000;
+    var major = Int32.Parse(p.Groups["major"].Value) * 1000000;
+    var minor = Int32.Parse(p.Groups["minor"].Value) *   10000;
+    var build = Int32.Parse(p.Groups["build"].Value) *     100;
     var rev = string.IsNullOrEmpty(p.Groups["rev"].Value) ? Int32.Parse(p.Groups["rev"].Value) : 0;
 
     return (major + minor + build + rev).ToString();

--- a/build.cake
+++ b/build.cake
@@ -98,6 +98,20 @@ private string GetCommitCount()
 
 private string GetVersionNumberFromTag()
 {
+    var platform = "";
+    if (target == "Build.Release.iOS.AppStore") 
+    {
+        platform = "ios";
+    } 
+    else if (target == "Build.Release.Android.PlayStore") 
+    {
+        platform = "android";
+    } 
+    else 
+    {
+        throw new InvalidOperationException($"Unable to get version number from this type of build target: {target}");
+    }
+    
     IEnumerable<string> redirectedOutput;
     StartProcess("git", new ProcessSettings
     {
@@ -106,8 +120,12 @@ private string GetVersionNumberFromTag()
     }, out redirectedOutput);
 
     var tagName = redirectedOutput.Last();
-    
-    var p = Regex.Match(tagName, @"(?<platform>(android|ios))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
+        
+    var p = Regex.Match(tagName, $@"(?<platform>({platform}))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
+    if (!p.Success) 
+    {
+        throw new InvalidOperationException($"Unsupported release tag format: {tagName}");
+    } 
     var major = Int32.Parse(p.Groups["major"].Value) * 10000000;
     var minor = Int32.Parse(p.Groups["minor"].Value) * 100000;
     var build = Int32.Parse(p.Groups["build"].Value) * 1000;

--- a/build.cake
+++ b/build.cake
@@ -128,7 +128,7 @@ private string GetVersionNumberFromTag()
     var major = Int32.Parse(p.Groups["major"].Value) * 1000000;
     var minor = Int32.Parse(p.Groups["minor"].Value) *   10000;
     var build = Int32.Parse(p.Groups["build"].Value) *     100;
-    var rev = string.IsNullOrEmpty(p.Groups["rev"].Value) ? Int32.Parse(p.Groups["rev"].Value) : 0;
+    var rev = string.IsNullOrEmpty(p.Groups["rev"].Value) ? 0 : Int32.Parse(p.Groups["rev"].Value);
 
     return (major + minor + build + rev).ToString();
 }

--- a/build.cake
+++ b/build.cake
@@ -99,11 +99,11 @@ private string GetCommitCount()
 private string GetVersionNumberFromTag()
 {
     var platform = "";
-    if (target == "Build.Release.iOS.AppStore.Upload") 
+    if (target == "Build.Release.iOS.AppStore") 
     {
         platform = "ios";
     } 
-    else if (target == "Build.Release.Android.PlayStore.Upload") 
+    else if (target == "Build.Release.Android.PlayStore") 
     {
         platform = "android";
     } 
@@ -278,7 +278,7 @@ private TemporaryFileTransformation GetIosInfoConfigurationTransformation()
         appName = "Toggl for Tests";
         iconSet = "Assets.xcassets/AppIcon-adhoc.appiconset";
     }
-    else if (target == "Build.Release.iOS.AppStore.Upload")
+    else if (target == "Build.Release.iOS.AppStore")
     {
         bundleId = "com.toggl.daneel";
         appName = "Toggl";
@@ -317,7 +317,7 @@ private TemporaryFileTransformation GetIosSiriExtensionInfoConfigurationTransfor
         bundleId = "com.toggl.daneel.adhoc.SiriExtension";
         appName = "Siri Extension Development";
     }
-    else if (target == "Build.Release.iOS.AppStore.Upload")
+    else if (target == "Build.Release.iOS.AppStore")
     {
         bundleId = "com.toggl.daneel.SiriExtension";
         appName = "Siri Extension";
@@ -353,7 +353,7 @@ private TemporaryFileTransformation GetIosSiriUIExtensionInfoConfigurationTransf
         bundleId = "com.toggl.daneel.adhoc.SiriUIExtension";
         appName = "Siri UI Extension Development";
     }
-    else if (target == "Build.Release.iOS.AppStore.Upload")
+    else if (target == "Build.Release.iOS.AppStore")
     {
         bundleId = "com.toggl.daneel.SiriUIExtension";
         appName = "Siri UI Extension";
@@ -447,7 +447,7 @@ private TemporaryFileTransformation GetAndroidManifestTransformation()
         packageName = "com.toggl.giskard.adhoc";
         appName = "Toggl for Tests";
     }
-    else if (target == "Build.Release.Android.PlayStore.Upload")
+    else if (target == "Build.Release.Android.PlayStore")
     {
         packageName = "com.toggl.giskard";
         appName = "Toggl";

--- a/build.cake
+++ b/build.cake
@@ -112,16 +112,15 @@ private string GetVersionNumberFromTag()
         throw new InvalidOperationException($"Unable to get version number from this type of build target: {target}");
     }
     
-    IEnumerable<string> redirectedOutput;
     StartProcess("git", new ProcessSettings
     {
-        Arguments = "describe --tags",
+        Arguments = "tag --list '" + platform + "-*'",
         RedirectStandardOutput = true
-    }, out redirectedOutput);
+    }, out var redirectedOutput);
 
     var tagName = redirectedOutput.Last();
-        
-    var p = Regex.Match(tagName, $@"(?<platform>({platform}))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
+         
+    var p = Regex.Match(tagName, @"(?<platform>(android|ios))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
     if (!p.Success) 
     {
         throw new InvalidOperationException($"Unsupported release tag format: {tagName}");
@@ -130,7 +129,7 @@ private string GetVersionNumberFromTag()
     var minor = Int32.Parse(p.Groups["minor"].Value) * 100000;
     var build = Int32.Parse(p.Groups["build"].Value) * 1000;
     var rev = string.IsNullOrEmpty(p.Groups["rev"].Value) ? Int32.Parse(p.Groups["rev"].Value) : 0;
-    
+
     return (major + minor + build + rev).ToString();
 }
 

--- a/build.cake
+++ b/build.cake
@@ -93,6 +93,26 @@ private string GetCommitCount()
     return redirectedOutput.Last();
 }
 
+private string GetVersionNumberFromTag()
+{
+    IEnumerable<string> redirectedOutput;
+    StartProcess("git", new ProcessSettings
+    {
+        Arguments = "describe --tags",
+        RedirectStandardOutput = true
+    }, out redirectedOutput);
+
+    var tagName = redirectedOutput.Last();
+    
+    var p = Regex.Match(tagName, @"(?<platform>(android|ios))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
+    var major = Int.parse(p.Groups["major"]) * 10000000;
+    var minor = Int.parse(p.Groups["minor"]) * 100000;
+    var build = Int.parse(p.Groups["build"]) * 1000;
+    var rev = string.IsNullOrEmpty(p.Groups["rev"]) ? Int.parse(p.Groups["rev"]) : 0;
+    
+    return major + minor + build + rev;
+}
+
 private TemporaryFileTransformation GetAndroidProjectConfigurationTransformation()
 {
     const string path = "Toggl.Droid/Toggl.Droid.csproj";
@@ -225,7 +245,7 @@ private TemporaryFileTransformation GetIosInfoConfigurationTransformation()
     const string appNameToReplace = "Toggl for Devs";
     const string iconSetToReplace = "Assets.xcassets/AppIcon-debug.appiconset";
 
-    var commitCount = GetCommitCount();
+    var bundleVersion = GetCommitCount();
     var reversedClientId = EnvironmentVariable("TOGGL_REVERSED_CLIENT_ID");
 
     var bundleId = bundleIdToReplace;
@@ -243,6 +263,7 @@ private TemporaryFileTransformation GetIosInfoConfigurationTransformation()
         bundleId = "com.toggl.daneel";
         appName = "Toggl";
         iconSet = "Assets.xcassets/AppIcon.appiconset";
+        bundleVersion = GetVersionNumberFromTag()
     }
 
     var filePath = GetFiles(path).Single();
@@ -253,7 +274,7 @@ private TemporaryFileTransformation GetIosInfoConfigurationTransformation()
         Path = path,
         Original = file,
         Temporary = file.Replace("{TOGGL_REVERSED_CLIENT_ID}", reversedClientId)
-                        .Replace("IOS_BUNDLE_VERSION", commitCount)
+                        .Replace("IOS_BUNDLE_VERSION", bundleVersion)
                         .Replace(bundleIdToReplace, bundleId)
                         .Replace(appNameToReplace, appName)
                         .Replace(iconSetToReplace, iconSet)
@@ -266,7 +287,7 @@ private TemporaryFileTransformation GetIosSiriExtensionInfoConfigurationTransfor
     const string bundleIdToReplace = "com.toggl.daneel.debug.SiriExtension";
     const string appNameToReplace = "Siri Extension Development";
 
-    var commitCount = GetCommitCount();
+    var bundleVersion = GetCommitCount();
 
     var bundleId = bundleIdToReplace;
     var appName = appNameToReplace;
@@ -280,6 +301,7 @@ private TemporaryFileTransformation GetIosSiriExtensionInfoConfigurationTransfor
     {
         bundleId = "com.toggl.daneel.SiriExtension";
         appName = "Siri Extension";
+        bundleVersion = GetVersionNumberFromTag()
     }
 
     var filePath = GetFiles(path).Single();
@@ -289,7 +311,7 @@ private TemporaryFileTransformation GetIosSiriExtensionInfoConfigurationTransfor
     {
         Path = path,
         Original = file,
-        Temporary = file.Replace("IOS_BUNDLE_VERSION", commitCount)
+        Temporary = file.Replace("IOS_BUNDLE_VERSION", bundleVersion)
                         .Replace(bundleIdToReplace, bundleId)
                         .Replace(appNameToReplace, appName)
     };
@@ -301,7 +323,7 @@ private TemporaryFileTransformation GetIosSiriUIExtensionInfoConfigurationTransf
     const string bundleIdToReplace = "com.toggl.daneel.debug.SiriUIExtension";
     const string appNameToReplace = "Toggl.Daneel.SiriExtension.UI";
 
-    var commitCount = GetCommitCount();
+    var bundleVersion = GetCommitCount();
 
     var bundleId = bundleIdToReplace;
     var appName = appNameToReplace;
@@ -315,6 +337,7 @@ private TemporaryFileTransformation GetIosSiriUIExtensionInfoConfigurationTransf
     {
         bundleId = "com.toggl.daneel.SiriUIExtension";
         appName = "Siri UI Extension";
+        bundleVersion = GetVersionNumberFromTag();
     }
 
     var filePath = GetFiles(path).Single();
@@ -324,7 +347,7 @@ private TemporaryFileTransformation GetIosSiriUIExtensionInfoConfigurationTransf
     {
         Path = path,
         Original = file,
-        Temporary = file.Replace("IOS_BUNDLE_VERSION", commitCount)
+        Temporary = file.Replace("IOS_BUNDLE_VERSION", bundleVersion)
                         .Replace(bundleIdToReplace, bundleId)
                         .Replace(appNameToReplace, appName)
     };
@@ -395,7 +418,7 @@ private TemporaryFileTransformation GetAndroidManifestTransformation()
     const string versionNumberToReplace = "987654321";
     const string appNameToReplace = "Toggl for Devs";
 
-    var commitCount = GetCommitCount();
+    var versionNumber = GetCommitCount();
     var packageName = packageNameToReplace;
     var appName = appNameToReplace;
 
@@ -408,6 +431,7 @@ private TemporaryFileTransformation GetAndroidManifestTransformation()
     {
         packageName = "com.toggl.giskard";
         appName = "Toggl";
+        versionNumber = GetVersionNumberFromTag();
     }
 
     var filePath = GetFiles(path).Single();
@@ -417,7 +441,7 @@ private TemporaryFileTransformation GetAndroidManifestTransformation()
     {
         Path = path,
         Original = file,
-        Temporary = file.Replace(versionNumberToReplace, commitCount)
+        Temporary = file.Replace(versionNumberToReplace, versionNumber)
                         .Replace(packageNameToReplace, packageName)
                         .Replace(appNameToReplace, appName)
     };

--- a/build.cake
+++ b/build.cake
@@ -99,11 +99,11 @@ private string GetCommitCount()
 private string GetVersionNumberFromTag()
 {
     var platform = "";
-    if (target == "Build.Release.iOS.AppStore") 
+    if (target == "Build.Release.iOS.AppStore.Upload") 
     {
         platform = "ios";
     } 
-    else if (target == "Build.Release.Android.PlayStore") 
+    else if (target == "Build.Release.Android.PlayStore.Upload") 
     {
         platform = "android";
     } 
@@ -278,7 +278,7 @@ private TemporaryFileTransformation GetIosInfoConfigurationTransformation()
         appName = "Toggl for Tests";
         iconSet = "Assets.xcassets/AppIcon-adhoc.appiconset";
     }
-    else if (target == "Build.Release.iOS.AppStore")
+    else if (target == "Build.Release.iOS.AppStore.Upload")
     {
         bundleId = "com.toggl.daneel";
         appName = "Toggl";
@@ -317,7 +317,7 @@ private TemporaryFileTransformation GetIosSiriExtensionInfoConfigurationTransfor
         bundleId = "com.toggl.daneel.adhoc.SiriExtension";
         appName = "Siri Extension Development";
     }
-    else if (target == "Build.Release.iOS.AppStore")
+    else if (target == "Build.Release.iOS.AppStore.Upload")
     {
         bundleId = "com.toggl.daneel.SiriExtension";
         appName = "Siri Extension";
@@ -353,7 +353,7 @@ private TemporaryFileTransformation GetIosSiriUIExtensionInfoConfigurationTransf
         bundleId = "com.toggl.daneel.adhoc.SiriUIExtension";
         appName = "Siri UI Extension Development";
     }
-    else if (target == "Build.Release.iOS.AppStore")
+    else if (target == "Build.Release.iOS.AppStore.Upload")
     {
         bundleId = "com.toggl.daneel.SiriUIExtension";
         appName = "Siri UI Extension";
@@ -447,7 +447,7 @@ private TemporaryFileTransformation GetAndroidManifestTransformation()
         packageName = "com.toggl.giskard.adhoc";
         appName = "Toggl for Tests";
     }
-    else if (target == "Build.Release.Android.PlayStore")
+    else if (target == "Build.Release.Android.PlayStore.Upload")
     {
         packageName = "com.toggl.giskard";
         appName = "Toggl";

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,9 @@
 #tool "nuget:?package=xunit.runner.console&version=2.2.0"
 #tool "nuget:?package=NUnit.Runners&version=2.6.3"
 
+using System.Text.RegularExpressions;
+using System;
+
 public class TemporaryFileTransformation
 {
     public string Path { get; set; }
@@ -105,12 +108,12 @@ private string GetVersionNumberFromTag()
     var tagName = redirectedOutput.Last();
     
     var p = Regex.Match(tagName, @"(?<platform>(android|ios))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
-    var major = Int.parse(p.Groups["major"]) * 10000000;
-    var minor = Int.parse(p.Groups["minor"]) * 100000;
-    var build = Int.parse(p.Groups["build"]) * 1000;
-    var rev = string.IsNullOrEmpty(p.Groups["rev"]) ? Int.parse(p.Groups["rev"]) : 0;
+    var major = Int32.Parse(p.Groups["major"].Value) * 10000000;
+    var minor = Int32.Parse(p.Groups["minor"].Value) * 100000;
+    var build = Int32.Parse(p.Groups["build"].Value) * 1000;
+    var rev = string.IsNullOrEmpty(p.Groups["rev"].Value) ? Int32.Parse(p.Groups["rev"].Value) : 0;
     
-    return major + minor + build + rev;
+    return (major + minor + build + rev).ToString();
 }
 
 private TemporaryFileTransformation GetAndroidProjectConfigurationTransformation()
@@ -263,7 +266,7 @@ private TemporaryFileTransformation GetIosInfoConfigurationTransformation()
         bundleId = "com.toggl.daneel";
         appName = "Toggl";
         iconSet = "Assets.xcassets/AppIcon.appiconset";
-        bundleVersion = GetVersionNumberFromTag()
+        bundleVersion = GetVersionNumberFromTag();
     }
 
     var filePath = GetFiles(path).Single();
@@ -301,7 +304,7 @@ private TemporaryFileTransformation GetIosSiriExtensionInfoConfigurationTransfor
     {
         bundleId = "com.toggl.daneel.SiriExtension";
         appName = "Siri Extension";
-        bundleVersion = GetVersionNumberFromTag()
+        bundleVersion = GetVersionNumberFromTag();
     }
 
     var filePath = GetFiles(path).Single();


### PR DESCRIPTION
## What's this?
This is a new way to increase versionCodes/bundleVersion for AppStore/PlayStore builds

### Relationships
Closes #6086

## Why do we want this?
We want to take more control over our version codes

## How is it done?
Parsing the tag name with regex ( thanks to @kornelijepetak and @juanlaube )

### Why not another way?
Show me

## Review hints
I don't even know how to test this properly :-) 

## Tests
<!-- If your PR touches API, schedule and add a link to Bitrise for 'Tests.Integration' -->
Integration tests: <!-- link --> - do not merge this branch unless these tests are passing.

## :squid: Permissions
Feel free