### PR TITLE
Add Japanese localization for the Jan/2020 campaign

### DIFF
--- a/Toggl.Shared/Resources.ja-JP.resx
+++ b/Toggl.Shared/Resources.ja-JP.resx
@@ -1328,4 +1328,19 @@
     <data name="LoginToShowSuggestions" xml:space="preserve">
         <value>提案を表示するためにログイン</value>
     </data>
+    <data name="January2020CampaignTitle" xml:space="preserve">
+        <value>年掛けプランは20%OFF</value>
+    </data>
+    <data name="January2020CampaignPositiveButtonText" xml:space="preserve">
+        <value>詳しく</value>
+    </data>
+    <data name="January2020CampaignNegativeButtonText" xml:space="preserve">
+        <value>断る</value>
+    </data>
+    <data name="January2020CampaignTextVersionA" xml:space="preserve">
+        <value>年掛けプランに変更して、お年玉のためひ貯金を貯めます。</value>
+    </data>
+    <data name="January2020CampaignTextVersionB" xml:space="preserve">
+        <value>おーい、少し早いプレゼントをあげますよ。ここから1月17日までに年掛けプランに変更したら20%OFFになります。</value>
+    </data>
 </root>

--- a/Toggl.Shared/Resources.resx
+++ b/Toggl.Shared/Resources.resx
@@ -1333,22 +1333,17 @@ to project members</value>
     </data>
     <data name="January2020CampaignTitle" xml:space="preserve">
         <value>Save 20% on Annual Plans</value>
-        <comment>@Invariant</comment>
     </data>
     <data name="January2020CampaignPositiveButtonText" xml:space="preserve">
         <value>Learn more</value>
-        <comment>@Invariant</comment>
     </data>
     <data name="January2020CampaignNegativeButtonText" xml:space="preserve">
         <value>Dismiss</value>
-        <comment>@Invariant</comment>
     </data>
     <data name="January2020CampaignTextVersionA" xml:space="preserve">
         <value>Upgrade to any annual plan and pocket some extra cash just in time for the holiday season!</value>
-        <comment>@Invariant</comment>
     </data>
     <data name="January2020CampaignTextVersionB" xml:space="preserve">
         <value>Psst... we've got an early gift for you! Sign up for any annual plan between now and January 17th and get 20% off.</value>
-        <comment>@Invariant</comment>
     </data>
 </root>


### PR DESCRIPTION
## What's this?
This adds the Japanese localization for the Jan 2020 campaign

### Relationships
Ref #6616 

## Why do we want this?
To avoid having an English dialog appear in an app that's localized to Japanese.

## Localizations
I've wrote the localization myself, feel free to suggest something different.

## :squid: Permissions
🦑 it after the translations are greenlit internally 