### PR TITLE
🐛 Fix google login issue

### DIFF
--- a/Toggl.Droid/Activities/ReactiveActivity.GoogleTokenProvider.cs
+++ b/Toggl.Droid/Activities/ReactiveActivity.GoogleTokenProvider.cs
@@ -95,6 +95,10 @@ namespace Toggl.Droid.Activities
                     finally
                     {
                         isLoggingIn = false;
+                        if (googleApiClient.IsConnected)
+                        {
+                            googleApiClient.ClearDefaultAccountAndReconnect();
+                        }
                     }
                 });
             }


### PR DESCRIPTION
## What's this?
Fix for a weird issue where google login would just blink n fail if you had some successful/half-successful login before.

### Relationships

Closes #6572

## Why do we want this?
Google login should work every time

## How is it done?
The issue was that when you requested the google sign dialog for the second time, it would automatically choose and return the last logged user; thus the dialog would only blink and disappear.
When I finally understood where the problem is, I found out some related StackOverflow thread https://stackoverflow.com/questions/36659753/google-login-uses-same-account-everytime-users-login

Then I just carefully choose the right place for `googleApiClient.ClearDefaultAccountAndReconnect();  ` 

### Why not another way?
This seems to be the simplest way

### Side effects
Hopefully none

## Review hints
Here is the bundle build https://app.bitrise.io/build/033959b8f4386ce6#?tab=artifacts
I successfully installed `com.toggl.giskard-Signed.aab.universal.apk` and google login doesn't work there at all but it doesn't work even for the current develop(or 2.10) so it's probably not my fault 🤷‍♂ 
I've even tried the new simple https://play.google.com/apps/publish/internalappsharing/ method but also without success.
How do you test it then you ask? I have no idea - the only way I can think of now is to release it to the internal channel.

## :squid: Permissions
Anyone, anytime