### PR TITLE
Release/ios 2.19.2 tomato hotfix

### DIFF
--- a/Toggl.Shared/Resources.fr.resx
+++ b/Toggl.Shared/Resources.fr.resx
@@ -1428,4 +1428,24 @@ Exports PDF, CSV et XLS</value>
     <data name="BlogOnPersonalEfficiency" xml:space="preserve">
         <value>Toggl Blog on Personal Efficiency</value>
     </data>
+    <data name="TwelveHoursFormat">
+        <value>h tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="TwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwelveHoursFormat">
+        <value>h:mm tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="CalendarToolbarDateFormat">
+        <value>dddd, MMM d</value>
+        <comment>@Invariant</comment>
+    </data>
 </root>

--- a/Toggl.Shared/Resources.ja.resx
+++ b/Toggl.Shared/Resources.ja.resx
@@ -1369,4 +1369,24 @@ PDF、CSV &amp; XLSを書き出す</value>
     <data name="BlogOnPersonalEfficiency" xml:space="preserve">
         <value>Toggl Blog on Personal Efficiency</value>
     </data>
+    <data name="TwelveHoursFormat">
+        <value>h tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="TwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwelveHoursFormat">
+        <value>h:mm tt</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="EditingTwentyFourHoursFormat">
+        <value>HH:mm</value>
+        <comment>@Invariant</comment>
+    </data>
+    <data name="CalendarToolbarDateFormat">
+        <value>dddd, MMM d</value>
+        <comment>@Invariant</comment>
+    </data>
 </root>

--- a/Toggl.Shared/Resources.pt.resx
+++ b/Toggl.Shared/Resources.pt.resx
@@ -1429,4 +1429,24 @@ em outros planos</value>
   <data name="BlogOnPersonalEfficiency" xml:space="preserve">
     <value>Toggl Blog on Personal Efficiency</value>
   </data>
+  <data name="TwelveHoursFormat">
+    <value>h tt</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="TwentyFourHoursFormat">
+    <value>HH:mm</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="EditingTwelveHoursFormat">
+    <value>h:mm tt</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="EditingTwentyFourHoursFormat">
+    <value>HH:mm</value>
+    <comment>@Invariant</comment>
+  </data>
+  <data name="CalendarToolbarDateFormat">
+    <value>dddd, MMM d</value>
+    <comment>@Invariant</comment>
+  </data>
 </root>

--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -36,6 +36,6 @@
 		<string>com.apple.intents-ui-service</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension.UI/Info.plist
+++ b/Toggl.iOS.SiriExtension.UI/Info.plist
@@ -36,6 +36,6 @@
 		<string>com.apple.intents-ui-service</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.1</string>
+	<string>2.19.2</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -40,6 +40,6 @@
 		<string>IntentHandler</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.1</string>
+	<string>2.19.2</string>
 </dict>
 </plist>

--- a/Toggl.iOS.SiriExtension/Info.plist
+++ b/Toggl.iOS.SiriExtension/Info.plist
@@ -40,6 +40,6 @@
 		<string>IntentHandler</string>
 	</dict>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 </dict>
 </plist>

--- a/Toggl.iOS.TimerWidgetExtension/Info.plist
+++ b/Toggl.iOS.TimerWidgetExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.1</string>
+	<string>2.19.2</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS.TimerWidgetExtension/Info.plist
+++ b/Toggl.iOS.TimerWidgetExtension/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 	<key>CFBundleVersion</key>
 	<string>IOS_BUNDLE_VERSION</string>
 	<key>MinimumOSVersion</key>

--- a/Toggl.iOS/Cells/Calendar/CalendarItemView.cs
+++ b/Toggl.iOS/Cells/Calendar/CalendarItemView.cs
@@ -203,12 +203,12 @@ namespace Toggl.iOS.Cells.Calendar
         {
             var patternTint = color.ColorWithAlpha((nfloat)0.08);
             var patternTemplate = UIImage.FromBundle("stripes")
-                .ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
-                .ApplyTintColor(patternTint);
+                .ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
             UIGraphics.BeginImageContextWithOptions(patternTemplate.Size, false, patternTemplate.CurrentScale);
             UIGraphics.GetCurrentContext().ScaleCTM(1, -1);
             UIGraphics.GetCurrentContext().TranslateCTM(0, -patternTemplate.Size.Height);
+            patternTint.SetColor();
             patternTemplate.Draw(new CGRect(0, 0, patternTemplate.Size.Width, patternTemplate.Size.Height));
 
             var pattern = UIGraphics.GetImageFromCurrentImageContext();

--- a/Toggl.iOS/Extensions/Reactive/UIButtonExtensions.cs
+++ b/Toggl.iOS/Extensions/Reactive/UIButtonExtensions.cs
@@ -11,6 +11,7 @@ namespace Toggl.iOS.Extensions.Reactive
     public enum ButtonEventType
     {
         Tap,
+        TapGesture,
         LongPress
     }
 

--- a/Toggl.iOS/Extensions/Reactive/UIViewExtensions.cs
+++ b/Toggl.iOS/Extensions/Reactive/UIViewExtensions.cs
@@ -29,6 +29,22 @@ namespace Toggl.iOS.Extensions.Reactive
                 });
             });
 
+        public static IObservable<Unit> TapUsingGesture(this IReactive<UIView> reactive)
+            => Observable.Create<Unit>(observer =>
+            {
+                var gestureRecognizer = new UITapGestureRecognizer(_ => observer.OnNext(Unit.Default));
+                gestureRecognizer.ShouldRecognizeSimultaneously = (recognizer, otherRecognizer) => true;
+                reactive.Base.AddGestureRecognizer(gestureRecognizer);
+
+                return Disposable.Create(() =>
+                {
+                    DispatchQueue.MainQueue.DispatchAsync(() =>
+                    {
+                        reactive.Base.RemoveGestureRecognizer(gestureRecognizer);
+                    });
+                });
+            });
+
         public static IObservable<Unit> LongPress(this IReactive<UIView> reactive, bool useFeedback = false)
             => Observable.Create<Unit>(observer =>
             {
@@ -144,6 +160,9 @@ namespace Toggl.iOS.Extensions.Reactive
             {
                 case ButtonEventType.Tap:
                     eventObservable = reactive.Base.Rx().Tap();
+                    break;
+                case ButtonEventType.TapGesture:
+                    eventObservable = reactive.Base.Rx().TapUsingGesture();
                     break;
                 case ButtonEventType.LongPress:
                     eventObservable = reactive.Base.Rx().LongPress(useFeedback);

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -89,7 +89,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19</string>
+	<string>2.19.1</string>
 	<key>CFBundleDisplayName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Toggl.iOS/Info.plist
+++ b/Toggl.iOS/Info.plist
@@ -89,7 +89,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>CFBundleShortVersionString</key>
-	<string>2.19.1</string>
+	<string>2.19.2</string>
 	<key>CFBundleDisplayName</key>
 	<string>Toggl for Devs</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/Toggl.iOS/ViewControllers/Calendar/CalendarViewController.cs
+++ b/Toggl.iOS/ViewControllers/Calendar/CalendarViewController.cs
@@ -181,7 +181,7 @@ namespace Toggl.iOS.ViewControllers
                 .DisposedBy(DisposeBag);
 
             StartTimeEntryButton.Rx()
-                .BindAction(ViewModel.StartTimeEntry, _ => true)
+                .BindAction(ViewModel.StartTimeEntry, _ => true, ButtonEventType.TapGesture)
                 .DisposedBy(DisposeBag);
 
             StartTimeEntryButton.Rx()

--- a/Toggl.iOS/ViewControllers/MainViewController.cs
+++ b/Toggl.iOS/ViewControllers/MainViewController.cs
@@ -179,7 +179,7 @@ namespace Toggl.iOS.ViewControllers
             syncFailuresButton.Rx().BindAction(ViewModel.OpenSyncFailures).DisposedBy(DisposeBag);
             StopTimeEntryButton.Rx().BindAction(ViewModel.StopTimeEntry, _ => TimeEntryStopOrigin.Manual).DisposedBy(DisposeBag);
 
-            StartTimeEntryButton.Rx().BindAction(ViewModel.StartTimeEntry, _ => true).DisposedBy(DisposeBag);
+            StartTimeEntryButton.Rx().BindAction(ViewModel.StartTimeEntry, _ => true, ButtonEventType.TapGesture).DisposedBy(DisposeBag);
             StartTimeEntryButton.Rx().BindAction(ViewModel.StartTimeEntry, _ => false, ButtonEventType.LongPress, useFeedback: true).DisposedBy(DisposeBag);
 
             CurrentTimeEntryCard.Rx().Tap()


### PR DESCRIPTION
## What's this?
This includes a fix for an issue with the start time entry button where tapping on it didn't do anything (except animating the button).

## Why do we want this?
We want users to start time entries 😄 

## How is it done?
There's some conflict between the long press gesture recognizers and the touch up inside control event, so I replaced the touch up inside with a tap gesture recognizer.

### Why not another way?
Not sure if there's another way 🤷‍♂️ 

### Side effects
Can't think of any.

## Review hints
Test it, on the timer and calendar views.

## :squid: Permissions
🚫 NO!