### PR TITLE
💄 Fix reports segment colors

### DIFF
--- a/Toggl.iOS/Resources/Colors.xcassets/ReportsBarChartFilled.colorset/Contents.json
+++ b/Toggl.iOS/Resources/Colors.xcassets/ReportsBarChartFilled.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": 0.0235294122,
-          "green": 0.6666667,
-          "blue": 0.9607843,
+          "red": 0.2784314,
+          "green": 0.7647059,
+          "blue": 0.9882353,
           "alpha": 1.0
         }
       }

--- a/Toggl.iOS/Resources/Colors.xcassets/ReportsBarChartTotal.colorset/Contents.json
+++ b/Toggl.iOS/Resources/Colors.xcassets/ReportsBarChartTotal.colorset/Contents.json
@@ -5,9 +5,9 @@
       "color": {
         "color-space": "srgb",
         "components": {
-          "red": 0.2784314,
-          "green": 0.7647059,
-          "blue": 0.9882353,
+          "red": 0.0235294122,
+          "green": 0.6666667,
+          "blue": 0.9607843,
           "alpha": 1.0
         }
       }


### PR DESCRIPTION
## What's this?
Interchanges the billable and non billable colors for the reports bar view. Those were set the wrong way.

### Relationships
Closes #7202

## Why do we want this?
people called us out on twitter

## How is it done?
Interchanges the billable and non billable colors for the reports bar view

## Review hints
check agains web

## :squid: Permissions
me