### PR TITLE
Add UniqueId to entities and update DB with a migration

### DIFF
--- a/Toggl.Core.Tests/Mocks/MockClient.cs
+++ b/Toggl.Core.Tests/Mocks/MockClient.cs
@@ -11,6 +11,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long WorkspaceId { get; set; }
 
+        public string UniqueId { get; set; }
+
         public string Name { get; set; }
 
         public DateTimeOffset At { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockPreferences.cs
+++ b/Toggl.Core.Tests/Mocks/MockPreferences.cs
@@ -21,5 +21,7 @@ namespace Toggl.Core.Tests.Mocks
         public bool IsDeleted { get; set; }
 
         public long Id { get; set; }
+
+        public string UniqueId { get; set; }
     }
 }

--- a/Toggl.Core.Tests/Mocks/MockProject.cs
+++ b/Toggl.Core.Tests/Mocks/MockProject.cs
@@ -46,6 +46,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockTag.cs
+++ b/Toggl.Core.Tests/Mocks/MockTag.cs
@@ -19,6 +19,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockTask.cs
+++ b/Toggl.Core.Tests/Mocks/MockTask.cs
@@ -31,6 +31,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockTimeEntry.cs
+++ b/Toggl.Core.Tests/Mocks/MockTimeEntry.cs
@@ -43,6 +43,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockUser.cs
+++ b/Toggl.Core.Tests/Mocks/MockUser.cs
@@ -42,6 +42,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockWorkspace.cs
+++ b/Toggl.Core.Tests/Mocks/MockWorkspace.cs
@@ -36,6 +36,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Core.Tests/Mocks/MockWorkspaceFeatureCollection.cs
+++ b/Toggl.Core.Tests/Mocks/MockWorkspaceFeatureCollection.cs
@@ -9,6 +9,8 @@ namespace Toggl.Core.Tests.Mocks
     {
         public long Id => WorkspaceId;
 
+        public string UniqueId { get; set; }
+
         IDatabaseWorkspace IDatabaseWorkspaceFeatureCollection.Workspace => Workspace;
 
         IEnumerable<IDatabaseWorkspaceFeature> IDatabaseWorkspaceFeatureCollection.DatabaseFeatures => DatabaseFeatures;

--- a/Toggl.Core.Tests/Sync/States/Push/TestModel.cs
+++ b/Toggl.Core.Tests/Sync/States/Push/TestModel.cs
@@ -57,6 +57,8 @@ namespace Toggl.Core.Tests.Sync.States
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public DateTimeOffset At { get; set; }
 
         public DateTimeOffset? ServerDeletedAt { get; set; }

--- a/Toggl.Core/Interactors/Client/CreateClientInteractor.cs
+++ b/Toggl.Core/Interactors/Client/CreateClientInteractor.cs
@@ -39,6 +39,7 @@ namespace Toggl.Core.Interactors
         public IObservable<IThreadSafeClient> Execute()
             => dataSource.Create(new Client(
                 idProvider.GetNextIdentifier(),
+                idProvider.GetNewUniqueId(),
                 workspaceId,
                 clientName,
                 timeService.CurrentDateTime,

--- a/Toggl.Core/Interactors/Location/GetAllCountriesInteractor.cs
+++ b/Toggl.Core/Interactors/Location/GetAllCountriesInteractor.cs
@@ -15,6 +15,8 @@ namespace Toggl.Core.Interactors
         {
             public long Id { get; set; }
 
+            public string UniqueId { get; }
+
             public string Name { get; set; }
 
             [JsonProperty("country_code")]

--- a/Toggl.Core/Interactors/Project/CreateProjectInteractor.cs
+++ b/Toggl.Core/Interactors/Project/CreateProjectInteractor.cs
@@ -37,6 +37,7 @@ namespace Toggl.Core.Interactors
         public IObservable<IThreadSafeProject> Execute()
             => idProvider.GetNextIdentifier()
                 .Apply(Project.Builder.Create)
+                .SetUniqueId(idProvider.GetNewUniqueId())
                 .SetName(dto.Name)
                 .SetColor(dto.Color)
                 .SetClientId(dto.ClientId)

--- a/Toggl.Core/Interactors/TimeEntry/CreateTimeEntryInteractor.cs
+++ b/Toggl.Core/Interactors/TimeEntry/CreateTimeEntryInteractor.cs
@@ -73,6 +73,7 @@ namespace Toggl.Core.Interactors
             => idProvider.GetNextIdentifier()
                 .Apply(TimeEntry.Builder.Create)
                 .SetUserId(user.Id)
+                .SetUniqueId(idProvider.GetNewUniqueId())
                 .SetTagIds(prototype.TagIds)
                 .SetTaskId(prototype.TaskId)
                 .SetStart(startTime)

--- a/Toggl.Core/Interactors/Workspace/CreateDefaultWorkspaceInteractor.cs
+++ b/Toggl.Core/Interactors/Workspace/CreateDefaultWorkspaceInteractor.cs
@@ -57,6 +57,7 @@ namespace Toggl.Core.Interactors
         private IObservable<IThreadSafeWorkspace> createWorkspace(IThreadSafeUser user)
             => idProvider.GetNextIdentifier()
                 .Apply(Workspace.Builder.Create)
+                .SetUniqueId(idProvider.GetNewUniqueId())
                 .SetName(string.Format(Resources.WorkspacePossesive, user.Fullname))
                 .SetAt(timeService.CurrentDateTime)
                 .SetSyncStatus(SyncStatus.SyncNeeded)

--- a/Toggl.Core/Models/Client.cs
+++ b/Toggl.Core/Models/Client.cs
@@ -9,6 +9,7 @@ namespace Toggl.Core.Models
     internal class Client : IThreadSafeClient
     {
         public long Id { get; }
+        public string UniqueId { get; }
         public long WorkspaceId { get; }
         public string Name { get; }
         public DateTimeOffset At { get; }
@@ -22,12 +23,13 @@ namespace Toggl.Core.Models
         public bool IsInaccessible => Workspace.IsInaccessible;
 
         private Client(IClient entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false, IThreadSafeWorkspace workspace = null)
-            : this(entity.Id, entity.WorkspaceId, entity.Name, entity.At, syncStatus, lastSyncErrorMessage, isDeleted, entity.ServerDeletedAt, workspace)
+            : this(entity.Id, entity.UniqueId, entity.WorkspaceId, entity.Name, entity.At, syncStatus, lastSyncErrorMessage, isDeleted, entity.ServerDeletedAt, workspace)
         { }
 
-        public Client(long id, long workspaceId, string name, DateTimeOffset at, SyncStatus syncStatus, string lastSyncErrorMessage = "", bool isDeleted = false, DateTimeOffset? serverDeletedAt = null, IThreadSafeWorkspace workspace = null)
+        public Client(long id, string uniqueId, long workspaceId, string name, DateTimeOffset at, SyncStatus syncStatus, string lastSyncErrorMessage = "", bool isDeleted = false, DateTimeOffset? serverDeletedAt = null, IThreadSafeWorkspace workspace = null)
         {
             Id = id;
+            UniqueId = uniqueId;
             WorkspaceId = workspaceId;
             Name = name;
             At = at;

--- a/Toggl.Core/Models/Country.cs
+++ b/Toggl.Core/Models/Country.cs
@@ -10,6 +10,8 @@ namespace Toggl.Core.Models
 
         public long Id { get; }
 
+        public string UniqueId { get; }
+
         public Country(string name, string countryCode, long id)
         {
             Id = id;

--- a/Toggl.Core/Models/FoundationConstructors.cs
+++ b/Toggl.Core/Models/FoundationConstructors.cs
@@ -24,6 +24,7 @@ namespace Toggl.Core.Models
         private Project(IProject entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
+            UniqueId = entity.UniqueId;
             WorkspaceId = entity.WorkspaceId;
             ClientId = entity.ClientId;
             Name = entity.Name;
@@ -80,6 +81,7 @@ namespace Toggl.Core.Models
         private Tag(ITag entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
+            UniqueId = entity.UniqueId;
             WorkspaceId = entity.WorkspaceId;
             Name = entity.Name;
             At = entity.At;
@@ -127,6 +129,7 @@ namespace Toggl.Core.Models
         private Task(ITask entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
+            UniqueId = entity.UniqueId;
             Name = entity.Name;
             ProjectId = entity.ProjectId;
             WorkspaceId = entity.WorkspaceId;
@@ -180,6 +183,7 @@ namespace Toggl.Core.Models
         private TimeEntry(ITimeEntry entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
+            UniqueId = entity.UniqueId;
             WorkspaceId = entity.WorkspaceId;
             ProjectId = entity.ProjectId;
             TaskId = entity.TaskId;
@@ -231,6 +235,7 @@ namespace Toggl.Core.Models
         private User(IUser entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
+            UniqueId = entity.UniqueId;
             ApiToken = entity.ApiToken;
             DefaultWorkspaceId = entity.DefaultWorkspaceId;
             Email = entity.Email;
@@ -281,6 +286,7 @@ namespace Toggl.Core.Models
         private Workspace(IWorkspace entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
+            UniqueId = entity.UniqueId;
             Name = entity.Name;
             Admin = entity.Admin;
             SuspendedAt = entity.SuspendedAt;

--- a/Toggl.Core/Models/FoundationConstructors.cs
+++ b/Toggl.Core/Models/FoundationConstructors.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Toggl.Shared.Models;
 using Toggl.Storage;
 using Toggl.Storage.Models;
@@ -235,7 +236,6 @@ namespace Toggl.Core.Models
         private User(IUser entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
         {
             Id = entity.Id;
-            UniqueId = entity.UniqueId;
             ApiToken = entity.ApiToken;
             DefaultWorkspaceId = entity.DefaultWorkspaceId;
             Email = entity.Email;

--- a/Toggl.Core/Models/FoundationModels.cs
+++ b/Toggl.Core/Models/FoundationModels.cs
@@ -12,6 +12,8 @@ namespace Toggl.Core.Models
     {
         public long Id { get; }
 
+        public string UniqueId { get; }
+
         public long WorkspaceId { get; }
 
         public long? ClientId { get; }
@@ -67,6 +69,8 @@ namespace Toggl.Core.Models
     {
         public long Id { get; }
 
+        public string UniqueId { get; }
+
         public long WorkspaceId { get; }
 
         public string Name { get; }
@@ -91,6 +95,8 @@ namespace Toggl.Core.Models
     internal partial class Task : IThreadSafeTask
     {
         public long Id { get; }
+
+        public string UniqueId { get; }
 
         public string Name { get; }
 
@@ -132,6 +138,8 @@ namespace Toggl.Core.Models
     internal partial class TimeEntry : IThreadSafeTimeEntry
     {
         public long Id { get; }
+
+        public string UniqueId { get; }
 
         public long WorkspaceId { get; }
 
@@ -188,6 +196,8 @@ namespace Toggl.Core.Models
     {
         public long Id { get; }
 
+        public string UniqueId { get; }
+
         public string ApiToken { get; }
 
         public long? DefaultWorkspaceId { get; }
@@ -216,6 +226,8 @@ namespace Toggl.Core.Models
     internal partial class Workspace : IThreadSafeWorkspace
     {
         public long Id { get; }
+
+        public string UniqueId { get; }
 
         public string Name { get; }
 
@@ -265,6 +277,8 @@ namespace Toggl.Core.Models
     internal partial class WorkspaceFeatureCollection : IThreadSafeWorkspaceFeatureCollection
     {
         public long WorkspaceId { get; }
+
+        public string UniqueId { get; }
 
         public IEnumerable<IWorkspaceFeature> Features { get; }
 

--- a/Toggl.Core/Models/FoundationModels.cs
+++ b/Toggl.Core/Models/FoundationModels.cs
@@ -196,7 +196,7 @@ namespace Toggl.Core.Models
     {
         public long Id { get; }
 
-        public string UniqueId { get; }
+        public string UniqueId => fakeUniqueId;
 
         public string ApiToken { get; }
 

--- a/Toggl.Core/Models/Preferences.cs
+++ b/Toggl.Core/Models/Preferences.cs
@@ -1,4 +1,5 @@
-﻿using Toggl.Core.Models.Interfaces;
+﻿using System;
+using Toggl.Core.Models.Interfaces;
 using Toggl.Shared;
 using Toggl.Shared.Models;
 using Toggl.Storage;
@@ -18,6 +19,9 @@ namespace Toggl.Core.Models
 
         public const long fakeId = 0;
         public long Id => fakeId;
+
+        public static readonly string fakeUniqueId = Guid.Empty.ToString();
+        public string UniqueId => fakeUniqueId;
 
         private Preferences(IPreferences entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
             : this(entity.TimeOfDayFormat, entity.DateFormat, entity.DurationFormat, entity.CollapseTimeEntries, syncStatus, lastSyncErrorMessage, isDeleted)

--- a/Toggl.Core/Models/Project.cs
+++ b/Toggl.Core/Models/Project.cs
@@ -33,6 +33,8 @@ namespace Toggl.Core.Models
 
             public long Id { get; }
 
+            public string UniqueId { get; private set; }
+
             public string Name { get; private set; }
 
             public string Color { get; private set; }
@@ -69,6 +71,12 @@ namespace Toggl.Core.Models
             public Builder SetSyncStatus(SyncStatus syncStatus)
             {
                 SyncStatus = syncStatus;
+                return this;
+            }
+
+            public Builder SetUniqueId(string uniqueId)
+            {
+                UniqueId = uniqueId;
                 return this;
             }
 
@@ -166,6 +174,7 @@ namespace Toggl.Core.Models
         private Project(Builder builder)
         {
             Id = builder.Id;
+            UniqueId = builder.UniqueId;
             Name = builder.Name;
             At = builder.At.Value;
             Color = builder.Color;

--- a/Toggl.Core/Models/Tag.cs
+++ b/Toggl.Core/Models/Tag.cs
@@ -14,6 +14,8 @@ namespace Toggl.Core.Models
 
             public long Id { get; private set; }
 
+            public string UniqueId { get; private set; }
+
             public long? WorkspaceId { get; private set; }
 
             public string Name { get; private set; }
@@ -27,6 +29,12 @@ namespace Toggl.Core.Models
             private Builder(long id)
             {
                 Id = id;
+            }
+
+            public Builder SetUniqueId(string uniqueId)
+            {
+                UniqueId = uniqueId;
+                return this;
             }
 
             public Builder SetWorkspaceId(long worksaceId)
@@ -90,6 +98,7 @@ namespace Toggl.Core.Models
         private Tag(Builder builder)
         {
             Id = builder.Id;
+            UniqueId = builder.UniqueId;
             Name = builder.Name;
             At = builder.At;
             ServerDeletedAt = builder.ServerDeletedAt;

--- a/Toggl.Core/Models/Task.cs
+++ b/Toggl.Core/Models/Task.cs
@@ -11,6 +11,7 @@ namespace Toggl.Core.Models
             private const string errorMessage = "You need to set the {0} before building a task.";
 
             public long Id { get; }
+            public string UniqueId { get; }
             public long? WorkspaceId { get; private set; }
             public string Name { get; private set; }
             public SyncStatus? SyncStatus { get; private set; }
@@ -72,6 +73,7 @@ namespace Toggl.Core.Models
         private Task(Builder builder)
         {
             Id = builder.Id;
+            UniqueId = builder.UniqueId;
             Name = builder.Name;
             SyncStatus = builder.SyncStatus.Value;
         }

--- a/Toggl.Core/Models/TimeEntry.cs
+++ b/Toggl.Core/Models/TimeEntry.cs
@@ -15,6 +15,8 @@ namespace Toggl.Core.Models
 
             public long Id { get; }
 
+            public string UniqueId { get; private set; }
+
             public SyncStatus SyncStatus { get; private set; }
 
             public bool Billable { get; private set; }
@@ -51,6 +53,12 @@ namespace Toggl.Core.Models
             {
                 ensureValidity();
                 return new TimeEntry(this);
+            }
+
+            public Builder SetUniqueId(string uniqueId)
+            {
+                UniqueId = uniqueId;
+                return this;
             }
 
             public Builder SetStart(DateTimeOffset start)
@@ -179,6 +187,7 @@ namespace Toggl.Core.Models
         private TimeEntry(Builder builder)
         {
             Id = builder.Id;
+            UniqueId = builder.UniqueId;
             Duration = builder.Duration;
             At = builder.At.Value;
             Start = builder.Start;

--- a/Toggl.Core/Models/User.cs
+++ b/Toggl.Core/Models/User.cs
@@ -7,6 +7,8 @@ namespace Toggl.Core.Models
 {
     internal partial class User
     {
+        private static string fakeUniqueId = Guid.Empty.ToString();
+
         public User(IDatabaseUser user, long workspaceId)
             : this(user, SyncStatus.SyncNeeded, null)
         {
@@ -19,7 +21,7 @@ namespace Toggl.Core.Models
                 => new Builder(user);
 
             public long Id { get; private set; }
-            public string UniqueId { get; }
+            public string UniqueId => fakeUniqueId;
             public string ApiToken { get; private set; }
             public long? DefaultWorkspaceId { get; private set; }
             public Email Email { get; private set; }
@@ -36,7 +38,6 @@ namespace Toggl.Core.Models
             public Builder(IDatabaseUser user)
             {
                 Id = user.Id;
-                UniqueId = user.UniqueId;
                 ApiToken = user.ApiToken;
                 DefaultWorkspaceId = user.DefaultWorkspaceId;
                 Email = user.Email;
@@ -100,7 +101,6 @@ namespace Toggl.Core.Models
         private User(Builder builder)
         {
             Id = builder.Id;
-            UniqueId = builder.UniqueId;
             ApiToken = builder.ApiToken;
             DefaultWorkspaceId = builder.DefaultWorkspaceId;
             Email = builder.Email;

--- a/Toggl.Core/Models/User.cs
+++ b/Toggl.Core/Models/User.cs
@@ -19,6 +19,7 @@ namespace Toggl.Core.Models
                 => new Builder(user);
 
             public long Id { get; private set; }
+            public string UniqueId { get; }
             public string ApiToken { get; private set; }
             public long? DefaultWorkspaceId { get; private set; }
             public Email Email { get; private set; }
@@ -35,6 +36,7 @@ namespace Toggl.Core.Models
             public Builder(IDatabaseUser user)
             {
                 Id = user.Id;
+                UniqueId = user.UniqueId;
                 ApiToken = user.ApiToken;
                 DefaultWorkspaceId = user.DefaultWorkspaceId;
                 Email = user.Email;
@@ -98,6 +100,7 @@ namespace Toggl.Core.Models
         private User(Builder builder)
         {
             Id = builder.Id;
+            UniqueId = builder.UniqueId;
             ApiToken = builder.ApiToken;
             DefaultWorkspaceId = builder.DefaultWorkspaceId;
             Email = builder.Email;

--- a/Toggl.Core/Models/Workspace.cs
+++ b/Toggl.Core/Models/Workspace.cs
@@ -13,6 +13,8 @@ namespace Toggl.Core.Models
 
             public long Id { get; }
 
+            public string UniqueId { get; private set; }
+
             public string Name { get; private set; }
 
             public SyncStatus SyncStatus { get; private set; }
@@ -32,6 +34,12 @@ namespace Toggl.Core.Models
             public Builder SetName(string name)
             {
                 Name = name;
+                return this;
+            }
+
+            public Builder SetUniqueId(string uniqueId)
+            {
+                UniqueId = uniqueId;
                 return this;
             }
 
@@ -59,6 +67,7 @@ namespace Toggl.Core.Models
         private Workspace(Builder builder)
         {
             Id = builder.Id;
+            UniqueId = builder.UniqueId;
             Name = builder.Name;
             SyncStatus = builder.SyncStatus;
             At = builder.At;

--- a/Toggl.Networking.Tests/Models/ClientTests.cs
+++ b/Toggl.Networking.Tests/Models/ClientTests.cs
@@ -10,7 +10,7 @@ namespace Toggl.Networking.Tests.Models
         public sealed class TheClientModel
         {
             private string validJson
-                => "{\"id\":23741667,\"wid\":1427273,\"name\":\"Test\",\"at\":\"2014-04-25T10:10:13+00:00\",\"server_deleted_at\":null}";
+                => "{\"id\":23741667,\"unique_id\":null,\"wid\":1427273,\"name\":\"Test\",\"at\":\"2014-04-25T10:10:13+00:00\",\"server_deleted_at\":null}";
 
             private Client validClient => new Client
             {

--- a/Toggl.Networking.Tests/Models/ProjectTests.cs
+++ b/Toggl.Networking.Tests/Models/ProjectTests.cs
@@ -9,7 +9,7 @@ namespace Toggl.Networking.Tests.Models
     public sealed class ProjectTests
     {
         private string validJson
-            => "{\"id\":64261173,\"workspace_id\":376665,\"client_id\":null,\"name\":\"Test project\",\"is_private\":false,\"active\":true,\"at\":\"2016-05-20T17:28:00+00:00\",\"server_deleted_at\":null,\"color\":\"#f61d38\",\"billable\":false,\"template\":false,\"auto_estimates\":false,\"estimated_hours\":null,\"rate\":null,\"currency\":null,\"actual_hours\":277}";
+            => "{\"id\":64261173,\"unique_id\":null,\"workspace_id\":376665,\"client_id\":null,\"name\":\"Test project\",\"is_private\":false,\"active\":true,\"at\":\"2016-05-20T17:28:00+00:00\",\"server_deleted_at\":null,\"color\":\"#f61d38\",\"billable\":false,\"template\":false,\"auto_estimates\":false,\"estimated_hours\":null,\"rate\":null,\"currency\":null,\"actual_hours\":277}";
 
         private Project validProject => new Project
         {

--- a/Toggl.Networking.Tests/Models/TagTests.cs
+++ b/Toggl.Networking.Tests/Models/TagTests.cs
@@ -8,10 +8,10 @@ namespace Toggl.Networking.Tests.Models
     public sealed class TagTests
     {
         private string validJson
-            => "{\"id\":2024667,\"workspace_id\":424213,\"name\":\"mobile\",\"at\":\"2014-04-25T10:10:13+00:00\",\"deleted_at\":\"2014-04-25T10:10:10+00:00\"}";
+            => "{\"id\":2024667,\"unique_id\":null,\"workspace_id\":424213,\"name\":\"mobile\",\"at\":\"2014-04-25T10:10:13+00:00\",\"deleted_at\":\"2014-04-25T10:10:10+00:00\"}";
 
         private string validJsonWithDefaultAtValue
-            => "{\"id\":2024667,\"workspace_id\":424213,\"name\":\"mobile\",\"at\":\"1970-01-01T00:00:00+00:00\",\"deleted_at\":\"2014-04-25T10:10:10+00:00\"}";
+            => "{\"id\":2024667,\"unique_id\":null,\"workspace_id\":424213,\"name\":\"mobile\",\"at\":\"1970-01-01T00:00:00+00:00\",\"deleted_at\":\"2014-04-25T10:10:10+00:00\"}";
 
         private Tag validTag => new Tag
         {

--- a/Toggl.Networking.Tests/Models/TaskTests.cs
+++ b/Toggl.Networking.Tests/Models/TaskTests.cs
@@ -8,7 +8,7 @@ namespace Toggl.Networking.Tests.Models
     public sealed class TaskTests
     {
         private string validJson
-            => "{\"id\":79,\"name\":\"new task\",\"project_id\":1,\"workspace_id\":56,\"user_id\":null,\"estimated_seconds\":13,\"active\":true,\"at\":\"2017-01-01T02:03:00+00:00\",\"tracked_seconds\":12}";
+            => "{\"id\":79,\"unique_id\":null,\"name\":\"new task\",\"project_id\":1,\"workspace_id\":56,\"user_id\":null,\"estimated_seconds\":13,\"active\":true,\"at\":\"2017-01-01T02:03:00+00:00\",\"tracked_seconds\":12}";
 
         private Task validTask => new Task
         {

--- a/Toggl.Networking.Tests/Models/TimeEntryTests.cs
+++ b/Toggl.Networking.Tests/Models/TimeEntryTests.cs
@@ -11,10 +11,10 @@ namespace Toggl.Networking.Tests.Models
         public sealed class TheTimeEntryModel
         {
             private string validJson
-                => "{\"id\":525144694,\"workspace_id\":1414373,\"project_id\":3178352,\"task_id\":null,\"billable\":false,\"start\":\"2017-04-25T19:34:39+00:00\",\"stop\":null,\"duration\":-1493148879,\"description\":\"Some short description\",\"tag_ids\":[313040,3129041,319042],\"at\":\"2017-04-25T20:12:27+00:00\",\"server_deleted_at\":null,\"user_id\":0,\"created_with\":\"SomeApp\"}";
+                => "{\"id\":525144694,\"unique_id\":null,\"workspace_id\":1414373,\"project_id\":3178352,\"task_id\":null,\"billable\":false,\"start\":\"2017-04-25T19:34:39+00:00\",\"stop\":null,\"duration\":-1493148879,\"description\":\"Some short description\",\"tag_ids\":[313040,3129041,319042],\"at\":\"2017-04-25T20:12:27+00:00\",\"server_deleted_at\":null,\"user_id\":0,\"created_with\":\"SomeApp\"}";
 
             private string validJsonPosting
-                => "{\"id\":525144694,\"workspace_id\":1414373,\"project_id\":3178352,\"task_id\":null,\"billable\":false,\"start\":\"2017-04-25T19:34:39+00:00\",\"stop\":null,\"duration\":-1493148879,\"description\":\"Some short description\",\"tag_ids\":[313040,3129041,319042],\"at\":\"2017-04-25T20:12:27+00:00\",\"created_with\":\"SomeApp\"}";
+                => "{\"id\":525144694,\"unique_id\":null,\"workspace_id\":1414373,\"project_id\":3178352,\"task_id\":null,\"billable\":false,\"start\":\"2017-04-25T19:34:39+00:00\",\"stop\":null,\"duration\":-1493148879,\"description\":\"Some short description\",\"tag_ids\":[313040,3129041,319042],\"at\":\"2017-04-25T20:12:27+00:00\",\"created_with\":\"SomeApp\"}";
 
             private TimeEntry validTimeEntry => new TimeEntry
             {

--- a/Toggl.Networking.Tests/Models/UserTests.cs
+++ b/Toggl.Networking.Tests/Models/UserTests.cs
@@ -11,10 +11,10 @@ namespace Toggl.Networking.Tests.Models
         public sealed class TheUserModel
         {
             private string validJson =>
-                "{\"id\":9000,\"api_token\":\"1971800d4d82861d8f2c1651fea4d212\",\"default_workspace_id\":777,\"email\":\"johnt@swift.com\",\"fullname\":\"John Swift\",\"beginning_of_week\":0,\"language\":\"en_US\",\"image_url\":\"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png\",\"timezone\":\"Europe/Zagreb\",\"updated_at\":\"2013-03-06T12:18:42+00:00\"}";
+                "{\"id\":9000,\"unique_id\":null,\"api_token\":\"1971800d4d82861d8f2c1651fea4d212\",\"default_workspace_id\":777,\"email\":\"johnt@swift.com\",\"fullname\":\"John Swift\",\"beginning_of_week\":0,\"language\":\"en_US\",\"image_url\":\"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png\",\"timezone\":\"Europe/Zagreb\",\"updated_at\":\"2013-03-06T12:18:42+00:00\"}";
 
             private string validJsonWithNullDefaultWorkspaceId =>
-                "{\"id\":9000,\"api_token\":\"1971800d4d82861d8f2c1651fea4d212\",\"default_workspace_id\":null,\"email\":\"johnt@swift.com\",\"fullname\":\"John Swift\",\"beginning_of_week\":0,\"language\":\"en_US\",\"image_url\":\"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png\",\"timezone\":\"Europe/Zagreb\",\"updated_at\":\"2013-03-06T12:18:42+00:00\"}";
+                "{\"id\":9000,\"unique_id\":null,\"api_token\":\"1971800d4d82861d8f2c1651fea4d212\",\"default_workspace_id\":null,\"email\":\"johnt@swift.com\",\"fullname\":\"John Swift\",\"beginning_of_week\":0,\"language\":\"en_US\",\"image_url\":\"https://www.toggl.com/system/avatars/9000/small/open-uri20121116-2767-b1qr8l.png\",\"timezone\":\"Europe/Zagreb\",\"updated_at\":\"2013-03-06T12:18:42+00:00\"}";
 
             private User validUser => new User
             {

--- a/Toggl.Networking.Tests/Models/WorkspaceTests.cs
+++ b/Toggl.Networking.Tests/Models/WorkspaceTests.cs
@@ -59,13 +59,13 @@ namespace Toggl.Networking.Tests.Models
                 };
 
             private const string completeJson =
-                "{\"id\":1234,\"name\":\"Default workspace\",\"admin\":true,\"SuspendedAt\":\"2018-04-24T12:16:48+00:00\",\"server_deleted_at\":\"2017-04-20T12:16:48+00:00\",\"default_hourly_rate\":0.0,\"default_currency\":\"USD\",\"only_admins_may_create_projects\":false,\"only_admins_see_billable_rates\":false,\"only_admins_see_team_dashboard\":false,\"projects_billable_by_default\":true,\"rounding\":0,\"rounding_minutes\":0,\"at\":\"2017-04-24T12:16:48+00:00\",\"logo_url\":\"https://assets.toggl.com/images/workspace.jpg\"}";
+                "{\"id\":1234,\"unique_id\":null,\"name\":\"Default workspace\",\"admin\":true,\"SuspendedAt\":\"2018-04-24T12:16:48+00:00\",\"server_deleted_at\":\"2017-04-20T12:16:48+00:00\",\"default_hourly_rate\":0.0,\"default_currency\":\"USD\",\"only_admins_may_create_projects\":false,\"only_admins_see_billable_rates\":false,\"only_admins_see_team_dashboard\":false,\"projects_billable_by_default\":true,\"rounding\":0,\"rounding_minutes\":0,\"at\":\"2017-04-24T12:16:48+00:00\",\"logo_url\":\"https://assets.toggl.com/images/workspace.jpg\"}";
 
             private const string jsonWithNulls =
-                "{\"id\":1234,\"name\":\"Default workspace\",\"admin\":true,\"SuspendedAt\":null,\"server_deleted_at\":null,\"default_hourly_rate\":null,\"default_currency\":\"USD\",\"only_admins_may_create_projects\":false,\"only_admins_see_billable_rates\":false,\"only_admins_see_team_dashboard\":false,\"projects_billable_by_default\":true,\"rounding\":0,\"rounding_minutes\":0,\"at\":\"2017-04-24T12:16:48+00:00\",\"logo_url\":\"https://assets.toggl.com/images/workspace.jpg\"}";
+                "{\"id\":1234,\"unique_id\":null,\"name\":\"Default workspace\",\"admin\":true,\"SuspendedAt\":null,\"server_deleted_at\":null,\"default_hourly_rate\":null,\"default_currency\":\"USD\",\"only_admins_may_create_projects\":false,\"only_admins_see_billable_rates\":false,\"only_admins_see_team_dashboard\":false,\"projects_billable_by_default\":true,\"rounding\":0,\"rounding_minutes\":0,\"at\":\"2017-04-24T12:16:48+00:00\",\"logo_url\":\"https://assets.toggl.com/images/workspace.jpg\"}";
 
             private const string jsonWithoutSomeFields =
-                "{\"id\":1234,\"name\":\"Default workspace\",\"admin\":true,\"default_currency\":\"USD\",\"only_admins_may_create_projects\":false,\"only_admins_see_billable_rates\":false,\"only_admins_see_team_dashboard\":false,\"projects_billable_by_default\":true,\"rounding\":0,\"rounding_minutes\":0,\"at\":\"2017-04-24T12:16:48+00:00\",\"logo_url\":\"https://assets.toggl.com/images/workspace.jpg\"}";
+                "{\"id\":1234,\"unique_id\":null,\"name\":\"Default workspace\",\"admin\":true,\"default_currency\":\"USD\",\"only_admins_may_create_projects\":false,\"only_admins_see_billable_rates\":false,\"only_admins_see_team_dashboard\":false,\"projects_billable_by_default\":true,\"rounding\":0,\"rounding_minutes\":0,\"at\":\"2017-04-24T12:16:48+00:00\",\"logo_url\":\"https://assets.toggl.com/images/workspace.jpg\"}";
 
             private static readonly Workspace completeObject = new Workspace
             {

--- a/Toggl.Networking/Models/Client.cs
+++ b/Toggl.Networking/Models/Client.cs
@@ -8,6 +8,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         [JsonProperty("wid")]
         public long WorkspaceId { get; set; }
 

--- a/Toggl.Networking/Models/Country.cs
+++ b/Toggl.Networking/Models/Country.cs
@@ -6,6 +6,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public string Name { get; set; }
 
         public string CountryCode { get; set; }

--- a/Toggl.Networking/Models/Project.cs
+++ b/Toggl.Networking/Models/Project.cs
@@ -8,6 +8,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long WorkspaceId { get; set; }
 
         public long? ClientId { get; set; }

--- a/Toggl.Networking/Models/Tag.cs
+++ b/Toggl.Networking/Models/Tag.cs
@@ -8,6 +8,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long WorkspaceId { get; set; }
 
         public string Name { get; set; }

--- a/Toggl.Networking/Models/Task.cs
+++ b/Toggl.Networking/Models/Task.cs
@@ -7,6 +7,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public string Name { get; set; }
 
         public long ProjectId { get; set; }

--- a/Toggl.Networking/Models/TimeEntry.cs
+++ b/Toggl.Networking/Models/TimeEntry.cs
@@ -11,6 +11,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long WorkspaceId { get; set; }
 
         public long? ProjectId { get; set; }

--- a/Toggl.Networking/Models/User.cs
+++ b/Toggl.Networking/Models/User.cs
@@ -10,6 +10,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public string ApiToken { get; set; }
 
         public long? DefaultWorkspaceId { get; set; }

--- a/Toggl.Networking/Models/Workspace.cs
+++ b/Toggl.Networking/Models/Workspace.cs
@@ -9,6 +9,8 @@ namespace Toggl.Networking.Models
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public string Name { get; set; }
 
         public bool Admin { get; set; }

--- a/Toggl.Shared/Models/IIdentifiable.cs
+++ b/Toggl.Shared/Models/IIdentifiable.cs
@@ -3,5 +3,6 @@
     public interface IIdentifiable
     {
         long Id { get; }
+        string UniqueId { get; }
     }
 }

--- a/Toggl.Storage.Realm/IdProvider.cs
+++ b/Toggl.Storage.Realm/IdProvider.cs
@@ -24,6 +24,9 @@ namespace Toggl.Storage.Realm
             this.getRealmInstance = getRealmInstance;
         }
 
+        public string GetNewUniqueId()
+            => Guid.NewGuid().ToString();
+
         public long GetNextIdentifier()
         {
             var nextIdentifier = -1L;

--- a/Toggl.Storage.Realm/Migrations/AddUniqueIdMigration.cs
+++ b/Toggl.Storage.Realm/Migrations/AddUniqueIdMigration.cs
@@ -1,0 +1,21 @@
+﻿using Realms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Toggl.Shared.Extensions;
+using Toggl.Shared.Models;
+using Toggl.Storage.Realm.Models;
+
+namespace Toggl.Storage.Realm.Migrations
+{
+    public static class MigrationExtensions
+    {
+        public static void GenerateUniqueId<T>(this Migration migration) where T : RealmObject, IModifiableId
+        {
+            migration.NewRealm
+                .All<T>()
+                .ForEach(entity => entity.UniqueId = Guid.NewGuid().ToString());
+        }
+    }
+}

--- a/Toggl.Storage.Realm/Models/IModifiableId.cs
+++ b/Toggl.Storage.Realm/Models/IModifiableId.cs
@@ -8,6 +8,8 @@ namespace Toggl.Storage.Realm.Models
 
         long? OriginalId { get; set; }
 
+        new string UniqueId { get; set; }
+
         void ChangeId(long id);
     }
 }

--- a/Toggl.Storage.Realm/Models/RealmConstructors.cs
+++ b/Toggl.Storage.Realm/Models/RealmConstructors.cs
@@ -10,6 +10,8 @@ namespace Toggl.Storage.Realm
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long? OriginalId { get; set; }
 
         public bool IsDeleted { get; set; }
@@ -89,6 +91,8 @@ namespace Toggl.Storage.Realm
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long? OriginalId { get; set; }
 
         public bool IsDeleted { get; set; }
@@ -146,6 +150,8 @@ namespace Toggl.Storage.Realm
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long? OriginalId { get; set; }
 
         public bool IsDeleted { get; set; }
@@ -190,6 +196,8 @@ namespace Toggl.Storage.Realm
     internal partial class RealmTask : IUpdatesFrom<IDatabaseTask>, IModifiableId
     {
         public long Id { get; set; }
+
+        public string UniqueId { get; set; }
 
         public long? OriginalId { get; set; }
 
@@ -241,6 +249,8 @@ namespace Toggl.Storage.Realm
     internal partial class RealmTimeEntry : IUpdatesFrom<IDatabaseTimeEntry>, IModifiableId
     {
         public long Id { get; set; }
+
+        public string UniqueId { get; set; }
 
         public long? OriginalId { get; set; }
 
@@ -302,6 +312,8 @@ namespace Toggl.Storage.Realm
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public long? OriginalId { get; set; }
 
         public bool IsDeleted { get; set; }
@@ -350,6 +362,8 @@ namespace Toggl.Storage.Realm
     internal partial class RealmWorkspace : IUpdatesFrom<IDatabaseWorkspace>, IModifiableId
     {
         public long Id { get; set; }
+
+        public string UniqueId { get; set; }
 
         public long? OriginalId { get; set; }
 

--- a/Toggl.Storage.Realm/Models/RealmPreferences.cs
+++ b/Toggl.Storage.Realm/Models/RealmPreferences.cs
@@ -1,4 +1,5 @@
 ﻿using Realms;
+using System;
 using Toggl.Shared;
 using Toggl.Storage.Models;
 
@@ -10,6 +11,9 @@ namespace Toggl.Storage.Realm
 
         [Ignored]
         public long Id => fakeId;
+
+        [Ignored]
+        public string UniqueId => Guid.Empty.ToString();
 
         [Ignored]
         public TimeFormat TimeOfDayFormat

--- a/Toggl.Storage.Realm/Models/RealmSinceParameter.cs
+++ b/Toggl.Storage.Realm/Models/RealmSinceParameter.cs
@@ -9,6 +9,10 @@ namespace Toggl.Storage.Realm.Models
         [PrimaryKey]
         public long Id { get; set; }
 
+        private static readonly string fakeId = Guid.Empty.ToString();
+
+        public string UniqueId => fakeId;
+
         public DateTimeOffset? Since { get; set; }
 
         public RealmSinceParameter() { }

--- a/Toggl.Storage.Realm/RealmConfigurator.cs
+++ b/Toggl.Storage.Realm/RealmConfigurator.cs
@@ -1,5 +1,8 @@
 using Realms;
+using System;
 using System.Linq;
+using Toggl.Shared.Extensions;
+using Toggl.Storage.Realm.Migrations;
 
 namespace Toggl.Storage.Realm
 {
@@ -8,7 +11,7 @@ namespace Toggl.Storage.Realm
         public RealmConfiguration Configuration { get; }
             = new RealmConfiguration
             {
-                SchemaVersion = 8,
+                SchemaVersion = 9,
                 MigrationCallback = (migration, oldSchemaVersion) =>
                 {
                     if (oldSchemaVersion < 3)
@@ -43,6 +46,17 @@ namespace Toggl.Storage.Realm
                     {
                         // RealmUser: Added new property Timezone
                         // A migration is not required because it's acceptable for the timezone to be unspecified (null)
+                    }
+
+                    if (oldSchemaVersion < 9)
+                    {
+                        migration.GenerateUniqueId<RealmClient>();
+                        migration.GenerateUniqueId<RealmProject>();
+                        migration.GenerateUniqueId<RealmTag>();
+                        migration.GenerateUniqueId<RealmTask>();
+                        migration.GenerateUniqueId<RealmUser>();
+                        migration.GenerateUniqueId<RealmWorkspace>();
+                        migration.GenerateUniqueId<RealmTimeEntry>();
                     }
                 }
             };

--- a/Toggl.Storage.Tests/TestModel.cs
+++ b/Toggl.Storage.Tests/TestModel.cs
@@ -8,6 +8,8 @@ namespace Toggl.Storage.Tests
     {
         public long Id { get; set; }
 
+        public string UniqueId { get; set; }
+
         public SyncStatus SyncStatus { get; set; }
 
         public string LastSyncErrorMessage { get; set; }

--- a/Toggl.Storage/IIdProvider.cs
+++ b/Toggl.Storage/IIdProvider.cs
@@ -3,5 +3,6 @@
     public interface IIdProvider
     {
         long GetNextIdentifier();
+        string GetNewUniqueId();
     }
 }

--- a/Toggl.iOS.Shared/Models/TimeEntry.cs
+++ b/Toggl.iOS.Shared/Models/TimeEntry.cs
@@ -16,11 +16,12 @@ namespace Toggl.iOS.Shared.Models
         public IEnumerable<long> TagIds { get; }
         public long UserId { get; }
         public long Id { get; }
+        public string UniqueId { get; }
         public DateTimeOffset? ServerDeletedAt { get; }
         public DateTimeOffset At { get; }
 
         public TimeEntry(long workspaceId, long? projectId, long? taskId, bool billable, DateTimeOffset start, long? duration,
-                         string description, IEnumerable<long> tagIds, long userId, long id, DateTimeOffset? serverDeletedAt, DateTimeOffset at)
+                         string description, IEnumerable<long> tagIds, long userId, long id, string uniqueId, DateTimeOffset? serverDeletedAt, DateTimeOffset at)
         {
             WorkspaceId = workspaceId;
             ProjectId = projectId;
@@ -32,6 +33,7 @@ namespace Toggl.iOS.Shared.Models
             TagIds = tagIds;
             UserId = userId;
             Id = id;
+            UniqueId = uniqueId;
             ServerDeletedAt = serverDeletedAt;
             At = at;
         }
@@ -49,6 +51,7 @@ namespace Toggl.iOS.Shared.Models
                 entry.TagIds ?? new List<long>(),
                 entry.UserId,
                 entry.Id,
+                entry.UniqueId,
                 entry.ServerDeletedAt,
                 entry.At
             );
@@ -67,6 +70,7 @@ namespace Toggl.iOS.Shared.Models
                 this.TagIds,
                 this.UserId,
                 this.Id,
+                this.UniqueId,
                 this.ServerDeletedAt,
                 this.At
             );

--- a/Toggl.iOS.Shared/SharedStorage.TimeEntries.cs
+++ b/Toggl.iOS.Shared/SharedStorage.TimeEntries.cs
@@ -115,6 +115,8 @@ namespace Toggl.iOS.Shared
             var serverDeletedAt = dict.GetDateTimeOffsetForKey(timeEntryServerDeletedAt);
             var at = dict.GetDateTimeOffsetForKey(timeEntryAt).Value;
 
+            var fakeUniqueId = Guid.Empty.ToString();
+
             return new TimeEntry(
                 workspaceId,
                 projectId,
@@ -126,6 +128,7 @@ namespace Toggl.iOS.Shared
                 null,
                 userId,
                 id,
+                fakeUniqueId,
                 serverDeletedAt,
                 at);
         }

--- a/Toggl.iOS.SiriExtension/ContinueTimerIntentHandler.cs
+++ b/Toggl.iOS.SiriExtension/ContinueTimerIntentHandler.cs
@@ -89,6 +89,7 @@ namespace SiriExtension
                 originalTE.TagIds ?? new long[0],
                 originalTE.UserId,
                 0,
+                Guid.Empty.ToString(),
                 null,
                 DateTimeOffset.Now
             );

--- a/Toggl.iOS.SiriExtension/StartTimerFromClipboardIntentHandler.cs
+++ b/Toggl.iOS.SiriExtension/StartTimerFromClipboardIntentHandler.cs
@@ -78,6 +78,7 @@ namespace SiriExtension
                 intent.Tags == null ? new long[0] : stringToLongCollection(intent.Tags.Select(tag => tag.Identifier)),
                 (long)SharedStorage.Instance.GetUserId(),
                 0,
+                Guid.Empty.ToString(),
                 null,
                 DateTimeOffset.Now
             );

--- a/Toggl.iOS.SiriExtension/StartTimerIntentHandler.cs
+++ b/Toggl.iOS.SiriExtension/StartTimerIntentHandler.cs
@@ -70,6 +70,7 @@ namespace SiriExtension
                 intent.Tags == null ? new long[0] : stringToLongCollection(intent.Tags.Select(tag => tag.Identifier)),
                 (long)SharedStorage.Instance.GetUserId(),
                 0,
+                Guid.Empty.ToString(),
                 null,
                 DateTimeOffset.Now
             );

--- a/Toggl.iOS.TimerWidgetExtension/TodayViewController.cs
+++ b/Toggl.iOS.TimerWidgetExtension/TodayViewController.cs
@@ -136,6 +136,7 @@ namespace Toggl.iOS.TimerWidgetExtension
                 tagIds: new long[0],
                 userId: (long)SharedStorage.Instance.GetUserId(),
                 id: 0,
+                uniqueId: Guid.Empty.ToString(),
                 serverDeletedAt: null,
                 at: DateTimeOffset.Now);
             await createTimeEntry(timeEntry);
@@ -154,6 +155,7 @@ namespace Toggl.iOS.TimerWidgetExtension
                 suggestion.TagIds ?? new long[0],
                 (long)SharedStorage.Instance.GetUserId(),
                 id: 0,
+                uniqueId: Guid.Empty.ToString(),
                 serverDeletedAt: null,
                 at: DateTimeOffset.Now);
 


### PR DESCRIPTION
## What's this?
This PR

* Adds UniqueId to the entities
* Adds a migration that will fill in the entities currently in the database with the UUIDs
* Makes sure that the all the new entities have this UUID set up on creation

### Relationships
Closes #7278 
Closes #7279 

## Why do we want this?
Because of the new syncing where UUIDs are sent with the push actions to prevent duplicates.

### Side effects
Considering the fact that I'm not extremely familiar with all of the nuisances of all the layers of entities, make sure to note any weirdness during review.

## Tests
Does this need any particular tests?

## :squid: Permissions
Me or @simonrozsival 