### PR TITLE
Update Xamarin.Android csproj to improve build times

### DIFF
--- a/Toggl.Droid/Toggl.Droid.csproj
+++ b/Toggl.Droid/Toggl.Droid.csproj
@@ -15,11 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidLinkMode>Full</AndroidLinkMode>
-    <AndroidLinkSkip>Toggl.Giskard;Toggl.Storage.Realm</AndroidLinkSkip>
-    <EnableProguard>true</EnableProguard>
     <JavaMaximumHeapSize>2G</JavaMaximumHeapSize>
-    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,10 +29,16 @@
     <AndroidSupportedAbis>arm64-v8a;armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
+    <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <EnableProguard>true</EnableProguard>
+    <AndroidLinkMode>Full</AndroidLinkMode>
+    <AndroidLinkSkip>Toggl.Giskard;Toggl.Storage.Realm</AndroidLinkSkip>
     <AndroidSupportedAbis>armeabi-v7a;x86_64;x86;arm64-v8a</AndroidSupportedAbis>
     <DebugType>
     </DebugType>
@@ -732,8 +734,6 @@
     <AndroidResource Include="Resources\layout\SelectProjectActivityProjectCell.axml" />
     <AndroidResource Include="Resources\layout\SelectProjectActivityTaskCell.axml" />
     <AndroidResource Include="Resources\layout\SelectProjectActivityWorkspaceHeader.axml" />
-    <AndroidResource Include="Resources\layout\SelectDateFormatFragment.axml" />
-    <AndroidResource Include="Resources\layout\SelectDateFormatFragmentCell.axml" />
     <AndroidResource Include="Resources\drawable\TransparentToBackgroundGradient.xml" />
     <GoogleServicesJson Include="google-services.json" />
     <AndroidResource Include="Resources\layout\ReportsFragment.axml" />


### PR DESCRIPTION
## What's this?

I heard from @JonDouglas that the developer loop on this app was slow. Like 1-2 minutes or something...

I noticed a few settings that will drastically improve your Debug build times:

* The linker should be set to `None` for Debug builds.
* Only use ProGuard in Release builds.
* I moved the settings for Fast Deployment around, so things were explicit for Debug vs Release.

For details, see: https://devblogs.microsoft.com/xamarin/optimize-xamarin-android-builds/

However, I did find some bugs in Xamarin.Android's build system, when profiling builds of this app.

### Missing AndroidResource files

This app lists two files that do not exist:

    <AndroidResource Include="Resources\layout\SelectDateFormatFragment.axml" />
    <AndroidResource Include="Resources\layout\SelectDateFormatFragmentCell.axml" />

Due to the way MSBuild works, this causes:

    Building target "_CompileResources" completely.
    Input file "Resources\layout\SelectDateFormatFragment.xml" does not exist.
    Building target "_UpdateAndroidResgen" completely.
    Input file "Resources\layout\SelectDateFormatFragment.xml" does not exist.

Basically expensive `aapt2` calls happen on every build... We can just
remove these lines for now, until we get a Xamarin.Android update.

Fixed in: https://github.com/xamarin/xamarin-android/pull/3837

### Issue with GPS and aapt2

I noticed usage of Google Play Services and aapt2 causes a few MSBuild
targets to always run.

I don't have a workaround for this, but we have fixes in:

https://github.com/xamarin/GooglePlayServicesComponents/pull/271
https://github.com/xamarin/xamarin-android/pull/3856

### Relationships

https://github.com/xamarin/xamarin-android/pull/3837
https://github.com/xamarin/GooglePlayServicesComponents/pull/271
https://github.com/xamarin/xamarin-android/pull/3856