### PR TITLE
Prevent a remote notifications related startup crash

### DIFF
--- a/Toggl.iOS/Startup/AppDelegate.PushNotifications.cs
+++ b/Toggl.iOS/Startup/AppDelegate.PushNotifications.cs
@@ -13,6 +13,7 @@ namespace Toggl.iOS
     {
         public override void RegisteredForRemoteNotifications(UIApplication application, NSData deviceToken)
         {
+            if (Messaging.SharedInstance == null) return;
             Messaging.SharedInstance.ApnsToken = deviceToken;
         }
 


### PR DESCRIPTION
## What's this?
I tried debugging the app on my iPhone and got a `NullReferenceException` here. No idea why or how the thing is null, but this PR fixes the crash.

### Relationships
`null`

## Why do we want this?
No startup crashes.

## :squid: Permissions
🦑 