### PR TITLE
🐛 Fix a crash happening due to string translation missing

### DIFF
--- a/Toggl.Shared/Resources.fr.resx
+++ b/Toggl.Shared/Resources.fr.resx
@@ -705,6 +705,10 @@ Mettez en marche le chronomètre et vos enregistrements les plus utilisés s'aff
     <data name="TapToStopTimer" xml:space="preserve">
         <value>Appuez pour arrêter le chronomètre</value>
     </data>
+    <data name="ClickOnFolderIconToAssignAProject" xml:space="preserve">
+        <value>Click on $ or use @ to assign
+a Project to a Time Entry</value>
+    </data>
     <data name="DoneWithExclamationMark" xml:space="preserve">
         <value>Terminé!</value>
     </data>

--- a/Toggl.Shared/Resources.ja.resx
+++ b/Toggl.Shared/Resources.ja.resx
@@ -738,6 +738,10 @@
     <data name="TapToStopTimer" xml:space="preserve">
         <value>タップしてタイマーを停止</value>
     </data>
+    <data name="ClickOnFolderIconToAssignAProject" xml:space="preserve">
+        <value>Click on $ or use @ to assign
+a Project to a Time Entry</value>
+    </data>
     <data name="DoneWithExclamationMark" xml:space="preserve">
         <value>できました!</value>
     </data>

--- a/Toggl.Shared/Resources.pt.resx
+++ b/Toggl.Shared/Resources.pt.resx
@@ -450,6 +450,10 @@ Abra o app para marcar o tempo offline.</value>
   <data name="TapToStopTimer" xml:space="preserve">
     <value>Aperte para parar de marcar</value>
   </data>
+  <data name="ClickOnFolderIconToAssignAProject" xml:space="preserve">
+        <value>Click on $ or use @ to assign
+a Project to a Time Entry</value>
+  </data>
   <data name="TapToStartTimer" xml:space="preserve">
     <value>Aperte para começar a marcar</value>
   </data>


### PR DESCRIPTION

## What's this?
An attempt to fix https://appcenter.ms/orgs/Toggl/apps/Toggl-Android/crashes/errors/354678555u/overview

### Relationships
<!-- Mention any issues or PRs that are connected to this -->

Closes #

## How is it done?
Copy over the English strings to all other languages.

### Why not another way?
Because we don't have all the actual translations yet.

## Review hints
Validate the app doesn't crash in the start TE screen in one of the custom languages.

## :squid: Permissions
Anyone