### PR TITLE
Make maintenance part of the tag optional again

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -120,14 +120,14 @@ private string GetVersionNumberFromTag()
 
     var tagName = redirectedOutput.Last();
          
-    var p = Regex.Match(tagName, @"(?<platform>(android|ios))-(?<major>\d{1,2})\.(?<minor>\d{1,2})\.(?<build>\d{1,2})(-(?<rev>\d{1,2}))?");
+    var p = Regex.Match(tagName, @"(?<platform>(android|ios))-(?<major>\d{1,2})\.(?<minor>\d{1,2})(\.(?<build>\d{1,2}))?(-(?<rev>\d{1,2}))?");
     if (!p.Success) 
     {
         throw new InvalidOperationException($"Unsupported release tag format: {tagName}");
     } 
     var major = Int32.Parse(p.Groups["major"].Value) * 1000000;
     var minor = Int32.Parse(p.Groups["minor"].Value) *   10000;
-    var build = Int32.Parse(p.Groups["build"].Value) *     100;
+    var build = string.IsNullOrEmpty(p.Groups["build"].Value) ? 0 : Int32.Parse(p.Groups["build"].Value) * 100;
     var rev = string.IsNullOrEmpty(p.Groups["rev"].Value) ? 0 : Int32.Parse(p.Groups["rev"].Value);
 
     return (major + minor + build + rev).ToString();


### PR DESCRIPTION
## What's this?
Make maintenance part of the tag optional again

### Relationships
Closes #6184

## Why do we want this?
We want to be able to do tags like `android-2.5` again

## How is it done?
A small change in regexp to make the maintenance part optional

## :squid: Permissions
Anyone 