### PR TITLE
iOS 2.12: Mango

### DIFF
--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -36,6 +36,6 @@
 		<string>com.apple.intents-ui-service</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11</string>
+	<string>2.12</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -40,6 +40,6 @@
 		<string>IntentHandler</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11</string>
+	<string>2.12</string>
 </dict>
 </plist>

--- a/Toggl.iOS.TimerWidgetExtension/Info.plist
+++ b/Toggl.iOS.TimerWidgetExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11</string>
+	<string>2.12</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -81,7 +81,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11</string>
+	<string>2.12</string>
 	<key>CFBundleDisplayName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
## What's this?
The iOS 2.12 release.

Closes: #7139

### Changelog

- Added support for tasks in Siri Shortcuts
- Fixed a bug in calendar settings when requesting permissions
- Fixed several bugs in the calendar view
- Other syncing and performance improvements


https://github.com/toggl/mobileapp/compare/ios-2.11-2...release/ios-2.12-mango

### 🦑 Permissions
🚫Nope