### PR TITLE
Reduce the size of iOS artifacts

### DIFF
--- a/Toggl.iOS.SiriExtension.UI/Toggl.iOS.SiriExtension.UI.csproj
+++ b/Toggl.iOS.SiriExtension.UI/Toggl.iOS.SiriExtension.UI.csproj
@@ -64,7 +64,7 @@
     <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchLink>Full</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
@@ -73,6 +73,7 @@
     </OnDemandResourcesInitialInstallTags>
     <OnDemandResourcesPrefetchOrder>
     </OnDemandResourcesPrefetchOrder>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release.Adhoc|iPhone' ">
     <DebugType>pdbonly</DebugType>

--- a/Toggl.iOS.SiriExtension/Toggl.iOS.SiriExtension.csproj
+++ b/Toggl.iOS.SiriExtension/Toggl.iOS.SiriExtension.csproj
@@ -78,7 +78,7 @@
     <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchLink>Full</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchVerbosity>
@@ -87,6 +87,7 @@
     </OnDemandResourcesInitialInstallTags>
     <OnDemandResourcesPrefetchOrder>
     </OnDemandResourcesPrefetchOrder>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Toggl.iOS.TimerWidgetExtension/Toggl.iOS.TimerWidgetExtension.csproj
+++ b/Toggl.iOS.TimerWidgetExtension/Toggl.iOS.TimerWidgetExtension.csproj
@@ -93,6 +93,8 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchArch>ARM64</MtouchArch>
     <CodesignProvision>Daneel AppStore Widget Extension</CodesignProvision>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
+    <MtouchLink>Full</MtouchLink>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Toggl.iOS/Toggl.iOS.csproj
+++ b/Toggl.iOS/Toggl.iOS.csproj
@@ -59,12 +59,13 @@
     <DefineConstants>__UNIFIED__;__MOBILE__;__IOS__;USE_PRODUCTION_API;USE_ANALYTICS;USE_APPCENTER</DefineConstants>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Distribution</CodesignKey>
-    <MtouchExtraArgs>--linkskip Toggl.iOS --linkskip=Toggl.Storage.Realm --registrar:static</MtouchExtraArgs>
+    <MtouchExtraArgs>--linkskip=Toggl.Storage.Realm --registrar:static</MtouchExtraArgs>
     <MtouchFloat32>true</MtouchFloat32>
     <MtouchLink>Full</MtouchLink>
     <MtouchArch>ARM64</MtouchArch>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchUseLlvm>true</MtouchUseLlvm>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <MtouchArch>ARM64</MtouchArch>


### PR DESCRIPTION
## What's this?
This enables the Linker + LLVM in every iOS project

## Why do we want this?
We don't really wanna ship 200MB binaries

## How is it done?
Enabling Linker All + LLVM on all iOS projects

### Side effects
This will need some **really** thorough testing, since problems might have lurked in

## :squid: Permissions
@juanlaube 