### PR TITLE
iOS 2.6.1 Grapefruit hotfix

### DIFF
--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -36,6 +36,6 @@
 		<string>com.apple.intents-ui-service</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6</string>
+	<string>2.6.1</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -40,6 +40,6 @@
 		<string>IntentHandler</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6</string>
+	<string>2.6.1</string>
 </dict>
 </plist>

--- a/Toggl.iOS.TimerWidgetExtension/Info.plist
+++ b/Toggl.iOS.TimerWidgetExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6</string>
+	<string>2.6.1</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -81,7 +81,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6</string>
+	<string>2.6.1</string>
 	<key>CFBundleDisplayName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Toggl.iOS/Presentation/Transition/ModalPresentationController.cs
+++ b/Toggl.iOS/Presentation/Transition/ModalPresentationController.cs
@@ -192,7 +192,7 @@ namespace Toggl.iOS.Presentation.Transition
                             var firstResponderFrame =
                                 firstResponder.ConvertRectToView(firstResponder.Frame, PresentedView);
                             var newY = containerSize.Height - keyboardHeight - firstResponderFrame.Y - firstResponderFrame.Height - keyboardMargin;
-                            frame.Y = (nfloat)Clamp(newY, UIApplication.SharedApplication.StatusBarFrame.Height, frame.Y);
+                            frame.Y = (nfloat)Max(Min(newY, frame.Y), UIApplication.SharedApplication.StatusBarFrame.Height);
                         }
                     }
                 }


### PR DESCRIPTION
## User facing changelog (unchanged since last release)

- Added new today extension for timer and suggestions
- Improved RTL language support
- Fixed dates formatting issues
- Fixed a bug in Siri shortcuts
- Fixed a bug that made deleted time entries reappear
- Other stability and performance improvements

https://github.com/toggl/mobileapp/compare/ios-2.6-5...release/ios-2.6.1-grapefruit-hotfix