### PR TITLE
iOS 2.19 - Tomato

### DIFF
--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -36,6 +36,6 @@
 		<string>com.apple.intents-ui-service</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.18</string>
+	<string>2.19</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -40,6 +40,6 @@
 		<string>IntentHandler</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.18</string>
+	<string>2.19</string>
 </dict>
 </plist>

--- a/Toggl.iOS.TimerWidgetExtension/Info.plist
+++ b/Toggl.iOS.TimerWidgetExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.18</string>
+	<string>2.19</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -89,7 +89,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.18</string>
+	<string>2.19</string>
 	<key>CFBundleDisplayName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
## What's this?
This is the iOS 2.19 release PR.

Changelog:
```
Changed appearance for Toggl Track rebrand.
Added the start button and running time entry card to the calendar view.
Added more information to items in the calendar view.
Added support for navigating to more dates in the calendar view.
Changed the tabs order.
```

Diff: https://github.com/toggl/mobileapp/compare/ios-2.18..ios-2.19

## :squid: Permissions
🚫 