### PR TITLE
January campaign: Remote config

### DIFF
--- a/Toggl.Core.Tests/Services/UpdateRemoteConfigCacheServiceTests.cs
+++ b/Toggl.Core.Tests/Services/UpdateRemoteConfigCacheServiceTests.cs
@@ -52,19 +52,23 @@ namespace Toggl.Core.Tests.Services
                 KeyValueStorage.DidNotReceive().SetString(RatingViewTriggerParameter, Arg.Any<string>());
                 KeyValueStorage.DidNotReceive().SetBool(RegisterPushNotificationsTokenWithServerParameter, Arg.Any<bool>());
                 KeyValueStorage.DidNotReceive().SetBool(HandlePushNotificationsParameter, Arg.Any<bool>());
+                KeyValueStorage.DidNotReceive().SetString(January2020CampaignOption, Arg.Any<string>());
             }
 
             [Theory, LogIfTooSlow]
-            [InlineData(1, RatingViewCriterion.Continue, true, false)]
-            [InlineData(4, RatingViewCriterion.Start, false, true)]
-            public void ShouldUpdateTheCacheWhenFetchingSucceeds(int ratingViewDayCount, RatingViewCriterion ratingViewCriterion, bool registerPushes, bool handlePushes)
+            [InlineData(1, RatingViewCriterion.Continue, true, false, "A")]
+            [InlineData(4, RatingViewCriterion.Start, false, true, "B")]
+            [InlineData(5, RatingViewCriterion.None, true, true, "None")]
+            public void ShouldUpdateTheCacheWhenFetchingSucceeds(int ratingViewDayCount, RatingViewCriterion ratingViewCriterion, bool registerPushes, bool handlePushes, string campaignOption)
             {
                 var expectedRatingViewConfiguration = new RatingViewConfiguration(ratingViewDayCount, ratingViewCriterion);
                 var expectedPushNotificationsConfiguration = new PushNotificationsConfiguration(registerPushes, handlePushes);
+                var expectedCampaignConfiguration = new January2020CampaignConfiguration(campaignOption);
                 var mockFetchRemoteConfigService = new MockFetchRemoteConfigService(
                     true,
                     ratingViewConfigurationToReturn: expectedRatingViewConfiguration,
-                    pushNotificationsConfigurationReturn: expectedPushNotificationsConfiguration);
+                    pushNotificationsConfigurationReturn: expectedPushNotificationsConfiguration,
+                    january2020CampaignConfiguration: expectedCampaignConfiguration);
                 UpdateRemoteConfigCacheService = new UpdateRemoteConfigCacheService(TimeService, KeyValueStorage, mockFetchRemoteConfigService);
 
                 UpdateRemoteConfigCacheService.FetchAndStoreRemoteConfigData();
@@ -73,6 +77,7 @@ namespace Toggl.Core.Tests.Services
                 KeyValueStorage.Received().SetString(RatingViewTriggerParameter, ratingViewCriterion.ToString());
                 KeyValueStorage.Received().SetBool(RegisterPushNotificationsTokenWithServerParameter, registerPushes);
                 KeyValueStorage.Received().SetBool(HandlePushNotificationsParameter, handlePushes);
+                KeyValueStorage.Received().SetString(January2020CampaignOption, campaignOption);
             }
         }
 
@@ -175,19 +180,22 @@ namespace Toggl.Core.Tests.Services
             private readonly Exception exceptionOnFailure;
             private readonly RatingViewConfiguration ratingViewConfigurationToReturn;
             private readonly PushNotificationsConfiguration pushNotificationsConfigurationReturn;
+            private readonly January2020CampaignConfiguration january2020CampaignConfiguration;
 
             public MockFetchRemoteConfigService(
                 bool shouldSucceed = true,
                 bool shouldFail = false,
                 Exception exceptionOnFailure = null,
-                RatingViewConfiguration ratingViewConfigurationToReturn = default(RatingViewConfiguration),
-                PushNotificationsConfiguration pushNotificationsConfigurationReturn = default(PushNotificationsConfiguration))
+                RatingViewConfiguration ratingViewConfigurationToReturn = default,
+                PushNotificationsConfiguration pushNotificationsConfigurationReturn = default,
+                January2020CampaignConfiguration january2020CampaignConfiguration = default)
             {
                 this.shouldSucceed = shouldSucceed;
                 this.shouldFail = shouldFail;
                 this.exceptionOnFailure = exceptionOnFailure;
                 this.ratingViewConfigurationToReturn = ratingViewConfigurationToReturn;
                 this.pushNotificationsConfigurationReturn = pushNotificationsConfigurationReturn;
+                this.january2020CampaignConfiguration = january2020CampaignConfiguration;
             }
 
             public void FetchRemoteConfigData(Action onFetchSucceeded, Action<Exception> onFetchFailed)
@@ -201,6 +209,9 @@ namespace Toggl.Core.Tests.Services
 
             public PushNotificationsConfiguration ExtractPushNotificationsConfigurationFromRemoteConfig()
                 => pushNotificationsConfigurationReturn;
+
+            public January2020CampaignConfiguration ExtractJanuary2020CampaignConfig()
+                => january2020CampaignConfiguration;
         }
     }
 }

--- a/Toggl.Core/Extensions/RemoteConfigExtensions.cs
+++ b/Toggl.Core/Extensions/RemoteConfigExtensions.cs
@@ -15,5 +15,9 @@ namespace Toggl.Core.Extensions
             => new PushNotificationsConfiguration(
                 keyValueStorage.GetBool(RemoteConfigKeys.RegisterPushNotificationsTokenWithServerParameter),
                 keyValueStorage.GetBool(RemoteConfigKeys.HandlePushNotificationsParameter));
+
+        public static January2020CampaignConfiguration ReadJanuary2020CampaignConfiguration(this IKeyValueStorage keyValueStorage)
+            => new January2020CampaignConfiguration(
+                keyValueStorage.GetString(RemoteConfigKeys.January2020CampaignOption));
     }
 }

--- a/Toggl.Core/Services/IFetchRemoteConfigService.cs
+++ b/Toggl.Core/Services/IFetchRemoteConfigService.cs
@@ -8,5 +8,6 @@ namespace Toggl.Core.Services
         void FetchRemoteConfigData(Action onFetchSucceeded, Action<Exception> onFetchFailed);
         RatingViewConfiguration ExtractRatingViewConfigurationFromRemoteConfig();
         PushNotificationsConfiguration ExtractPushNotificationsConfigurationFromRemoteConfig();
+        January2020CampaignConfiguration ExtractJanuary2020CampaignConfig();
     }
 }

--- a/Toggl.Core/Services/IRemoteConfigService.cs
+++ b/Toggl.Core/Services/IRemoteConfigService.cs
@@ -7,5 +7,6 @@ namespace Toggl.Core.Services
     {
         RatingViewConfiguration GetRatingViewConfiguration();
         PushNotificationsConfiguration GetPushNotificationsConfiguration();
+        January2020CampaignConfiguration GetJanuary2020CampaignConfiguration();
     }
 }

--- a/Toggl.Core/Services/IUpdateRemoteConfigCacheService.cs
+++ b/Toggl.Core/Services/IUpdateRemoteConfigCacheService.cs
@@ -17,5 +17,6 @@ namespace Toggl.Core.Services
         public static string RegisterPushNotificationsTokenWithServerParameter { get; } = "PushNotificationsRegisterTokenWithServer";
         public static string HandlePushNotificationsParameter { get; } = "PushNotificationsHandle";
         public static string LastFetchAtKey { get; } = "LastFetchAtKey";
+        public static string January2020CampaignOption { get; } = "January2020CampaignOption";
     }
 }

--- a/Toggl.Core/Services/RemoteConfigService.cs
+++ b/Toggl.Core/Services/RemoteConfigService.cs
@@ -19,5 +19,8 @@ namespace Toggl.Core.Services
 
         public PushNotificationsConfiguration GetPushNotificationsConfiguration()
             => keyValueStorage.ReadStoredPushNotificationsConfiguration();
+
+        public January2020CampaignConfiguration GetJanuary2020CampaignConfiguration()
+            => keyValueStorage.ReadJanuary2020CampaignConfiguration();
     }
 }

--- a/Toggl.Core/Services/UpdateRemoteConfigCacheService.cs
+++ b/Toggl.Core/Services/UpdateRemoteConfigCacheService.cs
@@ -59,11 +59,15 @@ namespace Toggl.Core.Services
         {
             var ratingViewConfiguration = fetchRemoteConfigService.ExtractRatingViewConfigurationFromRemoteConfig();
             var pushNotificationsConfiguration = fetchRemoteConfigService.ExtractPushNotificationsConfigurationFromRemoteConfig();
+            var january2020CampaignConfiguration = fetchRemoteConfigService.ExtractJanuary2020CampaignConfig();
 
             keyValueStorage.SetInt(RatingViewDelayParameter, ratingViewConfiguration.DayCount);
             keyValueStorage.SetString(RatingViewTriggerParameter, ratingViewConfiguration.Criterion.ToString());
+
             keyValueStorage.SetBool(RegisterPushNotificationsTokenWithServerParameter, pushNotificationsConfiguration.RegisterPushNotificationsTokenWithServer);
             keyValueStorage.SetBool(HandlePushNotificationsParameter, pushNotificationsConfiguration.HandlePushNotifications);
+
+            keyValueStorage.SetString(January2020CampaignOption, january2020CampaignConfiguration.Option.ToString());
 
             lock (updateLock)
             {

--- a/Toggl.Droid/Resources/xml/RemoteConfigDefaults.xml
+++ b/Toggl.Droid/Resources/xml/RemoteConfigDefaults.xml
@@ -16,4 +16,8 @@
         <key>PushNotificationsHandle</key>
         <value>false</value>
     </entry>
+    <entry>
+        <key>January2020CampaignOption</key>
+        <value>none</value>
+    </entry>
 </defaultsMap>

--- a/Toggl.Droid/Services/FetchRemoteConfigServiceAndroid.cs
+++ b/Toggl.Droid/Services/FetchRemoteConfigServiceAndroid.cs
@@ -55,6 +55,13 @@ namespace Toggl.Droid.Services
                 remoteConfig.GetBoolean(RegisterPushNotificationsTokenWithServerParameter),
                 remoteConfig.GetBoolean(HandlePushNotificationsParameter));
         }
+
+        public January2020CampaignConfiguration ExtractJanuary2020CampaignConfig()
+        {
+            var remoteConfig = FirebaseRemoteConfig.Instance;
+            return new January2020CampaignConfiguration(
+                remoteConfig.GetString(January2020CampaignOption));
+        }
     }
 
     public class RemoteConfigCompletionHandler : Java.Lang.Object, IOnCompleteListener

--- a/Toggl.Shared.Tests/January2020CampaignConfigurationTests.cs
+++ b/Toggl.Shared.Tests/January2020CampaignConfigurationTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Toggl.Shared.Tests
+{
+    using static January2020CampaignConfiguration.AvailableOption;
+
+    public sealed class January2020CampaignConfigurationTests
+    {
+        public sealed class TheConstructor
+        {
+            [Theory]
+            [LogIfTooSlow]
+            [InlineData("a")]
+            [InlineData("A")]
+            public void CorrectlyParsesOptionA(string a)
+            {
+                var config = new January2020CampaignConfiguration(a);
+
+                config.Option.Should().Be(A);
+            }
+
+            [Theory]
+            [LogIfTooSlow]
+            [InlineData("b")]
+            [InlineData("B")]
+            public void CorrectlyParsesOptionB(string b)
+            {
+                var config = new January2020CampaignConfiguration(b);
+
+                config.Option.Should().Be(B);
+            }
+
+            [Theory]
+            [LogIfTooSlow]
+            [InlineData("")]
+            [InlineData("none")]
+            [InlineData("None")]
+            [InlineData("NoNe")]
+            [InlineData("Some Unknown Text")]
+            public void CorrectlyParsesOptionNone(string none)
+            {
+                var config = new January2020CampaignConfiguration(none);
+
+                config.Option.Should().Be(None);
+            }
+        }
+
+        public sealed class TheToStringMethod
+        {
+            [Theory]
+            [LogIfTooSlow]
+            [InlineData(A)]
+            [InlineData(B)]
+            [InlineData(None)]
+            public void SerializesToParsableString(January2020CampaignConfiguration.AvailableOption option)
+            {
+                var config = new January2020CampaignConfiguration(option.ToString());
+
+                config.Option.Should().Be(option);
+            }
+        }
+    }
+}

--- a/Toggl.Shared/January2020CampaignConfiguration.cs
+++ b/Toggl.Shared/January2020CampaignConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Toggl.Shared
+{
+    public struct January2020CampaignConfiguration
+    {
+        public enum AvailableOption
+        {
+            None,
+            A,
+            B
+        }
+
+        public AvailableOption Option { get; }
+
+        public January2020CampaignConfiguration(string option)
+        {
+            Option = Enum.TryParse<AvailableOption>(option, true, out var result)
+                ? result
+                : AvailableOption.None;
+        }
+    }
+}

--- a/Toggl.iOS/RemoteConfigDefaults.plist
+++ b/Toggl.iOS/RemoteConfigDefaults.plist
@@ -2,13 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>UserRatingDialogDelayInDays</key>
-    <integer>5</integer>
-    <key>UserRatingDialogTrigger</key>
-    <string>none</string>
-    <key>PushNotificationsRegisterTokenWithServer</key>
-    <false/>
-    <key>PushNotificationsHandle</key>
-    <false/>
+	<key>UserRatingDialogDelayInDays</key>
+	<integer>5</integer>
+	<key>UserRatingDialogTrigger</key>
+	<string>none</string>
+	<key>PushNotificationsRegisterTokenWithServer</key>
+	<false/>
+	<key>PushNotificationsHandle</key>
+	<false/>
+	<key>January2020CampaignOption</key>
+	<string>none</string>
 </dict>
 </plist>

--- a/Toggl.iOS/Services/FetchRemoteConfigServiceIos.cs
+++ b/Toggl.iOS/Services/FetchRemoteConfigServiceIos.cs
@@ -47,5 +47,12 @@ namespace Toggl.iOS.Services
                 remoteConfig[RegisterPushNotificationsTokenWithServerParameter].BoolValue,
                 remoteConfig[HandlePushNotificationsParameter].BoolValue);
         }
+
+        public January2020CampaignConfiguration ExtractJanuary2020CampaignConfig()
+        {
+            var remoteConfig = RemoteConfig.SharedInstance;
+            return new January2020CampaignConfiguration(
+                remoteConfig[January2020CampaignOption].StringValue);
+        }
     }
 }


### PR DESCRIPTION
## What's this?
This PR adds a remote config option as it is specified in the referenced issue.

### Relationships
Ref #6616 

## Why do we want this?
We want A/B testing.

### Side effects
It's quite a lot of code for something so simple 🤔 

## :squid: Permissions
🦑 