### PR TITLE
Prevent null ref excepton in the iOS Widget

### DIFF
--- a/Toggl.iOS.Shared/SharedStorage.TimeEntries.cs
+++ b/Toggl.iOS.Shared/SharedStorage.TimeEntries.cs
@@ -86,7 +86,10 @@ namespace Toggl.iOS.Shared
                     change =>
                     {
                         var dict = change.NewValue as NSDictionary;
-                        onUpdate(getTimeEntryViewModel(dict));
+                        if (dict != null)
+                        {
+                            onUpdate(getTimeEntryViewModel(dict));
+                        }
                     });
         }
 

--- a/Toggl.iOS.Shared/SharedStorage.TimeEntries.cs
+++ b/Toggl.iOS.Shared/SharedStorage.TimeEntries.cs
@@ -86,10 +86,7 @@ namespace Toggl.iOS.Shared
                     change =>
                     {
                         var dict = change.NewValue as NSDictionary;
-                        if (dict != null)
-                        {
-                            onUpdate(getTimeEntryViewModel(dict));
-                        }
+                        onUpdate(getTimeEntryViewModel(dict));
                     });
         }
 

--- a/Toggl.iOS.TimerWidgetExtension/TodayViewController.cs
+++ b/Toggl.iOS.TimerWidgetExtension/TodayViewController.cs
@@ -60,7 +60,7 @@ namespace Toggl.iOS.TimerWidgetExtension
             dataSource.Callback = continueSuggestion;
             SuggestionsTableView.Source = dataSource;
 
-            SharedStorage.Instance.ObserveChangesToCurrentRunningTimeEntry(renderRunningTimeEntry);
+            SharedStorage.Instance.ObserveChangesToCurrentRunningTimeEntry(onDataChanged);
         }
 
         public override void ViewWillAppear(bool animated)
@@ -222,6 +222,20 @@ namespace Toggl.iOS.TimerWidgetExtension
 
             StartButton.Hidden = false;
             StopButton.Hidden = true;
+        }
+
+        private void onDataChanged(TimeEntryViewModel timeEntry)
+        {
+            if (timeEntry != null)
+            {
+                renderRunningTimeEntry(timeEntry);
+            }
+            else
+            {
+                elapsedTimeTimer?.Invalidate();
+                elapsedTimeTimer = null;
+                renderEmptyTimeEntry();
+            }
         }
 
         private void renderRunningTimeEntry(TimeEntryViewModel timeEntry)


### PR DESCRIPTION
## What's this?
A bugfix.

### Relationships
Closes #6871 

## Why do we want this?
No (fake) error messages! 🙈 

## How is it done?
When a TE was stopped, the observer tried to update the running entity, but it didn't account for TE stopping 🙈 

## :squid: Permissions
🦑 