### PR TITLE
Fix calendar day view lazy bindings

### DIFF
--- a/Toggl.Droid/Fragments/Calendar/CalendarDayViewPageFragment.cs
+++ b/Toggl.Droid/Fragments/Calendar/CalendarDayViewPageFragment.cs
@@ -140,6 +140,22 @@ namespace Toggl.Droid.Fragments.Calendar
             calendarDayView.HourHeight
                 .Subscribe(updateHourHeightIfCurrentPage)
                 .DisposedBy(DisposeBag);
+            
+            ViewModel.ContextualMenuViewModel
+                .CalendarItemInEditMode
+                .Subscribe(calendarDayView.SetCurrentItemInEditMode)
+                .DisposedBy(DisposeBag);
+
+            ViewModel.ContextualMenuViewModel
+                .MenuVisible
+                .Where(menuIsVisible => !menuIsVisible)
+                .Subscribe(_ => calendarDayView.ClearEditMode())
+                .DisposedBy(DisposeBag);
+
+            ViewModel.ContextualMenuViewModel
+                .DiscardChanges
+                .Subscribe(_ => calendarDayView.DiscardEditModeChanges())
+                .DisposedBy(DisposeBag);
         }
         private void handleMenuVisibility(bool visible)
         {
@@ -171,22 +187,6 @@ namespace Toggl.Droid.Fragments.Calendar
             ViewModel.ContextualMenuViewModel
                 .MenuVisible
                 .Subscribe(notifyMenuVisibilityIfCurrentPage)
-                .DisposedBy(DisposeBag);
-            
-            ViewModel.ContextualMenuViewModel
-                .CalendarItemInEditMode
-                .Subscribe(calendarDayView.SetCurrentItemInEditMode)
-                .DisposedBy(DisposeBag);
-
-            ViewModel.ContextualMenuViewModel
-                .MenuVisible
-                .Where(menuIsVisible => !menuIsVisible)
-                .Subscribe(_ => calendarDayView.ClearEditMode())
-                .DisposedBy(DisposeBag);
-
-            ViewModel.ContextualMenuViewModel
-                .DiscardChanges
-                .Subscribe(_ => calendarDayView.DiscardEditModeChanges())
                 .DisposedBy(DisposeBag);
 
             timeEntryPeriodObserver


### PR DESCRIPTION
## What's this?
This fixes the calendar day view bindings that were being done a little too late in the `CalendarDayViewPageFragment`.

### Relationships
Closes #6974

## Why do we want this?
So that the calendar works as expected.

## How is it done?
By moving the calendar day view bindings to where the calendar day view bindings should be.

### Why not another way?
This is the way.

## Review hints
Do a functional test please.

## :squid: Permissions
🦑 it please.