### PR TITLE
Use mobile preferences endpoint

### DIFF
--- a/Toggl.Core.Tests.Sync/Extensions/IPreferencesExtensions.cs
+++ b/Toggl.Core.Tests.Sync/Extensions/IPreferencesExtensions.cs
@@ -16,7 +16,8 @@ namespace Toggl.Core.Tests.Sync.Extensions
                 TimeOfDayFormat = preferences.TimeOfDayFormat,
                 DateFormat = preferences.DateFormat,
                 DurationFormat = durationFormat.ValueOr(preferences.DurationFormat),
-                CollapseTimeEntries = preferences.CollapseTimeEntries
+                CollapseTimeEntries = preferences.CollapseTimeEntries,
+                TimerView = preferences.TimerView,
             };
 
         public static IThreadSafePreferences ToSyncable(this IPreferences preferences)
@@ -29,7 +30,8 @@ namespace Toggl.Core.Tests.Sync.Extensions
                 IsDeleted = false,
                 LastSyncErrorMessage = null,
                 SyncStatus = SyncStatus.InSync,
-                TimeOfDayFormat = preferences.TimeOfDayFormat
+                TimeOfDayFormat = preferences.TimeOfDayFormat,
+                TimerView = preferences.TimerView
             };
     }
 }

--- a/Toggl.Core.Tests/Mocks/MockPreferences.cs
+++ b/Toggl.Core.Tests/Mocks/MockPreferences.cs
@@ -25,6 +25,8 @@ namespace Toggl.Core.Tests.Mocks
 
         public bool UseNewSync { get; set; }
 
+        public TimerView TimerView { get; set; }
+
         [JsonIgnore]
         public PropertySyncStatus TimeOfDayFormatSyncStatus { get; set; }
 
@@ -38,6 +40,9 @@ namespace Toggl.Core.Tests.Mocks
         public PropertySyncStatus CollapseTimeEntriesSyncStatus { get; set; }
 
         [JsonIgnore]
+        public PropertySyncStatus TimerViewSyncStatus { get; set; }
+
+        [JsonIgnore]
         public TimeFormat TimeOfDayFormatBackup { get; set; }
 
         [JsonIgnore]
@@ -48,5 +53,8 @@ namespace Toggl.Core.Tests.Mocks
 
         [JsonIgnore]
         public bool CollapseTimeEntriesBackup { get; set; }
+
+        [JsonIgnore]
+        public TimerView TimerViewBackup { get; set; }
     }
 }

--- a/Toggl.Core/Models/Extensions/ModelExtensions.cs
+++ b/Toggl.Core/Models/Extensions/ModelExtensions.cs
@@ -13,6 +13,7 @@ namespace Toggl.Core.Models
             New<DurationFormat> durationFormat = default(New<DurationFormat>),
             New<bool> collapseTimeEntries = default(New<bool>),
             New<bool> useNewSync = default(New<bool>),
+            New<TimerView> timerView = default(New<TimerView>),
             New<SyncStatus> syncStatus = default(New<SyncStatus>),
             New<string> lastSyncErrorMessage = default(New<string>),
             New<bool> isDeleted = default(New<bool>)
@@ -23,6 +24,7 @@ namespace Toggl.Core.Models
                 durationFormat.ValueOr(original.DurationFormat),
                 collapseTimeEntries.ValueOr(original.CollapseTimeEntries),
                 useNewSync.ValueOr(original.UseNewSync),
+                timerView.ValueOr(original.TimerView),
                 syncStatus.ValueOr(original.SyncStatus),
                 lastSyncErrorMessage.ValueOr(original.LastSyncErrorMessage),
                 isDeleted.ValueOr(original.IsDeleted)

--- a/Toggl.Core/Models/FoundationModels.Backups.cs
+++ b/Toggl.Core/Models/FoundationModels.Backups.cs
@@ -18,13 +18,13 @@ namespace Toggl.Core.Models
 
         public DateTimeOffset StartBackup { get; set; }
         public PropertySyncStatus StartSyncStatus { get; set; }
-        
+
         public long? DurationBackup { get; set; }
         public PropertySyncStatus DurationSyncStatus { get; set; }
-         
+
         public string DescriptionBackup { get; set; }
         public PropertySyncStatus DescriptionSyncStatus { get; set; }
-        
+
         public IList<long> TagIdsBackup { get; } = new List<long>();
         public PropertySyncStatus TagIdsSyncStatus { get; set; }
 
@@ -51,6 +51,7 @@ namespace Toggl.Core.Models
         public PropertySyncStatus DateFormatSyncStatus { get; set; }
         public PropertySyncStatus DurationFormatSyncStatus { get; set; }
         public PropertySyncStatus CollapseTimeEntriesSyncStatus { get; set; }
+        public PropertySyncStatus TimerViewSyncStatus { get; set; }
 
         public TimeFormat TimeOfDayFormatBackup { get; set; }
 
@@ -59,5 +60,6 @@ namespace Toggl.Core.Models
         public DurationFormat DurationFormatBackup { get; set; }
 
         public bool CollapseTimeEntriesBackup { get; set; }
+        public TimerView TimerViewBackup { get; set; }
     }
 }

--- a/Toggl.Core/Models/Preferences.cs
+++ b/Toggl.Core/Models/Preferences.cs
@@ -1,4 +1,5 @@
-﻿using Toggl.Core.Models.Interfaces;
+﻿using System.Timers;
+using Toggl.Core.Models.Interfaces;
 using Toggl.Shared;
 using Toggl.Shared.Models;
 using Toggl.Storage;
@@ -17,24 +18,37 @@ namespace Toggl.Core.Models
         public bool IsDeleted { get; }
         public bool UseNewSync { get; }
 
+        public TimerView TimerView { get; }
+
         public const long fakeId = 0;
         public long Id => fakeId;
 
         private Preferences(IPreferences entity, SyncStatus syncStatus, string lastSyncErrorMessage, bool isDeleted = false)
-            : this(entity.TimeOfDayFormat, entity.DateFormat, entity.DurationFormat, entity.CollapseTimeEntries, entity.UseNewSync, syncStatus, lastSyncErrorMessage, isDeleted)
+            : this(entity.TimeOfDayFormat, entity.DateFormat, entity.DurationFormat, entity.CollapseTimeEntries, entity.UseNewSync, entity.TimerView, syncStatus, lastSyncErrorMessage, isDeleted)
         {
             TimeOfDayFormatSyncStatus = entity.TimeOfDayFormatSyncStatus;
             DurationFormatSyncStatus = entity.DurationFormatSyncStatus;
             DateFormatSyncStatus = entity.DateFormatSyncStatus;
             CollapseTimeEntriesSyncStatus = entity.CollapseTimeEntriesSyncStatus;
+            TimerViewSyncStatus = entity.TimerViewSyncStatus;
 
             TimeOfDayFormatBackup = entity.TimeOfDayFormatBackup;
             DateFormatBackup = entity.DateFormatBackup;
             DurationFormatBackup = entity.DurationFormatBackup;
             CollapseTimeEntriesBackup = entity.CollapseTimeEntriesBackup;
+            TimerViewBackup = entity.TimerViewBackup;
         }
 
-        public Preferences(TimeFormat timeOfDayFormat, DateFormat dateFormat, DurationFormat durationFormat, bool collapseTimeEntries, bool useNewSync, SyncStatus syncStatus = default, string lastSyncErrorMessage = "", bool isDeleted = false)
+        public Preferences(
+            TimeFormat timeOfDayFormat,
+            DateFormat dateFormat,
+            DurationFormat durationFormat,
+            bool collapseTimeEntries,
+            bool useNewSync,
+            TimerView timerView,
+            SyncStatus syncStatus = default,
+            string lastSyncErrorMessage = "",
+            bool isDeleted = false)
         {
             Ensure.Argument.IsADefinedEnumValue(syncStatus, nameof(syncStatus));
             Ensure.Argument.IsNotNull(dateFormat.Localized, nameof(dateFormat));
@@ -48,6 +62,7 @@ namespace Toggl.Core.Models
             LastSyncErrorMessage = lastSyncErrorMessage;
             IsDeleted = isDeleted;
             UseNewSync = useNewSync;
+            TimerView = timerView;
         }
 
         public static Preferences From(IDatabasePreferences entity)
@@ -65,7 +80,8 @@ namespace Toggl.Core.Models
                 DateFormat.FromLocalizedDateFormat("DD.MM.YYYY"),
                 DurationFormat.Improved,
                 false,
-                false
+                false,
+                TimerView.List
             );
     }
 }

--- a/Toggl.Networking.Tests/Models/PreferencesTests.cs
+++ b/Toggl.Networking.Tests/Models/PreferencesTests.cs
@@ -14,10 +14,10 @@ namespace Toggl.Networking.Tests.Models
             => $"\"alpha_features\":[{{\"code\":\"mobile_sync_client\",\"enabled\":{useSync.ToString().ToLower()}}}]";
 
         private string getValidIncomingJson(bool useSync = false)
-            => $"{{\"timeofday_format\":\"h:mm A\",\"date_format\":\"YYYY-MM-DD\",\"duration_format\":\"improved\",\"CollapseTimeEntries\":true,{alphaFeaturesJson(useSync)}}}";
+            => $"{{\"timeofday_format\":\"h:mm A\",\"date_format\":\"YYYY-MM-DD\",\"duration_format\":\"improved\",\"CollapseTimeEntries\":true,\"TimerViewMobile\":\"list\",{alphaFeaturesJson(useSync)}}}";
 
         private string getValidJson()
-            => "{\"timeofday_format\":\"h:mm A\",\"date_format\":\"YYYY-MM-DD\",\"duration_format\":\"improved\",\"CollapseTimeEntries\":true}";
+            => "{\"timeofday_format\":\"h:mm A\",\"date_format\":\"YYYY-MM-DD\",\"duration_format\":\"improved\",\"CollapseTimeEntries\":true,\"TimerViewMobile\":\"list\"}";
 
         private Preferences validPreferences => new Preferences
         {
@@ -25,7 +25,8 @@ namespace Toggl.Networking.Tests.Models
             DateFormat = DateFormat.FromLocalizedDateFormat("YYYY-MM-DD"),
             DurationFormat = DurationFormat.Improved,
             CollapseTimeEntries = true,
-            UseNewSync = true
+            UseNewSync = true,
+            TimerView = TimerView.List,
         };
 
         [Fact, LogIfTooSlow]

--- a/Toggl.Networking/Models/ModelConstructors.cs
+++ b/Toggl.Networking/Models/ModelConstructors.cs
@@ -1,4 +1,5 @@
-﻿using Toggl.Shared;
+﻿using System.Timers;
+using Toggl.Shared;
 using Toggl.Shared.Models;
 
 namespace Toggl.Networking.Models
@@ -55,6 +56,7 @@ namespace Toggl.Networking.Models
             DurationFormat = entity.DurationFormat;
             CollapseTimeEntries = entity.CollapseTimeEntries;
             UseNewSync = entity.UseNewSync;
+            TimerView = entity.TimerView;
         }
     }
 

--- a/Toggl.Networking/Models/Preferences.Backup.cs
+++ b/Toggl.Networking/Models/Preferences.Backup.cs
@@ -29,5 +29,11 @@ namespace Toggl.Networking.Models
 
         [JsonIgnore]
         public bool CollapseTimeEntriesBackup { get; set; }
+
+        [JsonIgnore]
+        public PropertySyncStatus TimerViewSyncStatus { get; set; }
+
+        [JsonIgnore]
+        public TimerView TimerViewBackup { get; set; }
     }
 }

--- a/Toggl.Networking/Models/Preferences.cs
+++ b/Toggl.Networking/Models/Preferences.cs
@@ -29,7 +29,8 @@ namespace Toggl.Networking.Models
         [IgnoreWhenPosting]
         public bool UseNewSync { get; set; }
 
-        [JsonProperty("TimerViewMobile")]
+        [JsonProperty("TimerViewMobile", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(TimerViewConverter))]
         public TimerView TimerView { get; set; }
     }
 }

--- a/Toggl.Networking/Models/Preferences.cs
+++ b/Toggl.Networking/Models/Preferences.cs
@@ -28,5 +28,8 @@ namespace Toggl.Networking.Models
         [JsonConverter(typeof(AlphaFeaturesJsonConverter), newSyncClient, false)]
         [IgnoreWhenPosting]
         public bool UseNewSync { get; set; }
+
+        [JsonProperty("TimerViewMobile")]
+        public TimerView TimerView { get; set; }
     }
 }

--- a/Toggl.Networking/Network/Endpoints/PreferencesEndpoints.cs
+++ b/Toggl.Networking/Network/Endpoints/PreferencesEndpoints.cs
@@ -11,8 +11,8 @@ namespace Toggl.Networking.Network
             this.baseUrl = baseUrl;
         }
 
-        public Endpoint Get => Endpoint.Get(baseUrl, "me/preferences");
+        public Endpoint Get => Endpoint.Get(baseUrl, "me/preferences/mobile");
 
-        public Endpoint Post => Endpoint.Post(baseUrl, "me/preferences");
+        public Endpoint Post => Endpoint.Post(baseUrl, "me/preferences/mobile");
     }
 }

--- a/Toggl.Networking/Serialization/Converters/TimerViewConverter.cs
+++ b/Toggl.Networking/Serialization/Converters/TimerViewConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Timers;
+using Newtonsoft.Json;
+using Toggl.Shared;
+
+namespace Toggl.Networking.Serialization.Converters
+{
+    [Preserve(AllMembers = true)]
+    public sealed class TimerViewConverter: JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+            => objectType == typeof(TimerView);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+            => TimerView.FromString(reader.Value.ToString());
+
+        public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var timerView = (TimerView)value;
+            writer.WriteValue(timerView.Value);
+        }
+    }
+}

--- a/Toggl.Shared/Models/IPreferences.Backup.cs
+++ b/Toggl.Shared/Models/IPreferences.Backup.cs
@@ -13,5 +13,8 @@
 
         PropertySyncStatus CollapseTimeEntriesSyncStatus { get; set; }
         bool CollapseTimeEntriesBackup { get; set; }
+
+        PropertySyncStatus TimerViewSyncStatus { get; set; }
+        TimerView TimerViewBackup { get; set; }
     }
 }

--- a/Toggl.Shared/Models/IPreferences.cs
+++ b/Toggl.Shared/Models/IPreferences.cs
@@ -11,5 +11,7 @@
         bool CollapseTimeEntries { get; }
 
         bool UseNewSync { get; }
+
+        TimerView TimerView { get; }
     }
 }

--- a/Toggl.Shared/TimerView.cs
+++ b/Toggl.Shared/TimerView.cs
@@ -1,0 +1,8 @@
+namespace Toggl.Shared
+{
+    public enum TimerView
+    {
+        List = 0,
+        Calendar = 1
+    }
+}

--- a/Toggl.Shared/TimerView.cs
+++ b/Toggl.Shared/TimerView.cs
@@ -1,8 +1,31 @@
+using System;
+using System.Timers;
+
 namespace Toggl.Shared
 {
-    public enum TimerView
+    public struct TimerView
     {
-        List = 0,
-        Calendar = 1
+        private const string list = "list";
+        private const string calendar = "calendar";
+
+        public string Value { get; }
+
+        public static TimerView List { get; } = FromString(list);
+        public static TimerView Calendar { get; } = FromString(calendar);
+
+        public bool IsList => Value == list;
+        public bool IsCalendar => Value == calendar;
+
+        private TimerView(string value)
+        {
+            Value = value;
+        }
+
+        public static TimerView FromString(string value)
+        {
+            if (value == calendar)
+                return new TimerView(value);
+            return new TimerView(list);
+        }
     }
 }

--- a/Toggl.Storage.Realm/Models/RealmConstructors.cs
+++ b/Toggl.Storage.Realm/Models/RealmConstructors.cs
@@ -87,6 +87,7 @@ namespace Toggl.Storage.Realm
             DurationFormat = entity.DurationFormat;
             CollapseTimeEntries = entity.CollapseTimeEntries;
             UseNewSync = entity.UseNewSync;
+            TimerView = entity.TimerView;
 
             TimeOfDayFormatSyncStatus = entity.TimeOfDayFormatSyncStatus;
             DurationFormatSyncStatus = entity.DurationFormatSyncStatus;

--- a/Toggl.Storage.Realm/Models/RealmPreferences.Backup.cs
+++ b/Toggl.Storage.Realm/Models/RealmPreferences.Backup.cs
@@ -43,6 +43,15 @@ namespace Toggl.Storage.Realm
         public bool CollapseTimeEntriesBackup { get; set; }
 
         [Ignored]
+        public TimerView TimerViewBackup
+        {
+            get => (TimerView)TimerViewIntBackup;
+            set => TimerViewIntBackup = (int)value;
+        }
+
+        public int TimerViewIntBackup { get; set; }
+
+        [Ignored]
         public PropertySyncStatus TimeOfDayFormatSyncStatus
         {
             get => (PropertySyncStatus)TimeOfDayFormatSyncStatusInt;
@@ -77,5 +86,14 @@ namespace Toggl.Storage.Realm
         }
 
         public int CollapseTimeEntriesSyncStatusInt { get; set; }
+
+        [Ignored]
+        public PropertySyncStatus TimerViewSyncStatus
+        {
+            get => (PropertySyncStatus)TimerViewSyncStatusInt;
+            set => TimerViewSyncStatusInt = (int)value;
+        }
+
+        public int TimerViewSyncStatusInt { get; set; }
     }
 }

--- a/Toggl.Storage.Realm/Models/RealmPreferences.Backup.cs
+++ b/Toggl.Storage.Realm/Models/RealmPreferences.Backup.cs
@@ -45,11 +45,11 @@ namespace Toggl.Storage.Realm
         [Ignored]
         public TimerView TimerViewBackup
         {
-            get => (TimerView)TimerViewIntBackup;
-            set => TimerViewIntBackup = (int)value;
+            get => TimerView.FromString(TimerViewStringBackup);
+            set => TimerViewStringBackup = value.Value;
         }
 
-        public int TimerViewIntBackup { get; set; }
+        public string TimerViewStringBackup { get; set; }
 
         [Ignored]
         public PropertySyncStatus TimeOfDayFormatSyncStatus

--- a/Toggl.Storage.Realm/Models/RealmPreferences.cs
+++ b/Toggl.Storage.Realm/Models/RealmPreferences.cs
@@ -54,11 +54,11 @@ namespace Toggl.Storage.Realm
         [Ignored]
         public TimerView TimerView
         {
-            get => (TimerView)TimerViewInt;
-            set => TimerViewInt = (int)value;
+            get => TimerView.FromString(TimerViewString);
+            set => TimerViewString = value.Value;
         }
 
-        public int TimerViewInt { get; set; }
+        public string TimerViewString { get; set; }
 
         public void PrepareForSyncing()
         {
@@ -88,6 +88,7 @@ namespace Toggl.Storage.Realm
             DurationFormat = entity.DurationFormat;
             CollapseTimeEntries = entity.CollapseTimeEntries;
             UseNewSync = entity.UseNewSync;
+            TimerView = entity.TimerView;
             SyncStatus = SyncStatus.InSync;
             TimeOfDayFormatSyncStatus = InSync;
             DateFormatSyncStatus = InSync;

--- a/Toggl.Storage.Realm/Models/RealmPreferences.cs
+++ b/Toggl.Storage.Realm/Models/RealmPreferences.cs
@@ -51,6 +51,15 @@ namespace Toggl.Storage.Realm
 
         public bool UseNewSync { get; set; }
 
+        [Ignored]
+        public TimerView TimerView
+        {
+            get => (TimerView)TimerViewInt;
+            set => TimerViewInt = (int)value;
+        }
+
+        public int TimerViewInt { get; set; }
+
         public void PrepareForSyncing()
         {
             SyncStatus = SyncStatus.Syncing;

--- a/Toggl.Storage.Realm/RealmConfigurator.cs
+++ b/Toggl.Storage.Realm/RealmConfigurator.cs
@@ -57,6 +57,7 @@ namespace Toggl.Storage.Realm
                     {
                         // RealmExternalCalendar: New entity for the Calendar Integration
                         // RealmExternalCalendarEvent: New entity for the Calendar Integration
+                        // RealmPreferences: Added timer view properties
                     }
                 }
             };


### PR DESCRIPTION
## What's this?
This makes use of the new `/me/preferences/mobile` endpoint to sync the preferred default view in mobile, it's either the main log or the calendar.

NB: This only works with the old sync for now, backend devs in the mission team have to figure out how to make this work with the new sync server.

### Relationships

Closes #7673 

## Why do we want this?
We want to sync the preferred default view.

## How is it done?
Updating the endpoint and adding the new property to the preferences model.

### Side effects
None?

## :squid: Permissions
⛔ Not yet, I want to know what happens with the sync server part first.