### PR TITLE
Android 2.5 Faloodeh

### DIFF
--- a/Toggl.Droid/DebugHelpers/ErrorTriggeringFragment.cs
+++ b/Toggl.Droid/DebugHelpers/ErrorTriggeringFragment.cs
@@ -140,10 +140,11 @@ namespace Toggl.Droid.Debug
             noWorkspaceFragment.Show(FragmentManager, nameof(NoWorkspaceFragment));
         }
 
-        private void noDefaultWorkspaceErrorTriggered()
+        private async void noDefaultWorkspaceErrorTriggered()
         {
             var container = AndroidDependencyContainer.Instance;
             var noWorkspaceViewModel = container.ViewModelLoader.Load<SelectDefaultWorkspaceViewModel>();
+            await noWorkspaceViewModel.Initialize();
             var noWorkspaceFragment = new SelectDefaultWorkspaceFragment();
             container.ViewModelCache.Cache(noWorkspaceViewModel);
             noWorkspaceFragment.Show(FragmentManager, nameof(SelectDefaultWorkspaceFragment));

--- a/Toggl.Droid/Fragments/SelectDefaultWorkspaceFragment.ViewBinds.cs
+++ b/Toggl.Droid/Fragments/SelectDefaultWorkspaceFragment.ViewBinds.cs
@@ -1,15 +1,23 @@
 ﻿using Android.Support.V7.Widget;
 using Android.Views;
+using Android.Widget;
 
 namespace Toggl.Droid.Fragments
 {
     public partial class SelectDefaultWorkspaceFragment
     {
         private RecyclerView recyclerView;
-
+        private TextView txtSetDefaultWorkspace;
+        private TextView txtTimeWillBeTrackedAuto;
+        
         protected override void InitializeViews(View rootView)
         {
             recyclerView = rootView.FindViewById<RecyclerView>(Resource.Id.SelectDefaultWorkspaceRecyclerView);
+            txtSetDefaultWorkspace = rootView.FindViewById<TextView>(Resource.Id.TxtSetDefaultWorkspace);
+            txtTimeWillBeTrackedAuto = rootView.FindViewById<TextView>(Resource.Id.TxtTimeWillBeTrackedAuto);
+
+            txtSetDefaultWorkspace.Text = Shared.Resources.SetDefaultWorkspace;
+            txtTimeWillBeTrackedAuto.Text = Shared.Resources.SelectDefaultWorkspaceDescription;
         }
     }
 }

--- a/Toggl.Droid/Properties/AndroidManifest.xml
+++ b/Toggl.Droid/Properties/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:versionCode="987654321"
-    android:versionName="2.4.1"
+    android:versionName="2.5"
     package="com.toggl.giskard.debug"
     android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28" />

--- a/Toggl.Droid/Resources/layout/SelectDefaultWorkspaceFragment.axml
+++ b/Toggl.Droid/Resources/layout/SelectDefaultWorkspaceFragment.axml
@@ -7,6 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <TextView
+        android:id="@+id/TxtSetDefaultWorkspace"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:text="Set default workspace"
@@ -18,6 +19,7 @@
         android:layout_marginBottom="12dp"
         android:layout_marginLeft="24dp"/>
     <TextView
+        android:id="@+id/TxtTimeWillBeTrackedAuto"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:text="Your time will be tracked automatically from this workspace. You can cange this later from the Settings."


### PR DESCRIPTION
# User facing
- Added sync status next to the logout button
- Fixed a bug which made syncing appear to take forever
- Fixed a crash that occurred when filtering lists
- Fixed visual glitches in the pie chart
- Fixed an empty view presented when selecting a default workspace
- Fixed incorrect copy on the login page

# Internal
- Fixed rating view not being presented
- Made background sync use light sync, instead of full sync
- Added analytic events for calendar selection
- Enabled analytic events for background syncing

# Changes
https://github.com/toggl/mobileapp/compare/android-2.4.1...android-2.5-faloodeh