### PR TITLE
Release/ios 2.19.1 tomato hotfix

### DIFF
--- a/Toggl.Shared/Resources.fr.resx
+++ b/Toggl.Shared/Resources.fr.resx
@@ -1428,4 +1428,24 @@ Exports PDF, CSV et XLS</value>
     <data name="BlogOnPersonalEfficiency" xml:space="preserve">
         <value>Toggl Blog on Personal Efficiency</value>
     </data>
+    <data name="TwelveHoursFormat">
+        <value>h tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="TwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwelveHoursFormat">
+        <value>h:mm tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="CalendarToolbarDateFormat">
+        <value>dddd, MMM d</value>
+        <comment>@Invariant</comment>
+    </data>
 </root>

--- a/Toggl.Shared/Resources.ja.resx
+++ b/Toggl.Shared/Resources.ja.resx
@@ -1369,4 +1369,24 @@ PDF、CSV &amp; XLSを書き出す</value>
     <data name="BlogOnPersonalEfficiency" xml:space="preserve">
         <value>Toggl Blog on Personal Efficiency</value>
     </data>
+    <data name="TwelveHoursFormat">
+        <value>h tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="TwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwelveHoursFormat">
+        <value>h:mm tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="CalendarToolbarDateFormat">
+        <value>dddd, MMM d</value>
+        <comment>@Invariant</comment>
+    </data>
 </root>

--- a/Toggl.Shared/Resources.pt.resx
+++ b/Toggl.Shared/Resources.pt.resx
@@ -1429,4 +1429,24 @@ em outros planos</value>
   <data name="BlogOnPersonalEfficiency" xml:space="preserve">
     <value>Toggl Blog on Personal Efficiency</value>
   </data>
+  <data name="TwelveHoursFormat">
+    <value>h tt</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="TwentyFourHoursFormat">
+    <value>HH:mm</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="EditingTwelveHoursFormat">
+    <value>h:mm tt</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="EditingTwentyFourHoursFormat">
+    <value>HH:mm</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="CalendarToolbarDateFormat">
+    <value>dddd, MMM d</value>
+    <comment>@Invariant</comment>
+  </data>
 </root>

--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -36,6 +36,6 @@
 		<string>com.apple.intents-ui-service</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -40,6 +40,6 @@
 		<string>IntentHandler</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 </dict>
 </plist>

--- a/Toggl.iOS.TimerWidgetExtension/Info.plist
+++ b/Toggl.iOS.TimerWidgetExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS/Cells/Calendar/CalendarItemView.cs
+++ b/Toggl.iOS/Cells/Calendar/CalendarItemView.cs
@@ -203,12 +203,12 @@ namespace Toggl.iOS.Cells.Calendar
         {
             var patternTint = color.ColorWithAlpha((nfloat)0.08);
             var patternTemplate = UIImage.FromBundle("stripes")
-                .ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
-                .ApplyTintColor(patternTint);
+                .ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
             UIGraphics.BeginImageContextWithOptions(patternTemplate.Size, false, patternTemplate.CurrentScale);
             UIGraphics.GetCurrentContext().ScaleCTM(1, -1);
             UIGraphics.GetCurrentContext().TranslateCTM(0, -patternTemplate.Size.Height);
+            patternTint.SetColor();
             patternTemplate.Draw(new CGRect(0, 0, patternTemplate.Size.Width, patternTemplate.Size.Height));
 
             var pattern = UIGraphics.GetImageFromCurrentImageContext();

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -89,7 +89,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 	<key>CFBundleDisplayName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
## What's this?
A hotfix for iOS 2.19. The crash happens on iOS < 13 because I used an iOS 13 only API 🙈 

## Why do we want this?
We don't want crashes.

## How is it done?
The crash happens when drawing the running time entry background pattern on the calendar items, I changed this to the old way instead of using the fancy new API.

### Why not another way?
This is the way.

### Side effects
None.

## :squid: Permissions
🚫 NO!