### PR TITLE
Fix google signup

### DIFF
--- a/Toggl.Core.Tests/UI/ViewModels/OnboardingViewModelTests.cs
+++ b/Toggl.Core.Tests/UI/ViewModels/OnboardingViewModelTests.cs
@@ -10,6 +10,7 @@ using Toggl.Core.UI.Navigation;
 using Toggl.Core.UI.Parameters;
 using Toggl.Core.UI.ViewModels;
 using Toggl.Core.UI.Views;
+using Toggl.Networking.Exceptions;
 using Toggl.Shared;
 using Toggl.Shared.Models;
 using Toggl.Storage.Settings;
@@ -149,7 +150,26 @@ namespace Toggl.Core.Tests.UI.ViewModels
             }
 
             [Fact, LogIfTooSlow]
-            public void DoesntDisplayAnErrorWhenLoginFails()
+            public void DisplaysAnErrorWhenLoginFailsWithGoogleError()
+            {
+                UserAccessManager
+                    .LoginWithGoogle(Arg.Any<string>())
+                    .Returns(Observable.Throw<Unit>(new GoogleLoginException(false)));
+
+                ViewModel.ContinueWithGoogle.Execute();
+
+                TestScheduler.Start();
+
+                View.DidNotReceive()
+                    .Alert(
+                        Arg.Any<string>(),
+                        Arg.Any<string>(),
+                        Arg.Any<string>())
+                    .Wait();
+            }
+
+            [Fact, LogIfTooSlow]
+            public void DoesntDisplayAnErrorWhenLoginFailsWithGenericError()
             {
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
@@ -191,7 +211,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
-                    .Returns(Observable.Throw<Unit>(new GoogleLoginException(false)));
+                    .Returns(Observable.Throw<Unit>(new Exception()));
 
                 UserAccessManager
                     .SignUpWithGoogle(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>())
@@ -231,7 +251,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
             {
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
-                    .Returns(Observable.Throw<Unit>(new GoogleLoginException(false)));
+                    .Returns(Observable.Throw<Unit>(new Exception()));
 
                 UserAccessManager
                     .SignUpWithGoogle(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>())
@@ -300,7 +320,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
 
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
-                    .Returns(Observable.Throw<Unit>(new GoogleLoginException(false)));
+                    .Returns(Observable.Throw<Unit>(new Exception()));
                 UserAccessManager
                     .SignUpWithGoogle(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<int>(), Arg.Any<string>())
                     .Returns(Observable.Return(Unit.Default));

--- a/Toggl.Core.Tests/UI/ViewModels/OnboardingViewModelTests.cs
+++ b/Toggl.Core.Tests/UI/ViewModels/OnboardingViewModelTests.cs
@@ -160,7 +160,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
 
                 TestScheduler.Start();
 
-                View.DidNotReceive()
+                View.Received()
                     .Alert(
                         Arg.Any<string>(),
                         Arg.Any<string>(),
@@ -287,9 +287,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
 
                 TestScheduler.Start();
                 observer.Messages.AssertEqual(
-                    ReactiveTest.OnNext(1, false),
-                    ReactiveTest.OnNext(2, true),
-                    ReactiveTest.OnNext(3, false)
+                    ReactiveTest.OnNext(1, false)
                 );
             }
 

--- a/Toggl.Core.Tests/UI/ViewModels/OnboardingViewModelTests.cs
+++ b/Toggl.Core.Tests/UI/ViewModels/OnboardingViewModelTests.cs
@@ -149,7 +149,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
             }
 
             [Fact, LogIfTooSlow]
-            public void DisplaysErrorWhenLoginFails()
+            public void DoesntDisplayAnErrorWhenLoginFails()
             {
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
@@ -159,16 +159,16 @@ namespace Toggl.Core.Tests.UI.ViewModels
 
                 TestScheduler.Start();
 
-                View.Received()
+                View.DidNotReceive()
                     .Alert(
-                        Arg.Is(Resources.Oops),
-                        Arg.Is(Resources.GenericLoginError),
-                        Arg.Is(Resources.Ok))
+                        Arg.Any<string>(),
+                        Arg.Any<string>(),
+                        Arg.Any<string>())
                     .Wait();
             }
 
             [Fact, LogIfTooSlow]
-            public void DoesntSetIsLoadingToFalseWhenLoginFails()
+            public void SetIsLoadingToTrueWhenLoginFails()
             {
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
@@ -181,7 +181,8 @@ namespace Toggl.Core.Tests.UI.ViewModels
 
                 TestScheduler.Start();
                 observer.Messages.AssertEqual(
-                    ReactiveTest.OnNext(1, false)
+                    ReactiveTest.OnNext(1, false),
+                    ReactiveTest.OnNext(2, true)
                 );
             }
 
@@ -249,7 +250,7 @@ namespace Toggl.Core.Tests.UI.ViewModels
             }
 
             [Fact, LogIfTooSlow]
-            public void DoesntSetIsLoadingToFalseWhenSignupFails()
+            public void SetIsLoadingToFalseWhenSignupFails()
             {
                 UserAccessManager
                     .LoginWithGoogle(Arg.Any<string>())
@@ -266,7 +267,9 @@ namespace Toggl.Core.Tests.UI.ViewModels
 
                 TestScheduler.Start();
                 observer.Messages.AssertEqual(
-                    ReactiveTest.OnNext(1, false)
+                    ReactiveTest.OnNext(1, false),
+                    ReactiveTest.OnNext(2, true),
+                    ReactiveTest.OnNext(3, false)
                 );
             }
 

--- a/Toggl.Core.UI/ViewModels/OnboardingViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/OnboardingViewModel.cs
@@ -135,16 +135,18 @@ namespace Toggl.Core.UI.ViewModels
 
         private void onGoogleLoginFailure(Exception exception)
         {
-            var e = exception as GoogleLoginException;
+            if (exception is GoogleLoginException)
+            {
+                View.Alert(Resources.Oops, Resources.GenericLoginError, Resources.Ok);
+                return;
+            }
 
-            if (e == null)
+            if (exception != null)
             {
                 isLoadingSubject.OnNext(false);
                 analyticsService.UnknownSignUpFailure.Track(exception.GetType().FullName, exception.Message);
                 analyticsService.TrackAnonymized(exception);
             }
-
-            if (e != null && e.LoginWasCanceled) return;
 
             signUpWithGoogle();
         }
@@ -174,14 +176,8 @@ namespace Toggl.Core.UI.ViewModels
         {
             isLoadingSubject.OnNext(false);
 
-            var e = exception as GoogleLoginException;
-            if (e == null)
-            {
-                analyticsService.UnknownSignUpFailure.Track(exception.GetType().FullName, exception.Message);
-                analyticsService.TrackAnonymized(exception);
-            }
-            else if (e.LoginWasCanceled) return;
-
+            analyticsService.UnknownSignUpFailure.Track(exception.GetType().FullName, exception.Message);
+            analyticsService.TrackAnonymized(exception);
             View.Alert(Resources.Oops, Resources.GenericSignUpError, Resources.Ok);
         }
 

--- a/Toggl.Core.UI/ViewModels/OnboardingViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/OnboardingViewModel.cs
@@ -137,14 +137,12 @@ namespace Toggl.Core.UI.ViewModels
         {
             if (exception is GoogleLoginException)
             {
-                isLoadingSubject.OnNext(false);
                 View.Alert(Resources.Oops, Resources.GenericLoginError, Resources.Ok);
                 return;
             }
 
             if (exception != null)
             {
-                isLoadingSubject.OnNext(false);
                 analyticsService.UnknownSignUpFailure.Track(exception.GetType().FullName, exception.Message);
                 analyticsService.TrackAnonymized(exception);
             }
@@ -158,14 +156,12 @@ namespace Toggl.Core.UI.ViewModels
 
             if (country == null) return;
 
-            isLoadingSubject.OnNext(true);
-
             interactorFactory.GetSupportedTimezones().Execute()
                 .Select(supportedTimezones =>
                     supportedTimezones.FirstOrDefault(tz => platformInfo.TimezoneIdentifier == tz)
                 )
                 .Select(timezone =>
-                    userAccessManager.SignUpWithGoogle(googleToken, true, (int) country.Id, timezone)
+                    userAccessManager.SignUpWithGoogle(googleToken, true, (int)country.Id, timezone)
                 )
                 .Merge()
                 .Track(analyticsService.SignUp, AuthenticationMethod.Google)

--- a/Toggl.Core.UI/ViewModels/OnboardingViewModel.cs
+++ b/Toggl.Core.UI/ViewModels/OnboardingViewModel.cs
@@ -137,6 +137,7 @@ namespace Toggl.Core.UI.ViewModels
         {
             if (exception is GoogleLoginException)
             {
+                isLoadingSubject.OnNext(false);
                 View.Alert(Resources.Oops, Resources.GenericLoginError, Resources.Ok);
                 return;
             }

--- a/Toggl.iOS/Presentation/NavigationPresenter.cs
+++ b/Toggl.iOS/Presentation/NavigationPresenter.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using Toggl.Core.UI.ViewModels;
 using Toggl.Core.UI.ViewModels.Settings;
 using Toggl.Core.UI.Views;
+using Toggl.iOS.Presentation.Transition;
 using UIKit;
 
 namespace Toggl.iOS.Presentation
 {
     public sealed class NavigationPresenter : IosPresenter
     {
+        private readonly FromBottomTransitionDelegate fromBottomTransitionDelegate = new FromBottomTransitionDelegate();
         protected override HashSet<Type> AcceptedViewModels { get; } = new HashSet<Type>
         {
             typeof(AboutViewModel),
@@ -42,6 +44,14 @@ namespace Toggl.iOS.Presentation
 
                 if (!tryPushOnViewController(selectedController, viewController))
                     throw new Exception($"Failed to find a navigation controller to present view controller of type {viewController.GetType().Name}");
+            }
+            else
+            {
+                viewController.ModalPresentationStyle = UIModalPresentationStyle.Custom;
+                viewController.TransitioningDelegate = fromBottomTransitionDelegate;
+
+                UIViewController topmostViewController = FindPresentedViewController();
+                topmostViewController.PresentViewController(viewController, true, null);
             }
         }
 


### PR DESCRIPTION
## What's this?
Fixes the google signup in the onboardingVC

### Relationships
none

## Why do we want this?
We kind of want users to signup.

## How is it done?
I changed the NavigationPresenter to present modally if the presentingVC is not a navigationController. Fixed onboardingVC to actually signup after failed login.

### Why not another way?


### Side effects
The issue is that the from the moment the login attempt starts there is a considerable time passing until the error is returned and the signup starts (by showing the country selection UI). No loading UI at this point makes the app look like it is doing nothing and waiting for user to tap buttons.

## Review hints
Create a google account and try to signup

Ping me if you need help setting up the goole signup in debug.

## :squid: Permissions
:squid: