### PR TITLE
Fix iOS RTL project and tag creation

### DIFF
--- a/Toggl.iOS/Autocomplete/AutocompleteExtensions.cs
+++ b/Toggl.iOS/Autocomplete/AutocompleteExtensions.cs
@@ -70,6 +70,8 @@ namespace Toggl.iOS.Autocomplete
             var start = 0;
             bool queryTextSpanAlreadyUsed = false;
 
+            List<ISpan> spans = new List<ISpan>();
+
             while (start != text.Length)
             {
                 var attributes = text.GetAttributes(start, out var longestEffectiveRange, new NSRange(start, text.Length - start));
@@ -80,12 +82,12 @@ namespace Toggl.iOS.Autocomplete
                 {
                     var (projectId, projectName, projectColor, taskId, taskName) = attributes.GetProjectInformation();
 
-                    yield return new ProjectSpan(projectId, projectName, projectColor, taskId, taskName);
+                    spans.Add(new ProjectSpan(projectId, projectName, projectColor, taskId, taskName));
                 }
                 else if (attributes.ContainsKey(TagId))
                 {
                     var (tagId, tagName) = attributes.GetTagInformation();
-                    yield return new TagSpan(tagId, tagName);
+                    spans.Add(new TagSpan(tagId, tagName));
                 }
                 else if (length > 0)
                 {
@@ -93,16 +95,35 @@ namespace Toggl.iOS.Autocomplete
                     if (queryTextSpanAlreadyUsed == false && cursorPosition.IsInRange(start, end))
                     {
                         queryTextSpanAlreadyUsed = true;
-                        yield return new QueryTextSpan(subText, cursorPosition - start);
+                        spans.Add(new QueryTextSpan(subText, cursorPosition - start));
                     }
                     else
                     {
-                        yield return new TextSpan(subText);
+                        spans.Add(new TextSpan(subText));
                     }
                 }
 
                 start = end;
             }
+
+            for(var i = 1; i < spans.Count; i++)
+            {
+                var previousSpan = spans[i - 1];
+                if (!previousSpan.IsTextSpan())
+                    continue;
+
+                var previousTextSpan = (TextSpan)previousSpan;
+                if (previousTextSpan.Text.Contains(QuerySymbols.ProjectsString)
+                    || previousTextSpan.Text.Contains(QuerySymbols.TagsString))
+                {
+                    var currentSpan = (QueryTextSpan)spans[i];
+                    var newText = previousTextSpan.Text + currentSpan.Text;
+                    spans[i] = new QueryTextSpan(newText, newText.Length);
+                    spans.Remove(spans[i - 1]);
+                }
+            }
+
+            return spans;
         }
 
         public static NSAttributedString AsAttributedTextAndCursorPosition(this TextFieldInfo self)

--- a/Toggl.iOS/ViewControllers/StartTimeEntryViewController.xib
+++ b/Toggl.iOS/ViewControllers/StartTimeEntryViewController.xib
@@ -111,7 +111,7 @@
                                     <attributes>
                                         <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                         <font key="NSFont" metaFont="system" size="16"/>
-                                        <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" minimumLineHeight="24" maximumLineHeight="24" tighteningFactorForTruncation="0.0"/>
+                                        <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" minimumLineHeight="24" maximumLineHeight="24" tighteningFactorForTruncation="0.0"/>
                                     </attributes>
                                 </fragment>
                             </attributedString>


### PR DESCRIPTION
## What's this?
A rather hack-like fix to the problem of creating projects and tags from the Start TE view when using an RTL language.

### Relationships
Closes #5561

## Why do we want this?
We care about all our users.

## How is it done?
We use the Xamarin ver of `attributes(at:longestEffectiveRange:in:)` to extract the existing tag/project substrings out of the big description string. The problem happens when we mix RTL languages with non-RTL chars, like `@` and `#` — the method treats them as separate segments. This way, instead of getting a single string for `TE Name @newproj`, we get three: `TE Name`, `@` and `newproj`. In this implementation I loop over the output spans and look for spans, preceded by spans containing `@` or `#`. Then I merge these spans into one new `QueryTextSpan`, which is then processed correctly by our pipeline.

### Why not another way?
This seems like the most obvious one.

### Side effects
While the StartTE view normally would respect the language direction, adding a project breaks it, and forces it to be left-aligned. My theory is that this happens bc of the addition of non-RTL chars.

## Review hints
Add an Arabic or Hewbrew KB, and try creating a project in that language.

## :squid: Permissions
Go for it.

### PS
I kept remembering @shedokan's KT about how horrible RTL support is everywhere 😢 