### PR TITLE
Add taken project name error check

### DIFF
--- a/.github/ISSUE_TEMPLATE/d-manual-test-template.md
+++ b/.github/ISSUE_TEMPLATE/d-manual-test-template.md
@@ -29,6 +29,7 @@ about: A manual testing checklist that can be assigned to a release to track the
 - [ ] Stop timer
 - [ ] Enter description
 - [ ] Add new project
+- [ ] Add new project with already taken project name (does it show proper error message) 
 - [ ] Add new client
 - [ ] Add new tag
 - [ ] Add long (3000 characters) description and confirm character limit error shows in the edit view after sync


### PR DESCRIPTION
## What's this?
For a long time, we had this 'taken project name error' check broken on Android because nobody was testing this. Users shouldn't be able to add new project with the existing project name espetially if that existing project name has the same client as well. (Android currently checks only name, web checks both... ) 

## Why do we want this?
We don't want another regression.

## :squid: Permissions
Anyone