### PR TITLE
Make campaign dialog not dismissible when tapping outside

### DIFF
--- a/Toggl.Droid/Fragments/January2020CampaignFragment.cs
+++ b/Toggl.Droid/Fragments/January2020CampaignFragment.cs
@@ -19,6 +19,7 @@ namespace Toggl.Droid.Fragments
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             base.OnCreateView(inflater, container, savedInstanceState);
+            Cancelable = false;
             var view = inflater.Inflate(Resource.Layout.January2020CampaignFragment, null);
 
             InitializeViews(view);


### PR DESCRIPTION
## What's this?
This makes campaign dialog not dismissible when tapping outside.
Ref #6616

## Why do we want this?
To make sure the users see the campaign, avoiding mistaps when the campaign dialog shows up.
Ref https://github.com/toggl/mobileapp/issues/6616#issuecomment-558209945
Internal conversation: /archives/C02APMYTM/p1574697864231100

## How is it done?
The change is very simple, take a look at the single line change.

## :squid: Permissions
🦑 it