### PR TITLE
Send fullname if possible on sign up with Apple

### DIFF
--- a/Toggl.Core.Tests/UI/ViewModels/LoginViewModelTests.cs
+++ b/Toggl.Core.Tests/UI/ViewModels/LoginViewModelTests.cs
@@ -368,27 +368,27 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
 
-                UserAccessManager.Received().ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>());
+                UserAccessManager.Received().ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>());
             }
 
             [Fact, LogIfTooSlow]
             public void DoesNothingWhenThePageIsCurrentlyLoading()
             {
                 var never = Observable.Never<Unit>();
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>()).Returns(never);
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>()).Returns(never);
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
 
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
 
-                UserAccessManager.Received(1).ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>());
+                UserAccessManager.Received(1).ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>());
             }
 
             [Fact, LogIfTooSlow]
             public void NavigatesToTheTimeEntriesViewModelWhenTheLoginSucceeds()
             {
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>())
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>())
                     .Returns(Observable.Return(Unit.Default));
 
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
@@ -399,8 +399,8 @@ namespace Toggl.Core.Tests.UI.ViewModels
             [Fact, LogIfTooSlow]
             public void TracksGoogleLoginEvent()
             {
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>())
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>())
                     .Returns(Observable.Return(Unit.Default));
 
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
@@ -413,8 +413,8 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 var observer = TestScheduler.CreateObserver<bool>();
                 ViewModel.IsLoading.Subscribe(observer);
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>())
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>())
                     .Returns(Observable.Throw<Unit>(new ThirdPartyLoginException(ThirdPartyLoginProvider.Google, false)));
 
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
@@ -430,8 +430,8 @@ namespace Toggl.Core.Tests.UI.ViewModels
             [Fact, LogIfTooSlow]
             public void DoesNotNavigateWhenTheLoginFails()
             {
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>())
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>())
                     .Returns(Observable.Throw<Unit>(new ThirdPartyLoginException(ThirdPartyLoginProvider.Google, false)));
 
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
@@ -444,8 +444,8 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 var observer = SchedulerProvider.TestScheduler.CreateObserver<string>();
                 ViewModel.ErrorMessage.Subscribe(observer);
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>())
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>())
                     .Returns(Observable.Throw<Unit>(new ThirdPartyLoginException(ThirdPartyLoginProvider.Google, true)));
 
                 ViewModel.ThirdPartyLogin(ThirdPartyLoginProvider.Google);
@@ -460,8 +460,8 @@ namespace Toggl.Core.Tests.UI.ViewModels
             public void SavesTheTimeOfLastLogin(DateTimeOffset now)
             {
                 TimeService.CurrentDateTime.Returns(now);
-                View.GetToken(ThirdPartyLoginProvider.Google).Returns(Observable.Return(""));
-                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<string>())
+                View.GetLoginInfo(ThirdPartyLoginProvider.Google).Returns(Observable.Return(new ThirdPartyLoginInfo("")));
+                UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>())
                     .Returns(Observable.Return(Unit.Default));
                 var viewModel = CreateViewModel();
                 viewModel.AttachView(View);

--- a/Toggl.Core.Tests/UI/ViewModels/SignupViewModelTests.cs
+++ b/Toggl.Core.Tests/UI/ViewModels/SignupViewModelTests.cs
@@ -316,7 +316,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                 ViewModel.GoogleSignup.Execute();
 
                 TestScheduler.Start();
-                UserAccessManager.DidNotReceive().ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>());
+                UserAccessManager.DidNotReceive().ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>());
             }
 
             [Fact, LogIfTooSlow]
@@ -324,7 +324,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 NavigationService.Navigate<TermsOfServiceViewModel, bool>(ViewModel.View).Returns(true);
                 UserAccessManager
-                    .ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>())
+                    .ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>())
                     .Returns(Observable.Throw<Unit>(new Exception()));
 
                 ViewModel.GoogleSignup.Execute();
@@ -355,19 +355,19 @@ namespace Toggl.Core.Tests.UI.ViewModels
                     ViewModel.GoogleSignup.Execute();
 
                     TestScheduler.Start();
-                    UserAccessManager.Received().ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), true, Arg.Any<int>(), Arg.Any<string>());
+                    UserAccessManager.Received().ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), true, Arg.Any<int>(), Arg.Any<string>());
                 }
 
                 [Fact, LogIfTooSlow]
                 public void DoesNothingWhenThePageIsCurrentlyLoading()
                 {
                     var never = Observable.Never<Unit>();
-                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(never);
+                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(never);
                     ViewModel.GoogleSignup.Execute();
                     ViewModel.GoogleSignup.Execute();
 
                     TestScheduler.Start();
-                    UserAccessManager.Received(1).ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>());
+                    UserAccessManager.Received(1).ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>());
                 }
 
                 [Fact, LogIfTooSlow]
@@ -376,7 +376,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                     var observer = TestScheduler.CreateObserver<bool>();
                     ViewModel.IsLoading.Subscribe(observer);
 
-                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), true, Arg.Any<int>(), Arg.Any<string>()).Returns(
+                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), true, Arg.Any<int>(), Arg.Any<string>()).Returns(
                         Observable.Never<Unit>());
 
                     ViewModel.GoogleSignup.Execute();
@@ -391,7 +391,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                 [Fact, LogIfTooSlow]
                 public void TracksGoogleSignupEvent()
                 {
-                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), true, Arg.Any<int>(), Arg.Any<string>()).Returns(
+                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), true, Arg.Any<int>(), Arg.Any<string>()).Returns(
                         Observable.Return(Unit.Default));
 
                     ViewModel.GoogleSignup.Execute();
@@ -406,7 +406,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                     var observer = TestScheduler.CreateObserver<bool>();
                     ViewModel.IsLoading.Subscribe(observer);
 
-                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(
+                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(
                         Observable.Throw<Unit>(new ThirdPartyLoginException(ThirdPartyLoginProvider.Google, false)));
 
                     ViewModel.GoogleSignup.Execute();
@@ -422,7 +422,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                 [Fact, LogIfTooSlow]
                 public void DoesNotNavigateWhenTheLoginFails()
                 {
-                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(
+                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(
                         Observable.Throw<Unit>(new ThirdPartyLoginException(ThirdPartyLoginProvider.Google, false)));
 
                     ViewModel.GoogleSignup.Execute();
@@ -439,7 +439,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                     var errorTextObserver = TestScheduler.CreateObserver<string>();
                     ViewModel.ErrorMessage.Subscribe(errorTextObserver);
 
-                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(
+                    UserAccessManager.ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>()).Returns(
                         Observable.Throw<Unit>(new ThirdPartyLoginException(ThirdPartyLoginProvider.Google, true)));
 
                     ViewModel.GoogleSignup.Execute();
@@ -468,7 +468,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
                         ViewModel.Initialize(DefaultParameters).Wait();
 
                         UserAccessManager
-                            .ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<string>(), true, Arg.Any<int>(), Arg.Any<string>())
+                            .ThirdPartySignUp(ThirdPartyLoginProvider.Google, Arg.Any<ThirdPartyLoginInfo>(), true, Arg.Any<int>(), Arg.Any<string>())
                             .Returns(Observable.Return(Unit.Default));
 
                         NavigationService.Navigate<TermsOfServiceViewModel, bool>(ViewModel.View).Returns(true);

--- a/Toggl.Core.Tests/UserAccessManager/UserAccessManagerTests.cs
+++ b/Toggl.Core.Tests/UserAccessManager/UserAccessManagerTests.cs
@@ -551,7 +551,8 @@ namespace Toggl.Core.Tests.Login
             [Fact, LogIfTooSlow]
             public async Task EmptiesTheDatabaseBeforeTryingToCreateTheUser()
             {
-                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken);
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
+                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo);
 
                 Received.InOrder(async () =>
                 {
@@ -563,7 +564,8 @@ namespace Toggl.Core.Tests.Login
             [Fact, LogIfTooSlow]
             public async Task CallsTheGetWithGoogleOfTheUserApi()
             {
-                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken);
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
+                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo);
 
                 await Api.User.Received().GetWithGoogle();
             }
@@ -571,7 +573,8 @@ namespace Toggl.Core.Tests.Login
             [Fact, LogIfTooSlow]
             public async Task PersistsTheUserToTheDatabase()
             {
-                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken);
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
+                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo);
 
                 await Database.User.Received().Create(Arg.Is<IDatabaseUser>(receivedUser => receivedUser.Id == User.Id));
             }
@@ -579,7 +582,8 @@ namespace Toggl.Core.Tests.Login
             [Fact, LogIfTooSlow]
             public async Task PersistsTheUserWithTheSyncStatusSetToInSync()
             {
-                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken);
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
+                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo);
 
                 await Database.User.Received().Create(Arg.Is<IDatabaseUser>(receivedUser => receivedUser.SyncStatus == SyncStatus.InSync));
             }
@@ -587,15 +591,17 @@ namespace Toggl.Core.Tests.Login
             [Fact, LogIfTooSlow]
             public async Task AlwaysReturnsASingleResult()
             {
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
                 await UserAccessManager
-                        .ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken)
+                        .ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo)
                         .SingleAsync();
             }
 
             [Fact, LogIfTooSlow]
             public async Task SavesTheApiTokenToPrivateSharedStorage()
             {
-                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken);
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
+                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo);
 
                 PrivateSharedStorageService.Received().SaveApiToken(Arg.Any<string>());
             }
@@ -603,7 +609,8 @@ namespace Toggl.Core.Tests.Login
             [Fact, LogIfTooSlow]
             public async Task SavesTheUserIdToPrivateSharedStorage()
             {
-                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, googleToken);
+                var loginInfo = new ThirdPartyLoginInfo(googleToken);
+                await UserAccessManager.ThirdPartyLogin(ThirdPartyLoginProvider.Google, loginInfo);
 
                 PrivateSharedStorageService.Received().SaveUserId(Arg.Any<long>());
             }

--- a/Toggl.Core.UI/ViewModels/LoginViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/LoginViewModel.cs
@@ -200,8 +200,8 @@ namespace Toggl.Core.UI.ViewModels
                 : AuthenticationMethod.Apple;
 
             loginDisposable = View?
-                .GetToken(provider)
-                .SelectMany(token => userAccessManager.ThirdPartyLogin(provider, token))
+                .GetLoginInfo(provider)
+                .SelectMany(loginInfo => userAccessManager.ThirdPartyLogin(provider, loginInfo))
                 .Track(analyticsService.Login, authenticationMethod)
                 .Subscribe(_ => onAuthenticated(), onError, onCompleted);
         }

--- a/Toggl.Core.UI/ViewModels/SignupViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/SignupViewModel.cs
@@ -355,9 +355,9 @@ namespace Toggl.Core.UI.ViewModels
             isLoadingSubject.OnNext(true);
             errorMessageSubject.OnNext(string.Empty);
 
-            signupDisposable = View.GetToken(ThirdPartyLoginProvider.Google)
-                .SelectMany(googleToken => userAccessManager
-                    .ThirdPartySignUp(ThirdPartyLoginProvider.Google, googleToken, termsOfServiceAccepted, (int)countryId.Value, timezone))
+            signupDisposable = View.GetLoginInfo(ThirdPartyLoginProvider.Google)
+                .SelectMany(loginInfo => userAccessManager
+                    .ThirdPartySignUp(ThirdPartyLoginProvider.Google, loginInfo, termsOfServiceAccepted, (int)countryId.Value, timezone))
                 .Track(analyticsService.SignUp, AuthenticationMethod.Google)
                 .Subscribe(_ => onAuthenticated(), onError, onCompleted);
         }
@@ -377,9 +377,9 @@ namespace Toggl.Core.UI.ViewModels
             isLoadingSubject.OnNext(true);
             errorMessageSubject.OnNext(string.Empty);
 
-            signupDisposable = View.GetToken(ThirdPartyLoginProvider.Apple)
-                .SelectMany(appleToken => userAccessManager
-                    .ThirdPartySignUp(ThirdPartyLoginProvider.Apple, appleToken, termsOfServiceAccepted, (int)countryId.Value, timezone))
+            signupDisposable = View.GetLoginInfo(ThirdPartyLoginProvider.Apple)
+                .SelectMany(loginInfo => userAccessManager
+                    .ThirdPartySignUp(ThirdPartyLoginProvider.Apple, loginInfo, termsOfServiceAccepted, (int)countryId.Value, timezone))
                 .Track(analyticsService.SignUp, AuthenticationMethod.Apple)
                 .Subscribe(_ => onAuthenticated(), onError, onCompleted);
         }

--- a/Toggl.Core.UI/Views/IThirdPartyTokenProvider.cs
+++ b/Toggl.Core.UI/Views/IThirdPartyTokenProvider.cs
@@ -5,6 +5,6 @@ namespace Toggl.Core.UI.Views
 {
     public interface IThirdPartyTokenProvider
     {
-        IObservable<string> GetToken(ThirdPartyLoginProvider provider);
+        IObservable<ThirdPartyLoginInfo> GetLoginInfo(ThirdPartyLoginProvider provider);
     }
 }

--- a/Toggl.Core/Helper/ThirdPartyLoginInfo.cs
+++ b/Toggl.Core/Helper/ThirdPartyLoginInfo.cs
@@ -1,0 +1,14 @@
+namespace Toggl.Core.Helper
+{
+    public struct ThirdPartyLoginInfo
+    {
+        public string Token { get; }
+        public string Fullname { get; }
+
+        public ThirdPartyLoginInfo(string token, string fullname = null)
+        {
+            Token = token;
+            Fullname = fullname;
+        }
+    }
+}

--- a/Toggl.Core/UserAccessManager/IUserAccessManager.cs
+++ b/Toggl.Core/UserAccessManager/IUserAccessManager.cs
@@ -19,10 +19,10 @@ namespace Toggl.Core.Login
 
         void LoginWithSavedCredentials();
 
-        IObservable<Unit> ThirdPartyLogin(ThirdPartyLoginProvider provider, string token);
+        IObservable<Unit> ThirdPartyLogin(ThirdPartyLoginProvider provider, ThirdPartyLoginInfo loginInfo);
         IObservable<Unit> Login(Email email, Password password);
 
-        IObservable<Unit> ThirdPartySignUp(ThirdPartyLoginProvider provider, string token, bool termsAccepted, int countryId, string timezone);
+        IObservable<Unit> ThirdPartySignUp(ThirdPartyLoginProvider provider, ThirdPartyLoginInfo loginInfo, bool termsAccepted, int countryId, string timezone);
         IObservable<Unit> SignUp(Email email, Password password, bool termsAccepted, int countryId, string timezone);
 
         IObservable<Unit> RefreshToken(Password password);

--- a/Toggl.Droid/Activities/ReactiveActivity.ThirdPartyTokenProvider.cs
+++ b/Toggl.Droid/Activities/ReactiveActivity.ThirdPartyTokenProvider.cs
@@ -25,17 +25,17 @@ namespace Toggl.Droid.Activities
 
         private bool isLoggingIn;
         private GoogleApiClient googleApiClient;
-        private Subject<string> loginSubject = new Subject<string>();
+        private Subject<ThirdPartyLoginInfo> loginSubject = new Subject<ThirdPartyLoginInfo>();
 
-        public IObservable<string> GetToken(ThirdPartyLoginProvider provider)
+        public IObservable<ThirdPartyLoginInfo> GetLoginInfo(ThirdPartyLoginProvider provider)
         {
             if (provider == ThirdPartyLoginProvider.Google)
-                return getGoogleToken();
+                return getGoogleLoginInfo();
 
             throw new InvalidOperationException("You shouldn't be doing this from Android.");
         }
 
-        private IObservable<string> getGoogleToken()
+        private IObservable<ThirdPartyLoginInfo> getGoogleLoginInfo()
         {
             ensureApiClientExists();
 
@@ -55,7 +55,7 @@ namespace Toggl.Droid.Activities
                 return logoutSubject.AsObservable();
             }
 
-            IObservable<string> getGoogleToken(Unit _)
+            IObservable<ThirdPartyLoginInfo> getGoogleToken(Unit _)
             {
                 lock (lockable)
                 {
@@ -63,7 +63,7 @@ namespace Toggl.Droid.Activities
                         return loginSubject.AsObservable();
 
                     isLoggingIn = true;
-                    loginSubject = new Subject<string>();
+                    loginSubject = new Subject<ThirdPartyLoginInfo>();
 
                     if (googleApiClient.IsConnected)
                     {
@@ -94,7 +94,8 @@ namespace Toggl.Droid.Activities
                     try
                     {
                         var token = GoogleAuthUtil.GetToken(Application.Context, signInData.SignInAccount.Account, scope);
-                        loginSubject.OnNext(token);
+                        var loginInfo = new ThirdPartyLoginInfo(token);
+                        loginSubject.OnNext(loginInfo);
                         loginSubject.OnCompleted();
                     }
                     catch (Exception e)

--- a/Toggl.Droid/Fragments/Calendar/CalendarDayViewPageFragment.PermissionHandler.cs
+++ b/Toggl.Droid/Fragments/Calendar/CalendarDayViewPageFragment.PermissionHandler.cs
@@ -36,12 +36,12 @@ namespace Toggl.Droid.Fragments.Calendar
         public void OpenAppSettings()
             => this.FireAppSettingsIntent();
 
-        public IObservable<string> GetToken(ThirdPartyLoginProvider provider)
+        public IObservable<ThirdPartyLoginInfo> GetLoginInfo(ThirdPartyLoginProvider provider)
         {
             if (!(Activity is IThirdPartyTokenProvider tokenProvider))
                 throw new InvalidOperationException();
 
-            return tokenProvider.GetToken(provider);
+            return tokenProvider.GetLoginInfo(provider);
         }
 
         public void Close()

--- a/Toggl.Droid/Fragments/ReactiveDialogFragment.cs
+++ b/Toggl.Droid/Fragments/ReactiveDialogFragment.cs
@@ -135,7 +135,7 @@ namespace Toggl.Droid.Fragments
         public IObservable<bool> RequestNotificationAuthorization(bool force = false)
             => throw new InvalidOperationException("You shouldn't be doing this from the Dialog. Use the parent activity/fragment");
 
-        public IObservable<string> GetToken(ThirdPartyLoginProvider provider)
+        public IObservable<ThirdPartyLoginInfo> GetLoginInfo(ThirdPartyLoginProvider provider)
             => throw new InvalidOperationException("You shouldn't be doing this from the Dialog. Use the parent activity/fragment");
     }
 }

--- a/Toggl.Droid/Fragments/ReactiveTabFragment.cs
+++ b/Toggl.Droid/Fragments/ReactiveTabFragment.cs
@@ -101,12 +101,12 @@ namespace Toggl.Droid.Fragments
         {
         }
 
-        public IObservable<string> GetToken(ThirdPartyLoginProvider provider)
+        public IObservable<ThirdPartyLoginInfo> GetLoginInfo(ThirdPartyLoginProvider provider)
         {
             if (!(Activity is IThirdPartyTokenProvider tokenProvider))
                 throw new InvalidOperationException();
 
-            return tokenProvider.GetToken(provider);
+            return tokenProvider.GetLoginInfo(provider);
         }
 
         public bool OnMenuItemClick(IMenuItem item)

--- a/Toggl.Networking.Tests/ApiClients/UserApiTests.cs
+++ b/Toggl.Networking.Tests/ApiClients/UserApiTests.cs
@@ -108,10 +108,19 @@ namespace Toggl.Networking.Tests.ApiClients
                 => api.SignUpWithGoogle("", true, 237, null);
         }
 
-        public class TheSignUpWithAppleMethod : Base
+        public class TheSignUpWithAppleMethod
         {
-            protected override Task<IUser> CallEndpoint(IUserApi api)
-                => api.SignUpWithApple("daneel.debug", "", true, 237, null);
+            public class WithFullname : Base
+            {
+                protected override Task<IUser> CallEndpoint(IUserApi api)
+                    => api.SignUpWithApple("daneel.debug", "", "John Appleseed", true, 237, null);
+            }
+
+            public class WithoutFullname : Base
+            {
+                protected override Task<IUser> CallEndpoint(IUserApi api)
+                    => api.SignUpWithApple("daneel.debug", "", null, true, 237, null);
+            }
         }
     }
 }

--- a/Toggl.Networking/ApiClients/Interfaces/IUserApi.cs
+++ b/Toggl.Networking/ApiClients/Interfaces/IUserApi.cs
@@ -13,6 +13,6 @@ namespace Toggl.Networking.ApiClients
         Task<string> ResetPassword(Email email);
         Task<IUser> SignUp(Email email, Password password, bool termsAccepted, int countryId, string timezone);
         Task<IUser> SignUpWithGoogle(string googleToken, bool termsAccepted, int countryId, string timezone);
-        Task<IUser> SignUpWithApple(string clientId, string appleToken, bool termsAccepted, int countryId, string timezone);
+        Task<IUser> SignUpWithApple(string clientId, string appleToken, string fullname, bool termsAccepted, int countryId, string timezone);
     }
 }

--- a/Toggl.Networking/ApiClients/UserApi.cs
+++ b/Toggl.Networking/ApiClients/UserApi.cs
@@ -116,13 +116,14 @@ namespace Toggl.Networking.ApiClients
                 .ConfigureAwait(false);
         }
 
-        public async Task<IUser> SignUpWithApple(string clientId, string appleToken, bool termsAccepted, int countryId, string timezone)
+        public async Task<IUser> SignUpWithApple(string clientId, string appleToken, string fullname, bool termsAccepted, int countryId, string timezone)
         {
             Ensure.Argument.IsNotNull(appleToken, nameof(appleToken));
             var parameters = new ThirdPartySignUpParameters
             {
                 Provider = appleProvider,
                 Token = appleToken,
+                Fullname = fullname,
                 Workspace = new WorkspaceParameters
                 {
                     InitialPricingPlan = PricingPlans.Free
@@ -171,6 +172,9 @@ namespace Toggl.Networking.ApiClients
             public string Token { get; set; }
 
             public string Provider { get; set; }
+
+            [JsonProperty("full_name", NullValueHandling = NullValueHandling.Ignore)]
+            public string? Fullname { get; set; }
 
             public WorkspaceParameters Workspace { get; set; }
 

--- a/Toggl.iOS/ViewControllers/Reactive/ReactiveTableViewController.cs
+++ b/Toggl.iOS/ViewControllers/Reactive/ReactiveTableViewController.cs
@@ -96,7 +96,7 @@ namespace Toggl.iOS.ViewControllers
             DisposeBag?.Dispose();
         }
 
-        public IObservable<string> GetToken(ThirdPartyLoginProvider provider)
+        public IObservable<ThirdPartyLoginInfo> GetLoginInfo(ThirdPartyLoginProvider provider)
             => throw new InvalidOperationException();
 
         protected virtual void ConfigureKeyCommands()


### PR DESCRIPTION
## What's this?
Sends the fullname on sign up with Apple.

### Relationships

Closes #7166 

## Why do we want this?
Because otherwise the username will be taken from the email address and we don't want to send emails to users saying "Hi asd987asd, Welcome to Toggl..."

## How is it done?
Fetching the fullname from the returned data in the apple token provider.

### Why not another way?
This is the way.

### Side effects
None.

## Review hints
If you are going to test this, make sure to unlink toggl from your appleid first, otherwise it might not work (and that's fine, it's how sign in with Apple works).

## :squid: Permissions
⛔️ No