### PR TITLE
Fix start entry description text color

### DIFF
--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.cs
@@ -278,6 +278,7 @@ namespace Toggl.iOS.ViewControllers
 
             TimeInput.TintColor = Colors.StartTimeEntry.Cursor.ToNativeColor();
 
+            DescriptionTextView.TextColor = ColorAssets.Text;
             DescriptionTextView.TintColor = Colors.StartTimeEntry.Cursor.ToNativeColor();
             DescriptionTextView.BecomeFirstResponder();
 


### PR DESCRIPTION
## What's this?
Fixes start entry description text color in dark mode.

### Relationships
Closes #6245 

## How is it done?
I just set the color of the text when preparing the view. It worked when you setup a project or tag, because then it takes the color from the attributed text, but not when the user starts typing.

## :squid: Permissions
Do it!