### PR TITLE
Release/android 2.19.1 tiramisu hotfix

### DIFF
--- a/Toggl.Droid/Properties/AndroidManifest.xml
+++ b/Toggl.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="987654321" android:versionName="2.19" package="com.toggl.giskard.debug" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="987654321" android:versionName="2.19.1" package="com.toggl.giskard.debug" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />

--- a/Toggl.Droid/Views/Calendar/CalendarDayView.Events.cs
+++ b/Toggl.Droid/Views/Calendar/CalendarDayView.Events.cs
@@ -229,7 +229,9 @@ namespace Toggl.Droid.Views.Calendar
 
             if (runningTimeEntryIndex.HasValue && runningTimeEntryDisposable == null)
             {
-                runningTimeEntryDisposable = timeService.CurrentDateTimeObservable.Subscribe(_ => Invalidate());
+                runningTimeEntryDisposable = timeService.CurrentDateTimeObservable
+                    .AsDriver(default, AndroidDependencyContainer.Instance.SchedulerProvider)
+                    .Subscribe(_ => Invalidate());
             }
             else if (!runningTimeEntryIndex.HasValue)
             {


### PR DESCRIPTION
## What's this?
At hotfix for Android 2.19. The only significant crash is caused by an invalidation of the calendar view in a thread that is not the main thread.

## Why do we want this?
We don't want crashes.

## How is it done?
Subscribing to that current date time observable on the main thread.

### Why not another way?
This is the way.

### Side effects
None.

## Review hints
See if you can reproduce the issue first, I couldn't but it's obviously happening.

## :squid: Permissions
🚫 NO!