### PR TITLE
Cherry pick #6597 for android 2.7

### DIFF
--- a/Toggl.Droid/Extensions/FloatingActionButtonExtensions.cs
+++ b/Toggl.Droid/Extensions/FloatingActionButtonExtensions.cs
@@ -8,17 +8,17 @@ namespace Toggl.Droid.Extensions
     {
         public static void SetDrawableImageSafe(this FloatingActionButton button, Drawable drawable)
         {
-            var wasHiddenBeforeChange = button.IsOrWillBeHidden;
-
+            // HACK: This is a really nasty work around added in #4824
+            // and changed in #6597 to try fixing a bug that exists in
+            // the FloatingActionButton class. Don't remove it unless you know
+            // exactly what you are doing.
+            // Google Issue: https://issuetracker.google.com/issues/117476935
             button.Hide();
             button.SetImageDrawable(drawable);
             button.Show(new FabVisibilityListener(() =>
             {
                 button.ImageMatrix.SetScale(1, 1);
             }));
-
-            if (wasHiddenBeforeChange)
-                button.Hide();
         }
 
         public sealed class FabVisibilityListener : FloatingActionButton.OnVisibilityChangedListener

--- a/Toggl.Droid/Fragments/MainFragment.cs
+++ b/Toggl.Droid/Fragments/MainFragment.cs
@@ -136,7 +136,7 @@ namespace Toggl.Droid.Fragments
                 .DisposedBy(DisposeBag);
 
             ViewModel.IsTimeEntryRunning
-                .Subscribe(onTimeEntryCardVisibilityChanged)
+                .Subscribe(visible => playButton.SetExpanded(visible))
                 .DisposedBy(DisposeBag);
 
             ViewModel.SyncProgressState
@@ -334,11 +334,6 @@ namespace Toggl.Droid.Fragments
         private void onSwipeActionsChanged(bool enabled)
         {
             touchCallback.AreSwipeActionsEnabled = enabled;
-        }
-
-        private void onTimeEntryCardVisibilityChanged(bool visible)
-        {
-            playButton.SetExpanded(visible);
         }
 
         private void onEmptyStateVisibilityChanged(bool shouldShowEmptyState)


### PR DESCRIPTION
## What's this?
This PR was created by cherry picking the commit 1070cfa51d80f157f68ab59c3360f60379732890

### Relationships
Closes #Nothing

## Why do we want this?
This is a best-effort bug fix to prevent the user from having no start/create time entry button in the main log (check #6584)

## How is it done?
It cherry-picks the commit generated by #6597 

This commit could be safely cherry-picked because it doesn't touch anything androidX related :)

## :squid: Permissions
I'll handle it.